### PR TITLE
feat: own the enquiry backend — Cloudflare D1 + Pages Function

### DIFF
--- a/functions/api/enquiry.js
+++ b/functions/api/enquiry.js
@@ -1,0 +1,47 @@
+// POST /api/enquiry — receives the enquiry form submission and stores it in the
+// Cloudflare D1 database (binding `DB`, see wrangler.toml). This replaces the old
+// trcabe.onrender.com backend: it runs on Cloudflare's edge (no server to sleep,
+// no cold start) and the data lands in a database we own.
+export async function onRequestPost(context) {
+  const { request, env } = context;
+
+  if (!env.DB) {
+    return json({ error: "storage not configured" }, 500);
+  }
+
+  let data;
+  try {
+    data = await request.json();
+  } catch {
+    return json({ error: "invalid request body" }, 400);
+  }
+
+  const fullname = str(data.fullname);
+  const mobile = str(data.mobile);
+  if (!fullname || !mobile) {
+    return json({ error: "fullname and mobile are required" }, 400);
+  }
+
+  try {
+    await env.DB.prepare(
+      "INSERT INTO enquiries (fullname, mobile, email, experience, message) VALUES (?1, ?2, ?3, ?4, ?5)"
+    )
+      .bind(fullname, mobile, str(data.email), str(data.experience), str(data.message))
+      .run();
+  } catch (err) {
+    return json({ error: "could not save enquiry" }, 500);
+  }
+
+  return json({ ok: true }, 201);
+}
+
+function str(v) {
+  return typeof v === "string" ? v.trim().slice(0, 2000) : "";
+}
+
+function json(body, status) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}

--- a/schema.sql
+++ b/schema.sql
@@ -1,0 +1,13 @@
+-- Enquiry leads captured from the site's enquiry form.
+-- Applied to the Cloudflare D1 database `restcoder-enquiries`.
+CREATE TABLE IF NOT EXISTS enquiries (
+  id         INTEGER PRIMARY KEY AUTOINCREMENT,
+  fullname   TEXT NOT NULL,
+  mobile     TEXT NOT NULL,
+  email      TEXT,
+  experience TEXT,
+  message    TEXT,
+  created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_enquiries_created_at ON enquiries (created_at);

--- a/src/components/forms/Enquiry Form/EnquiryForm.jsx
+++ b/src/components/forms/Enquiry Form/EnquiryForm.jsx
@@ -67,11 +67,11 @@ const handleSubmit = async (e)=>
     setIsSubmitting(true)
     try
     {
-      // https://trcabe.onrender.com/enquiries/get/enquiries
+      // Same-origin Cloudflare Pages Function (functions/api/enquiry.js) that
+      // writes to our own D1 database. Replaces the old trcabe.onrender.com backend.
       // axios only resolves for 2xx responses by default; anything else (and network
       // errors/timeouts) rejects and is handled in the catch block below.
-      await axios.post('https://trcabe.onrender.com/enquiries/create/enquiry',enquiryData,{timeout:SUBMIT_TIMEOUT_MS})
-      // await axios.post('http://localhost:4005/enquiries/create/enquiry',enquiryData)
+      await axios.post('/api/enquiry',enquiryData,{timeout:SUBMIT_TIMEOUT_MS})
 
       notify(`Enquiry received. We'll call you on ${enquiryData.mobile} within one working day.`)
       closeModal()

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,0 +1,11 @@
+# Cloudflare Pages config for restcoder-academy.
+# The D1 binding below is what makes `env.DB` available inside the
+# Pages Functions in ./functions (e.g. the enquiry endpoint).
+name = "restcoder-academy"
+compatibility_date = "2024-09-23"
+pages_build_output_dir = "dist"
+
+[[d1_databases]]
+binding = "DB"
+database_name = "restcoder-enquiries"
+database_id = "1c557470-b96a-4005-8dd8-6baa2ebb21e8"


### PR DESCRIPTION
Replaces `trcabe.onrender.com` with a backend we own (D1 + a Pages Function on the same Cloudflare account). Enquiries land in a database we control; the sleeping-server bug is structurally gone. **Verified end-to-end on a preview deploy** (POST → 201 → row in D1, all fields; test row removed). WhatsApp fallback unchanged.

Closes #20
Closes #19