### PR TITLE
Fix enquiry form silently losing leads on submit failure

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -48,6 +48,7 @@
 .ReactModal__Overlay {
   opacity: 0;
   transition: opacity 300ms ease-in-out;
+  z-index: 1300;
 }
 
 .ReactModal__Overlay--after-open{
@@ -62,19 +63,20 @@
 
 .modal-enquiry-form
 {
-    /* border: 2px solid red!important; */
     position: absolute;
-    inset: 53% auto auto 50%;
-    border: 1px solid rgb(204, 204, 204);
+    inset: 50% auto auto 50%;
+    border: none;
     background: rgb(255, 255, 255);
     overflow: auto;
-    border-radius: 4px;
+    border-radius: 12px;
     outline: none;
-    padding: 20px;
+    padding: 0;
     margin-right: -50%;
     transform: translate(-50%, -50%);
-    height: 480px;
-    width: 350px;
+    max-height: 90vh;
+    width: min(92vw, 400px);
+    box-shadow: 0 20px 60px rgba(6, 6, 90, 0.25);
+    z-index: 1301;
 }
 
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -21,7 +21,7 @@ function App() {
   let closeModal=()=> {
     setIsOpen(false);
   }
-  const notify = (fullname) => toast(`Thanks ${fullname}.We will reach you soon`);
+  const notify = (message) => toast(message);
 
   const customStyles = {
     overlay:{

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -25,7 +25,8 @@ function App() {
 
   const customStyles = {
     overlay:{
-      backgroundColor:"#06065abd"
+      backgroundColor:"rgba(15, 15, 25, 0.55)",
+      backdropFilter:"blur(3px)",
     },
     // content: {
     //   top: '55%',

--- a/src/components/atoms/InputBoxComponent/InputBoxComponent.jsx
+++ b/src/components/atoms/InputBoxComponent/InputBoxComponent.jsx
@@ -18,6 +18,14 @@ export default function InputBoxComponent({
       {...params}
       sx={{
         width: "100%",
+        "& .MuiInputBase-input": {
+          backgroundColor: "#ffffff",
+          color: "#000000",
+        },
+        "& .MuiInputBase-input:-webkit-autofill": {
+          WebkitBoxShadow: "0 0 0 1000px #ffffff inset",
+          WebkitTextFillColor: "#000000",
+        },
       }}
       name={name}
       size="small"

--- a/src/components/atoms/TextAreaComponent/textareacomponent.module.css
+++ b/src/components/atoms/TextAreaComponent/textareacomponent.module.css
@@ -15,6 +15,8 @@
 }
 
 .textarea{
+    background-color: #ffffff;
+    color: #000000;
     border-color: rgba(126, 126, 126, 0.6);
     border-radius: 5px;
     resize: none;

--- a/src/components/forms/Enquiry Form/EnquiryForm.css
+++ b/src/components/forms/Enquiry Form/EnquiryForm.css
@@ -59,6 +59,33 @@
     width: 100%!important;
 }
 
+.enquiry-form .enquiry-submit-error
+{
+    margin-top: .6rem;
+    padding: .6rem;
+    border: 1px solid #c0392b;
+    border-radius: .3rem;
+    background-color: #fdecea;
+    text-align: center;
+}
+.enquiry-form .enquiry-submit-error p
+{
+    color: #c0392b;
+    margin: 0 0 .4rem 0;
+}
+.enquiry-form .enquiry-whatsapp-fallback
+{
+    display: inline-block;
+    color: #128c7e;
+    font-weight: 600;
+    text-decoration: underline;
+}
+.enquiry-form .enquiry-submit-spinner
+{
+    margin-right: .4rem;
+    vertical-align: middle;
+}
+
 /* ? media quries */
         /* Custom, iPhone Retina */ 
         @media (min-width:320px) and  (max-width:479.98px) {

--- a/src/components/forms/Enquiry Form/EnquiryForm.css
+++ b/src/components/forms/Enquiry Form/EnquiryForm.css
@@ -1,58 +1,76 @@
 .enquiry-form
 {
-    border: 1px solid rgba(6, 6, 90, 0.507);
-    border-radius: .3rem;
-    /* height: 100%; */
     width: 100%;
-     padding: .5rem;
-
 }
+
 .enquiry-form .form-heading
 {
-    /* border: 1px solid black; */
-    /* padding: .5rem; */
-    /* box-shadow: 1px 0px 10px 1px lightgray; */
     display: flex;
+    align-items: center;
     justify-content: space-between;
-    
+    padding: 1rem 1.25rem;
+    background: rgb(3, 8, 76);
 }
 .enquiry-form .form-heading h6
 {
-    text-align: center;
-    color: #06065abd;
+    text-align: left;
+    color: #ffffff;
+    font-weight: 600;
+    letter-spacing: .02em;
 }
 .enquiry-form .form-heading button
 {
-    background-color: transparent!important;
-    color: #06065abd!important;
+    background-color: rgba(255, 255, 255, 0.12)!important;
+    color: #ffffff!important;
     padding: 0!important;
     min-width: 0;
+    width: 1.75rem;
+    height: 1.75rem;
+    border-radius: 50%;
+    font-size: 1.1rem;
+    line-height: 1;
+    transition: background-color .15s ease;
+}
+.enquiry-form .form-heading button:hover
+{
+    background-color: rgba(255, 255, 255, 0.24)!important;
+}
 
+.enquiry-form .enquiry-fields
+{
+    padding: 1.25rem!important;
 }
 
 .enquiry-form .enquiry-field,.enquiry-form .enquiry-field-button
 {
-    /* border: 2px solid pink; */
-    margin-top: .6rem;
-    /* width: 100%!important; */
+    margin-top: 1rem;
+}
+.enquiry-form .enquiry-field:first-child
+{
+    margin-top: 0;
 }
 .enquiry-form .enquiry-field-button
 {
     text-align: center;
-    /* border: 1px solid red; */
+    margin-top: 1.4rem;
 }
 .enquiry-form .enquiry-field-button button
 {
-    border-radius: .3rem;
-    padding: .5rem 1rem;
+    border-radius: .5rem;
+    padding: .65rem 1rem;
     font-size: 1rem;
-
+    font-weight: 600;
+    letter-spacing: .02em;
+    box-shadow: 0 4px 14px rgba(3, 8, 76, 0.25);
+    transition: transform .1s ease, box-shadow .15s ease;
 }
-
-.enquiry-form .enquiry-field-button button:active
+.enquiry-form .enquiry-field-button button:hover:not(:disabled)
 {
-    background-color: rgb(46, 46, 143);
-
+    box-shadow: 0 6px 18px rgba(3, 8, 76, 0.32);
+}
+.enquiry-form .enquiry-field-button button:active:not(:disabled)
+{
+    transform: translateY(1px);
 }
 .enquiry-form .enquiry-field textarea
 {
@@ -61,24 +79,37 @@
 
 .enquiry-form .enquiry-submit-error
 {
-    margin-top: .6rem;
-    padding: .6rem;
-    border: 1px solid #c0392b;
-    border-radius: .3rem;
+    margin-top: 1rem;
+    padding: .75rem .9rem;
+    border: 1px solid #f1b5ac;
+    border-radius: .5rem;
     background-color: #fdecea;
     text-align: center;
+    animation: enquiry-error-in .2s ease-out;
 }
 .enquiry-form .enquiry-submit-error p
 {
-    color: #c0392b;
-    margin: 0 0 .4rem 0;
+    color: #b3261e;
+    margin: 0 0 .5rem 0;
+    line-height: 1.4;
 }
 .enquiry-form .enquiry-whatsapp-fallback
 {
-    display: inline-block;
-    color: #128c7e;
+    display: inline-flex;
+    align-items: center;
+    gap: .35rem;
+    padding: .4rem .9rem;
+    border-radius: 999px;
+    background-color: #128c7e;
+    color: #ffffff;
     font-weight: 600;
-    text-decoration: underline;
+    font-size: .85rem;
+    text-decoration: none;
+    transition: background-color .15s ease;
+}
+.enquiry-form .enquiry-whatsapp-fallback:hover
+{
+    background-color: #0e6f64;
 }
 .enquiry-form .enquiry-submit-spinner
 {
@@ -86,36 +117,36 @@
     vertical-align: middle;
 }
 
+@keyframes enquiry-error-in
+{
+    from { opacity: 0; transform: translateY(-4px); }
+    to { opacity: 1; transform: translateY(0); }
+}
+
 /* ? media quries */
-        /* Custom, iPhone Retina */ 
+        /* Custom, iPhone Retina */
         @media (min-width:320px) and  (max-width:479.98px) {
-            
-            .enquiry-form .enquiry-field textarea
-            {
-                background-color: white!important;
-                color: black!important;
-            }
 
         }
-/* Extra Small Devices, Phones */ 
+/* Extra Small Devices, Phones */
         @media (min-width: 480px) and (max-width: 575.98px) {
 
         }
 /* Small Devices, Tablets */
         @media (min-width: 576px) and (max-width:767.98px) {
 
-            
+
         }
 /* Medium Devices, Desktops */
-        
+
         @media (min-width: 768px) and (max-width:991.98px ) {
 
-           
+
         }
 
         /* Large Devices, Wide Screens */
 
         @media (min-width: 992px) and (max-width:1200px ) {
 
-           
+
         }

--- a/src/components/forms/Enquiry Form/EnquiryForm.css
+++ b/src/components/forms/Enquiry Form/EnquiryForm.css
@@ -93,6 +93,13 @@
     margin: 0 0 .5rem 0;
     line-height: 1.4;
 }
+.enquiry-form .enquiry-whatsapp-links
+{
+    display: flex;
+    gap: .5rem;
+    justify-content: center;
+    flex-wrap: wrap;
+}
 .enquiry-form .enquiry-whatsapp-fallback
 {
     display: inline-flex;

--- a/src/components/forms/Enquiry Form/EnquiryForm.jsx
+++ b/src/components/forms/Enquiry Form/EnquiryForm.jsx
@@ -10,7 +10,8 @@ import { useAuth } from '../../../App';
 import { regex } from '../../../regex/regex';
 import axios from 'axios';
 
-const WHATSAPP_FALLBACK_URL="https://wa.me/918073762257"
+const WHATSAPP_FALLBACK_NUMBERS=["918073762257","919110424403"]
+const WHATSAPP_PREFILL=encodeURIComponent("Hi Rest Coder Academy, I'd like to enquire about a course.")
 const SUBMIT_TIMEOUT_MS=10000
 
 function EnquiryForm() {
@@ -218,14 +219,19 @@ const handleSubmit = async (e)=>
               variant="body2"
               text="We couldn't send that just now. Message us on WhatsApp and we'll pick it up straight away."
             />
-            <a
-              className="enquiry-whatsapp-fallback"
-              href={WHATSAPP_FALLBACK_URL}
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              Message us on WhatsApp
-            </a>
+            <div className="enquiry-whatsapp-links">
+              {WHATSAPP_FALLBACK_NUMBERS.map((num) => (
+                <a
+                  key={num}
+                  className="enquiry-whatsapp-fallback"
+                  href={`https://wa.me/${num}?text=${WHATSAPP_PREFILL}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  WhatsApp {num.replace(/^91/, "").replace(/(\d{5})(\d{5})/, "$1 $2")}
+                </a>
+              ))}
+            </div>
           </Box>
         )}
         <Box className="enquiry-field-button">

--- a/src/components/forms/Enquiry Form/EnquiryForm.jsx
+++ b/src/components/forms/Enquiry Form/EnquiryForm.jsx
@@ -64,18 +64,13 @@ const handleSubmit = async (e)=>
     try
     {
       // https://trcabe.onrender.com/enquiries/get/enquiries
-      let response=await axios.post('https://trcabe.onrender.com/enquiries/create/enquiry',enquiryData,{timeout:SUBMIT_TIMEOUT_MS})
+      // axios only resolves for 2xx responses by default; anything else (and network
+      // errors/timeouts) rejects and is handled in the catch block below.
+      await axios.post('https://trcabe.onrender.com/enquiries/create/enquiry',enquiryData,{timeout:SUBMIT_TIMEOUT_MS})
       // await axios.post('http://localhost:4005/enquiries/create/enquiry',enquiryData)
 
-      if(response.status>=200 && response.status<300)
-      {
-        notify(`Enquiry received. We'll call you on ${enquiryData.mobile} within one working day.`)
-        closeModal()
-      }
-      else
-      {
-        setSubmitFailed(true)
-      }
+      notify(`Enquiry received. We'll call you on ${enquiryData.mobile} within one working day.`)
+      closeModal()
     }
     catch(err)
     {
@@ -158,7 +153,7 @@ const handleSubmit = async (e)=>
           </ButtonComponent>
       </Box>
 
-      <Box className="enquiry-fields" p={2}>
+      <Box className="enquiry-fields">
         <Box className="enquiry-field">
           <InputBoxComponent
             value={enquiryData.fullname}

--- a/src/components/forms/Enquiry Form/EnquiryForm.jsx
+++ b/src/components/forms/Enquiry Form/EnquiryForm.jsx
@@ -154,7 +154,7 @@ const handleSubmit = async (e)=>
        paddingY={1}
             onBtnClick={closeModal}
           >
-           X
+           ×
           </ButtonComponent>
       </Box>
 

--- a/src/components/forms/Enquiry Form/EnquiryForm.jsx
+++ b/src/components/forms/Enquiry Form/EnquiryForm.jsx
@@ -1,5 +1,5 @@
-import { Box, Typography,Grid, Paper } from '@mui/material';
-import React, { useEffect, useState } from 'react'
+import { Box, Typography,Grid, Paper, CircularProgress } from '@mui/material';
+import React, { useState } from 'react'
 import InputBoxComponent from '../../atoms/InputBoxComponent/InputBoxComponent';
 import TextAreaComponent from '../../atoms/TextAreaComponent/TextAreaComponent';
 import DropdownComponent from '../../atoms/DropdownComponent/DropdownComponent';
@@ -17,9 +17,13 @@ function EnquiryForm() {
   let [enquiryData,setenquiryData]=useState({fullname:"",mobile:"",email:"",experience:"",message:""})
   // const { register, handleSubmit, watch, formState: { errors } , control, reset} = useForm();
   let [enquiryErrors,setenquiryErrors]=useState({})
-  let [issubmit,setissubmit]=useState(false)
+  let [isSubmitting,setIsSubmitting]=useState(false)
+  let [submitFailed,setSubmitFailed]=useState(false)
 
   let {closeModal,notify}=useAuth()
+
+  const WHATSAPP_FALLBACK_URL="https://wa.me/918073762257"
+  const SUBMIT_TIMEOUT_MS=10000
 
     let  options =[
         { label: "Working professional - Technical roles", id: 1 },
@@ -38,38 +42,51 @@ let changeDropDown=(value)=>
     setenquiryData({...enquiryData,experience: value.label})
 }
     
-const handleSubmit = (e)=>
+const handleSubmit = async (e)=>
   {
     e.preventDefault();
-    
-    setenquiryErrors(
-    validateEnquiryForm(enquiryData))
-    setissubmit(true)
+
+    let errors=validateEnquiryForm(enquiryData)
+    setenquiryErrors(errors)
+
+    if(Object.keys(errors).length>0)
+    {
+      return
+    }
+
+    await sendEnquiry()
   };
 
   let sendEnquiry=async ()=>
   {
+    setSubmitFailed(false)
+    setIsSubmitting(true)
     try
     {
       // https://trcabe.onrender.com/enquiries/get/enquiries
-      let response=await axios.post('https://trcabe.onrender.com/enquiries/create/enquiry',enquiryData)
+      let response=await axios.post('https://trcabe.onrender.com/enquiries/create/enquiry',enquiryData,{timeout:SUBMIT_TIMEOUT_MS})
       // await axios.post('http://localhost:4005/enquiries/create/enquiry',enquiryData)
+
+      if(response.status>=200 && response.status<300)
+      {
+        notify(`Enquiry received. We'll call you on ${enquiryData.mobile} within one working day.`)
+        closeModal()
+      }
+      else
+      {
+        setSubmitFailed(true)
+      }
     }
     catch(err)
     {
       console.log(err)
+      setSubmitFailed(true)
+    }
+    finally
+    {
+      setIsSubmitting(false)
     }
   }
-
-useEffect(()=>
-{
-  if(Object.keys(enquiryErrors).length===0 && issubmit)
-    {
-      sendEnquiry();
-      notify(enquiryData.fullname);
-      closeModal()
-    }
-},[enquiryErrors])
 
 
   let validateEnquiryForm=({fullname,mobile,email,experience,message})=>
@@ -196,6 +213,23 @@ useEffect(()=>
           
           />
         </Box>
+        {submitFailed && (
+          <Box className="enquiry-submit-error" role="alert">
+            <TypoGraphyComponent
+              component="p"
+              variant="body2"
+              text="We couldn't send that just now. Message us on WhatsApp and we'll pick it up straight away."
+            />
+            <a
+              className="enquiry-whatsapp-fallback"
+              href={WHATSAPP_FALLBACK_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Message us on WhatsApp
+            </a>
+          </Box>
+        )}
         <Box className="enquiry-field-button">
           <ButtonComponent
             variant="contained"
@@ -204,12 +238,15 @@ useEffect(()=>
             paddingX={1.5}
             paddingY={0.7}
             type="submit"
+            disabled={isSubmitting}
           >
-            Submit
+            {isSubmitting
+              ? <><CircularProgress size={16} color="inherit" className="enquiry-submit-spinner" /> Sending…</>
+              : "Submit"}
           </ButtonComponent>
         </Box>
       </Box>
-     
+
     </form>
   );
 }

--- a/src/components/forms/Enquiry Form/EnquiryForm.jsx
+++ b/src/components/forms/Enquiry Form/EnquiryForm.jsx
@@ -1,4 +1,4 @@
-import { Box, Typography,Grid, Paper, CircularProgress } from '@mui/material';
+import { Box, CircularProgress } from '@mui/material';
 import React, { useState } from 'react'
 import InputBoxComponent from '../../atoms/InputBoxComponent/InputBoxComponent';
 import TextAreaComponent from '../../atoms/TextAreaComponent/TextAreaComponent';
@@ -10,7 +10,8 @@ import { useAuth } from '../../../App';
 import { regex } from '../../../regex/regex';
 import axios from 'axios';
 
-
+const WHATSAPP_FALLBACK_URL="https://wa.me/918073762257"
+const SUBMIT_TIMEOUT_MS=10000
 
 function EnquiryForm() {
 
@@ -21,9 +22,6 @@ function EnquiryForm() {
   let [submitFailed,setSubmitFailed]=useState(false)
 
   let {closeModal,notify}=useAuth()
-
-  const WHATSAPP_FALLBACK_URL="https://wa.me/918073762257"
-  const SUBMIT_TIMEOUT_MS=10000
 
     let  options =[
         { label: "Working professional - Technical roles", id: 1 },
@@ -45,6 +43,11 @@ let changeDropDown=(value)=>
 const handleSubmit = async (e)=>
   {
     e.preventDefault();
+
+    if(isSubmitting)
+    {
+      return
+    }
 
     let errors=validateEnquiryForm(enquiryData)
     setenquiryErrors(errors)

--- a/src/index.css
+++ b/src/index.css
@@ -18,7 +18,7 @@
   line-height: 1.5;
   font-weight: 400;
 
-  color-scheme: light dark;
+  color-scheme: light;
   color: rgba(255, 255, 255, 0.87);
   /* background-color: #042c68; */
 


### PR DESCRIPTION
## Summary
- Await the enquiry POST and only show success on a `2xx`; previously the form showed a fake success toast and closed regardless of the request's outcome, silently dropping every lead whenever the backend failed.
- On failure, keep the modal open with the user's typed data intact and show an error banner with a working WhatsApp fallback link (`wa.me/918073762257`) so the lead still reaches someone.
- Submit button shows a loading spinner + "Sending…" and disables itself while in flight, preventing double-submits.
- Add a ~10s request timeout so a cold/dead backend fails visibly instead of hanging.
- Success toast now reads "Enquiry received. We'll call you on {mobile} within one working day."
- Polish the enquiry modal UI (responsive sizing, shadow, header, buttons, error banner) and the overlay backdrop.
- Fix two pre-existing bugs surfaced while testing: text inputs/textarea rendering with unreadable dark backgrounds on browsers/OS in dark mode, and the modal rendering underneath the navbar due to a z-index clash with MUI's `AppBar`.

Fixes #2

## Test plan
- [x] `npm run build` succeeds
- [x] `npm run lint` shows no new errors (pre-existing repo-wide lint errors unaffected)
- [x] Manually verify in a browser: submit with backend down → spinner → error banner + WhatsApp link, modal stays open, data preserved, no double-submit
- [x] Manually verify success path once a live/mock backend returns 2xx: success toast names the mobile number, modal closes
- [x] Verify modal renders above the navbar and matches expected styling in both light and dark browser themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MXdnvv2AAYSyXEsegoxNja