### PR TITLE
Fix batch dates being hardcoded and advertised as upcoming when stale

### DIFF
--- a/src/components/organism/Batches/Batches.css
+++ b/src/components/organism/Batches/Batches.css
@@ -86,6 +86,18 @@
 {
     margin: 0;
 }
+.batches .batch-status-chip
+{
+    display: inline-block;
+    margin-top: .4rem;
+    padding: .15rem .7rem;
+    border-radius: 999px;
+    background-color: rgba(255, 255, 255, 0.18);
+    color: #ffffff;
+    font-size: .75rem;
+    font-weight: 600;
+    letter-spacing: .02em;
+}
 .batches .card-actions
 {
     border-top: .5px solid rgba(211, 211, 211, 0.582);

--- a/src/components/organism/Batches/BatchesCard.jsx
+++ b/src/components/organism/Batches/BatchesCard.jsx
@@ -9,6 +9,7 @@ import TypoGraphyComponent from '../../atoms/TypoGraphyComponent/TypoGraphyCompo
 import ButtonComponent from '../../atoms/ButtonComponent/ButtonComponent';
 import { List, ListItem, ListItemButton, ListItemIcon, ListItemText } from '@mui/material';
 import BatchItem from './BatchItem';
+import { isBatchUpcoming } from './batchDateUtils';
 import LaptopIcon from '@mui/icons-material/Laptop';
 import CalendarMonthIcon from '@mui/icons-material/CalendarMonth';
 import CalendarTodayIcon from '@mui/icons-material/CalendarToday';
@@ -21,6 +22,7 @@ import { useAuth } from '../../../App';
 
  function BatchesCard({name,date,day,time,trainer,duration,mode,contact}) {
     let {openModal}=useAuth()
+    let upcoming=isBatchUpcoming(date)
   return (
     <Card sx={{}} className="card">
       <Box className="course-header">
@@ -30,10 +32,16 @@ import { useAuth } from '../../../App';
           component="h5"
           text={name}
         />
+        {!upcoming && (
+          <Box component="span" className="batch-status-chip">Batch closed</Box>
+        )}
       </Box>
       <CardContent className="card-content">
         <List className="links">
-          <BatchItem title="Date" data={date} icon={<CalendarMonthIcon/>} />
+          {upcoming
+            ? <BatchItem title="Date" data={date} icon={<CalendarMonthIcon/>} />
+            : <BatchItem title="Status" data="New dates coming soon" icon={<CalendarMonthIcon/>} />
+          }
           <BatchItem title="Day" data={day} icon={<CalendarTodayIcon/>} />
           <BatchItem title="Time" data={time}  icon={<AccessTimeIcon/>} />
           <BatchItem title="Duration" data={duration} icon={<AlarmOnIcon/>} />
@@ -41,13 +49,13 @@ import { useAuth } from '../../../App';
           <BatchItem title="Trainer" data={trainer} icon={<PersonIcon/>} />
           <BatchItem title="Contact" data={contact} icon={<CallIcon/>} />
         </List>
-       
+
       </CardContent>
       <CardActions sx={{}} className="card-actions">
         <ButtonComponent
           size="large"
           variant="outlined"
-          label="Enquire Now"
+          label={upcoming ? "Enquire Now" : "Join the Waitlist"}
           borderRadius="0"
           sx={{}}
           onBtnClick={openModal}

--- a/src/components/organism/Batches/BatchesCard.jsx
+++ b/src/components/organism/Batches/BatchesCard.jsx
@@ -39,11 +39,13 @@ import { useAuth } from '../../../App';
       <CardContent className="card-content">
         <List className="links">
           {upcoming
-            ? <BatchItem title="Date" data={date} icon={<CalendarMonthIcon/>} />
+            ? <>
+                <BatchItem title="Date" data={date} icon={<CalendarMonthIcon/>} />
+                <BatchItem title="Day" data={day} icon={<CalendarTodayIcon/>} />
+                <BatchItem title="Time" data={time}  icon={<AccessTimeIcon/>} />
+              </>
             : <BatchItem title="Status" data="New dates coming soon" icon={<CalendarMonthIcon/>} />
           }
-          <BatchItem title="Day" data={day} icon={<CalendarTodayIcon/>} />
-          <BatchItem title="Time" data={time}  icon={<AccessTimeIcon/>} />
           <BatchItem title="Duration" data={duration} icon={<AlarmOnIcon/>} />
           <BatchItem title="Mode" data={mode} icon={<LaptopIcon/>} />
           <BatchItem title="Trainer" data={trainer} icon={<PersonIcon/>} />

--- a/src/components/organism/Batches/batchDateUtils.js
+++ b/src/components/organism/Batches/batchDateUtils.js
@@ -6,12 +6,23 @@ export function parseBatchDate(dateStr)
     {
         return null
     }
-    let [day,month,year]=dateStr.split("-").map(Number)
-    if(!day || !month || !year)
+    let parts=dateStr.split("-").map(Number)
+    if(parts.length!==3 || parts.some(Number.isNaN))
     {
         return null
     }
-    return new Date(year,month-1,day)
+    let [day,month,year]=parts
+    if(day<1 || day>31 || month<1 || month>12 || year<1000 || year>9999)
+    {
+        return null
+    }
+    let date=new Date(year,month-1,day)
+    // reject rollover dates (e.g. "31-04-2026" silently becoming 1 May)
+    if(date.getFullYear()!==year || date.getMonth()!==month-1 || date.getDate()!==day)
+    {
+        return null
+    }
+    return date
 }
 
 export function isBatchUpcoming(dateStr)

--- a/src/components/organism/Batches/batchDateUtils.js
+++ b/src/components/organism/Batches/batchDateUtils.js
@@ -1,0 +1,45 @@
+const MONTH_SHORT = ["Jan","Feb","Mar","Apr","May","Jun","Jul","Aug","Sep","Oct","Nov","Dec"]
+
+export function parseBatchDate(dateStr)
+{
+    if(!dateStr)
+    {
+        return null
+    }
+    let [day,month,year]=dateStr.split("-").map(Number)
+    if(!day || !month || !year)
+    {
+        return null
+    }
+    return new Date(year,month-1,day)
+}
+
+export function isBatchUpcoming(dateStr)
+{
+    let date=parseBatchDate(dateStr)
+    if(!date)
+    {
+        return false
+    }
+    let today=new Date()
+    today.setHours(0,0,0,0)
+    return date.getTime()>=today.getTime()
+}
+
+export function formatBatchDateShort(dateStr)
+{
+    let date=parseBatchDate(dateStr)
+    if(!date)
+    {
+        return ""
+    }
+    return `${date.getDate()} ${MONTH_SHORT[date.getMonth()]}`
+}
+
+export function getNextBatchForCourse(courseName,batches)
+{
+    let upcoming=batches
+        .filter((batch)=>batch.name===courseName && isBatchUpcoming(batch.date))
+        .sort((a,b)=>parseBatchDate(a.date)-parseBatchDate(b.date))
+    return upcoming[0] || null
+}

--- a/src/components/organism/Batches/batches.js
+++ b/src/components/organism/Batches/batches.js
@@ -1,8 +1,11 @@
+// NOTE: dates below are placeholders pending the current schedule from Uday (see issue #3).
+// Update them here only — batchDateUtils derives "upcoming"/"closed" status and the
+// course-card "Next batch" tag from this file, so nothing else needs to change.
 export let batches=[
     {
         id:"1",
         name:"Java Full Stack",
-        date:"24-05-2025",
+        date:"16-09-2026",
         day:"Wednesday",
         time:"10:00 AM",
         trainer:"Uday pawar S",
@@ -13,7 +16,7 @@ export let batches=[
     {
         id:"2",
         name:"Python Full Stack",
-        date:"24-05-2025",
+        date:"23-09-2026",
         day:"Wednesday",
         time:"10:00 AM",
         trainer:"Uday pawar S",
@@ -24,7 +27,7 @@ export let batches=[
     {
         id:"3",
         name:"MERN Stack",
-        date:"24-05-2025",
+        date:"30-09-2026",
         day:"Wednesday",
         time:"10:00 AM",
         trainer:"Uday pawar S",
@@ -35,7 +38,7 @@ export let batches=[
       {
         id:"4",
         name:"Reactjs & Nextjs",
-        date:"24-05-2025",
+        date:"07-10-2026",
         day:"Wednesday",
         time:"10:00 AM",
         trainer:"Uday pawar S",

--- a/src/components/organism/courses/Courses.css
+++ b/src/components/organism/courses/Courses.css
@@ -55,9 +55,21 @@
 .courses .course-header
 {
     background-image: linear-gradient(to right,#0f1a2b,#244668);
-    text-align: center; 
+    text-align: center;
     padding: 1rem 0;
     color: white;
+}
+.courses .next-batch-tag
+{
+    display: inline-block;
+    margin: 0 0 .5rem 0;
+    padding: .2rem .8rem;
+    border-radius: 999px;
+    background-color: rgba(255, 255, 255, 0.15);
+    color: #ffffff;
+    font-size: .8rem;
+    font-weight: 600;
+    letter-spacing: .02em;
 }
 .courses .card-actions
 {

--- a/src/components/organism/courses/CoursesCard.jsx
+++ b/src/components/organism/courses/CoursesCard.jsx
@@ -9,19 +9,25 @@ import TypoGraphyComponent from '../../atoms/TypoGraphyComponent/TypoGraphyCompo
 import ButtonComponent from '../../atoms/ButtonComponent/ButtonComponent';
 import { List, ListItem, ListItemText } from '@mui/material';
 import { useAuth } from '../../../App';
+import { batches } from '../Batches/batches';
+import { getNextBatchForCourse, formatBatchDateShort } from '../Batches/batchDateUtils';
 
 
  function CoursesCard({name,backend,audience,frontend,syllabus1,syllabus2}) {
     let {openModal}=useAuth()
+    let nextBatch=getNextBatchForCourse(name,batches)
   return (
     <Card sx={{ }} className='card'>
         <Box className="course-header">
             <TypoGraphyComponent
             variant="h5"
-            sx={{mb:".6rem"}}
+            sx={{mb:".3rem"}}
             component="h5"
             text={name}
         />
+        <Box component="span" className="next-batch-tag">
+            {nextBatch ? `Next batch · ${formatBatchDateShort(nextBatch.date)}` : "New dates coming soon"}
+        </Box>
          <TypoGraphyComponent
             variant="text"
             sx={{}}


### PR DESCRIPTION
## Summary
- The Batches section had every entry hardcoded to `date:"24-05-2025"` — 15 months in the past — advertising the academy as dormant to anyone who read it.
- Add `batchDateUtils.js`: a shared helper (`isBatchUpcoming`, `formatBatchDateShort`, `getNextBatchForCourse`) so date-status logic lives in one place, not scattered across components.
- `BatchesCard`: a batch whose date has passed now shows a muted **"Batch closed"** tag, replaces the date row with "New dates coming soon", and swaps the CTA from "Enquire Now" to **"Join the Waitlist"**. A past date can no longer render as if it's upcoming.
- `CoursesCard`: each course card now shows a **"Next batch · 16 Sep"**-style tag (matched by course name against the batches data), visible without scrolling to the Batches section — or "New dates coming soon" if none are upcoming.
- Updated the batch dates off the stale placeholder to near-future Wednesdays (Sep–Oct 2026), staggered per course. These are still placeholders pending the actual schedule from Uday — flagged with an inline comment in `batches.js` since I don't have the authoritative dates; the closed/waitlist safety net means the site can't misrepresent it again even if these go stale.

Fixes #3

## Test plan
- [x] `npm run build` succeeds
- [x] `npm run lint` shows no new errors (pre-existing repo-wide lint errors unaffected)
- [x] Manually verified in a browser: course cards show the correct "Next batch" date matching the Batches section
- [x] Manually verified in a browser: temporarily backdating a batch entry renders "Batch closed" + "New dates coming soon" + "Join the Waitlist" CTA, then reverted
- [ ] Swap placeholder dates in `batches.js` for Uday's real upcoming schedule before/after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MXdnvv2AAYSyXEsegoxNja