### PR TITLE
Add batch-dates admin panel — RCA edits without a redeploy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ node_modules
 # dist
 # dist-ssr
 *.local
+.wrangler
 
 # Editor directories and files
 .vscode/*

--- a/README.md
+++ b/README.md
@@ -67,8 +67,7 @@ enquiry form  ->  POST /api/enquiry  ->  functions/api/enquiry.js  ->  D1 (enqui
     --command "SELECT * FROM enquiries ORDER BY created_at DESC;"
   ```
 
-(A friendly `/admin` lead-list page for the academy is a planned follow-up — see
-the issues.)
+- **Web:** `/admin` — a password-protected lead-list page (see below).
 
 ### Changing the database schema
 
@@ -77,6 +76,43 @@ Edit `schema.sql`, then apply it:
 ```bash
 npx wrangler d1 execute restcoder-enquiries --remote --file=schema.sql
 ```
+
+## Batch dates (admin-controlled)
+
+RCA updates upcoming batch dates themselves, with no code change or redeploy
+(see issue #15):
+
+```
+Batches section  ->  GET /api/batches   ->  functions/api/batches.js  ->  D1 (batches table)
+/admin/batches   ->  add / edit / hide  ->  functions/admin/batches.js -> D1 (batches table)
+```
+
+- Public read: `GET /api/batches` — returns active batch entries as JSON,
+  consumed by the "Upcoming Batches" section and each course card's "Next
+  batch" tag.
+- Admin screen: `/admin/batches` — same auth as `/admin` (see below); add,
+  edit, or hide a batch entry with plain HTML forms.
+- If the D1 table is empty or the request fails, the frontend falls back to
+  the static list in `src/components/organism/Batches/batches.js` so the
+  site never breaks — same graceful-degradation approach as the enquiry
+  form's WhatsApp fallback.
+- A batch whose date has passed is never shown as upcoming: the UI renders
+  "Batch closed" / "New dates coming soon" and switches the CTA to "Join the
+  Waitlist" (see issue #3).
+
+## Admin screens (`/admin`, `/admin/batches`)
+
+Both are password-protected with HTTP Basic Auth, gated by the `ADMIN_PASSWORD`
+Pages secret (`ADMIN_USER` optional, defaults to `admin`). Fails **closed** —
+if `ADMIN_PASSWORD` isn't set, nobody gets in.
+
+```bash
+# set once per environment, from the Cloudflare dashboard or:
+npx wrangler pages secret put ADMIN_PASSWORD
+```
+
+- `/admin` — enquiry leads (read-only).
+- `/admin/batches` — batch dates (add / edit / hide).
 
 ## History / context
 

--- a/functions/_shared/adminStyles.js
+++ b/functions/_shared/adminStyles.js
@@ -1,0 +1,34 @@
+// Shared look for the admin screens (/admin, /admin/batches) so they read as
+// one cohesive area instead of two independently-styled pages. Plain CSS,
+// no build step — these are server-rendered HTML strings, not React.
+export const ADMIN_STYLES = `
+  :root { --navy:#03084C; --navy-2:#0b1660; --line:#e4e6ef; --muted:#5b6472; --green:#0f9d58; --red:#c0392b; --bg:#f5f6fa; }
+  * { box-sizing:border-box; }
+  body { margin:0; font-family:system-ui,-apple-system,Segoe UI,Roboto,sans-serif; color:#1b2030; background:var(--bg); }
+  header.admin-header { background:linear-gradient(120deg,var(--navy),var(--navy-2)); color:#fff; padding:1.1rem 1.5rem; display:flex; align-items:baseline; gap:.75rem; box-shadow:0 2px 10px rgba(3,8,76,.15); }
+  header.admin-header h1 { font-size:1.15rem; margin:0; font-weight:600; letter-spacing:.01em; }
+  header.admin-header .count { font-size:.85rem; opacity:.75; }
+  header.admin-header nav { margin-left:auto; }
+  header.admin-header nav a { color:#fff; opacity:.85; font-size:.82rem; text-decoration:none; padding:.35rem .75rem; border-radius:6px; background:rgba(255,255,255,.12); transition:background .15s ease,opacity .15s ease; }
+  header.admin-header nav a:hover { opacity:1; background:rgba(255,255,255,.22); }
+  .admin-wrap { max-width:1100px; margin:0 auto; padding:1.75rem 1.25rem 3rem; }
+  .admin-wrap .scroll { overflow-x:auto; border-radius:12px; }
+  table.admin-table { border-collapse:collapse; width:100%; min-width:760px; background:#fff; border:1px solid var(--line); border-radius:12px; overflow:hidden; box-shadow:0 6px 24px rgba(3,8,76,.08); }
+  table.admin-table th, table.admin-table td { text-align:left; padding:.7rem .9rem; border-bottom:1px solid var(--line); vertical-align:top; font-size:.88rem; }
+  table.admin-table th { background:#eef0f6; color:var(--navy); font-weight:600; white-space:nowrap; }
+  table.admin-table tr:last-child td { border-bottom:none; }
+  table.admin-table tbody tr:hover { background:#f8f9fd; }
+  .muted { color:var(--muted); font-size:.8rem; }
+  .empty { text-align:center; color:var(--muted); padding:2.5rem; }
+  .notice { margin:0 0 1.25rem; padding:.75rem 1rem; color:var(--red); background:#fdecea; border:1px solid #f1b5ac; border-radius:8px; font-size:.9rem; }
+  .badge { padding:.2rem .65rem; border-radius:999px; font-size:.75rem; font-weight:600; }
+  .badge.active { background:#e6f4ea; color:var(--green); }
+  .badge.hidden { background:#f1e6e6; color:var(--red); }
+  a.link { color:var(--navy); }
+  button { cursor:pointer; padding:.4rem .85rem; border-radius:7px; border:1px solid var(--line); background:#fff; font-size:.85rem; transition:background .15s ease; }
+  button:hover { background:#f2f3f8; }
+  button.primary { background:var(--navy); color:#fff; border:none; }
+  button.primary:hover { background:var(--navy-2); }
+  button.danger { color:var(--red); border-color:var(--red); }
+  button.danger:hover { background:#fdecea; }
+`

--- a/functions/_shared/auth.js
+++ b/functions/_shared/auth.js
@@ -1,0 +1,49 @@
+// Shared HTTP Basic Auth guard for admin-only Pages Functions routes.
+// Auth: against the `ADMIN_PASSWORD` Pages secret (user = ADMIN_USER or "admin").
+// Fails CLOSED — if ADMIN_PASSWORD isn't set, nobody gets in.
+//
+// Files under _shared/ are not routable by Cloudflare Pages Functions (the
+// leading underscore excludes them), so this is safe to import without
+// creating a stray route.
+export function requireAdminAuth(request, env) {
+  const challenge = () =>
+    new Response("Authentication required.", {
+      status: 401,
+      headers: {
+        "WWW-Authenticate": 'Basic realm="Rest Coder Academy — Admin", charset="UTF-8"',
+        "content-type": "text/plain; charset=utf-8",
+      },
+    });
+
+  if (!env.ADMIN_PASSWORD) return { ok: false, response: challenge() };
+
+  const header = request.headers.get("Authorization") || "";
+  if (!header.startsWith("Basic ")) return { ok: false, response: challenge() };
+
+  let user = "", pass = "";
+  try {
+    const decoded = atob(header.slice(6));
+    const i = decoded.indexOf(":");
+    user = decoded.slice(0, i);
+    pass = decoded.slice(i + 1);
+  } catch {
+    return { ok: false, response: challenge() };
+  }
+
+  const expectedUser = env.ADMIN_USER || "admin";
+  if (!safeEqual(user, expectedUser) || !safeEqual(pass, env.ADMIN_PASSWORD)) {
+    return { ok: false, response: challenge() };
+  }
+
+  return { ok: true };
+}
+
+// Constant-time-ish string compare to avoid leaking the password via timing.
+function safeEqual(a, b) {
+  a = String(a);
+  b = String(b);
+  if (a.length !== b.length) return false;
+  let diff = 0;
+  for (let i = 0; i < a.length; i++) diff |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  return diff === 0;
+}

--- a/functions/admin.js
+++ b/functions/admin.js
@@ -1,4 +1,5 @@
 import { requireAdminAuth } from "./_shared/auth.js";
+import { ADMIN_STYLES } from "./_shared/adminStyles.js";
 
 // GET /admin — password-protected lead list for the academy.
 // Reads enquiries from D1 (binding `DB`) and server-renders an HTML table.
@@ -34,11 +35,11 @@ function rowHtml(r) {
   return (
     "<tr>" +
     `<td>${esc(r.fullname)}</td>` +
-    `<td><a href="tel:${esc(r.mobile)}">${esc(r.mobile)}</a></td>` +
-    `<td>${r.email ? `<a href="mailto:${esc(r.email)}">${esc(r.email)}</a>` : "—"}</td>` +
+    `<td><a class="link" href="tel:${esc(r.mobile)}">${esc(r.mobile)}</a></td>` +
+    `<td>${r.email ? `<a class="link" href="mailto:${esc(r.email)}">${esc(r.email)}</a>` : "—"}</td>` +
     `<td>${esc(r.experience) || "—"}</td>` +
     `<td class="msg">${esc(r.message) || "—"}</td>` +
-    `<td class="when">${esc(r.created_at)}</td>` +
+    `<td class="muted">${esc(r.created_at)}</td>` +
     "</tr>"
   );
 }
@@ -51,33 +52,19 @@ function page(notice, count, body) {
 <meta name="robots" content="noindex, nofollow"/>
 <title>Enquiries — Rest Coder Academy</title>
 <style>
-  :root { --navy:#03084C; --line:#e4e6ef; --muted:#5b6472; }
-  * { box-sizing:border-box; }
-  body { margin:0; font-family:system-ui,-apple-system,Segoe UI,Roboto,sans-serif; color:#1b2030; background:#f5f6fa; }
-  header { background:var(--navy); color:#fff; padding:1rem 1.25rem; display:flex; align-items:baseline; gap:.75rem; }
-  header h1 { font-size:1.1rem; margin:0; }
-  header .count { font-size:.85rem; opacity:.8; }
-  header nav { margin-left:auto; }
-  header nav a { color:#fff; opacity:.8; font-size:.85rem; text-decoration:underline; }
-  .wrap { padding:1.25rem; overflow-x:auto; }
-  table { border-collapse:collapse; width:100%; min-width:760px; background:#fff; border:1px solid var(--line); border-radius:10px; overflow:hidden; }
-  th,td { text-align:left; padding:.6rem .8rem; border-bottom:1px solid var(--line); vertical-align:top; font-size:.9rem; }
-  th { background:#eef0f6; color:var(--navy); font-weight:600; white-space:nowrap; }
-  tr:last-child td { border-bottom:none; }
-  a { color:var(--navy); }
+${ADMIN_STYLES}
   .msg { max-width:340px; }
-  .when { white-space:nowrap; color:var(--muted); }
-  .empty { text-align:center; color:var(--muted); padding:2rem; }
-  .notice { padding:1rem 1.25rem; color:#b3261e; }
 </style></head>
 <body>
-  <header><h1>Enquiries</h1><span class="count">${count} total</span><nav><a href="/admin/batches">Batch dates →</a></nav></header>
-  ${notice ? `<div class="notice">${esc(notice)}</div>` : ""}
-  <div class="wrap">
-    <table>
-      <thead><tr><th>Name</th><th>Mobile</th><th>Email</th><th>Experience</th><th>Message</th><th>Received</th></tr></thead>
-      <tbody>${body}</tbody>
-    </table>
+  <header class="admin-header"><h1>Enquiries</h1><span class="count">${count} total</span><nav><a href="/admin/batches">Batch dates →</a></nav></header>
+  <div class="admin-wrap">
+    ${notice ? `<div class="notice">${esc(notice)}</div>` : ""}
+    <div class="scroll">
+      <table class="admin-table">
+        <thead><tr><th>Name</th><th>Mobile</th><th>Email</th><th>Experience</th><th>Message</th><th>Received</th></tr></thead>
+        <tbody>${body}</tbody>
+      </table>
+    </div>
   </div>
 </body></html>`;
 }

--- a/functions/admin.js
+++ b/functions/admin.js
@@ -1,39 +1,12 @@
+import { requireAdminAuth } from "./_shared/auth.js";
+
 // GET /admin — password-protected lead list for the academy.
 // Reads enquiries from D1 (binding `DB`) and server-renders an HTML table.
-// Auth: HTTP Basic Auth against the `ADMIN_PASSWORD` Pages secret (user = ADMIN_USER
-// or "admin"). Fails CLOSED — if ADMIN_PASSWORD isn't set, nobody gets in.
 export async function onRequestGet(context) {
   const { request, env } = context;
 
-  const challenge = () =>
-    new Response("Authentication required.", {
-      status: 401,
-      headers: {
-        "WWW-Authenticate": 'Basic realm="Rest Coder Academy — Admin", charset="UTF-8"',
-        "content-type": "text/plain; charset=utf-8",
-      },
-    });
-
-  // Fail closed if no password is configured.
-  if (!env.ADMIN_PASSWORD) return challenge();
-
-  const header = request.headers.get("Authorization") || "";
-  if (!header.startsWith("Basic ")) return challenge();
-
-  let user = "", pass = "";
-  try {
-    const decoded = atob(header.slice(6));
-    const i = decoded.indexOf(":");
-    user = decoded.slice(0, i);
-    pass = decoded.slice(i + 1);
-  } catch {
-    return challenge();
-  }
-
-  const expectedUser = env.ADMIN_USER || "admin";
-  if (!safeEqual(user, expectedUser) || !safeEqual(pass, env.ADMIN_PASSWORD)) {
-    return challenge();
-  }
+  const auth = requireAdminAuth(request, env);
+  if (!auth.ok) return auth.response;
 
   if (!env.DB) {
     return html(page("Storage not configured.", 0, ""), 500);
@@ -84,6 +57,8 @@ function page(notice, count, body) {
   header { background:var(--navy); color:#fff; padding:1rem 1.25rem; display:flex; align-items:baseline; gap:.75rem; }
   header h1 { font-size:1.1rem; margin:0; }
   header .count { font-size:.85rem; opacity:.8; }
+  header nav { margin-left:auto; }
+  header nav a { color:#fff; opacity:.8; font-size:.85rem; text-decoration:underline; }
   .wrap { padding:1.25rem; overflow-x:auto; }
   table { border-collapse:collapse; width:100%; min-width:760px; background:#fff; border:1px solid var(--line); border-radius:10px; overflow:hidden; }
   th,td { text-align:left; padding:.6rem .8rem; border-bottom:1px solid var(--line); vertical-align:top; font-size:.9rem; }
@@ -96,7 +71,7 @@ function page(notice, count, body) {
   .notice { padding:1rem 1.25rem; color:#b3261e; }
 </style></head>
 <body>
-  <header><h1>Enquiries</h1><span class="count">${count} total</span></header>
+  <header><h1>Enquiries</h1><span class="count">${count} total</span><nav><a href="/admin/batches">Batch dates →</a></nav></header>
   ${notice ? `<div class="notice">${esc(notice)}</div>` : ""}
   <div class="wrap">
     <table>
@@ -118,14 +93,4 @@ function esc(v) {
 
 function html(bodyStr, status) {
   return new Response(bodyStr, { status, headers: { "content-type": "text/html; charset=utf-8" } });
-}
-
-// Constant-time-ish string compare to avoid leaking the password via timing.
-function safeEqual(a, b) {
-  a = String(a);
-  b = String(b);
-  if (a.length !== b.length) return false;
-  let diff = 0;
-  for (let i = 0; i < a.length; i++) diff |= a.charCodeAt(i) ^ b.charCodeAt(i);
-  return diff === 0;
 }

--- a/functions/admin/batches.js
+++ b/functions/admin/batches.js
@@ -1,0 +1,240 @@
+import { requireAdminAuth } from "../_shared/auth.js";
+
+// GET/POST /admin/batches — password-protected screen for RCA to add, edit,
+// or hide batch entries without a code change (issue #15). Reads/writes D1
+// (table `batches`); the public /api/batches endpoint serves the same rows
+// to the site. Plain HTML forms, no client JS framework — POST redirects
+// back to GET (303) so a page refresh can't resubmit a mutation.
+
+export async function onRequestGet(context) {
+  const { request, env } = context;
+
+  const auth = requireAdminAuth(request, env);
+  if (!auth.ok) return auth.response;
+
+  if (!env.DB) {
+    return html(page({ notice: "Storage not configured.", rows: [] }), 500);
+  }
+
+  const rows = await listBatches(env);
+  return html(page({ rows }), 200);
+}
+
+export async function onRequestPost(context) {
+  const { request, env } = context;
+
+  const auth = requireAdminAuth(request, env);
+  if (!auth.ok) return auth.response;
+
+  if (!env.DB) {
+    return html(page({ notice: "Storage not configured.", rows: [] }), 500);
+  }
+
+  let form;
+  try {
+    form = await request.formData();
+  } catch {
+    return html(page({ notice: "Invalid form submission.", rows: await listBatches(env) }), 400);
+  }
+
+  const action = str(form.get("action"));
+
+  try {
+    if (action === "create") {
+      await env.DB.prepare(
+        "INSERT INTO batches (course, batch_date, time, mode, duration, trainer, contact, status) " +
+          "VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)"
+      )
+        .bind(...fieldsFrom(form), statusFrom(form))
+        .run();
+    } else if (action === "update") {
+      const id = Number(form.get("id"));
+      if (id) {
+        await env.DB.prepare(
+          "UPDATE batches SET course=?1, batch_date=?2, time=?3, mode=?4, duration=?5, trainer=?6, " +
+            "contact=?7, status=?8, updated_at=datetime('now') WHERE id=?9"
+        )
+          .bind(...fieldsFrom(form), statusFrom(form), id)
+          .run();
+      }
+    } else if (action === "delete") {
+      const id = Number(form.get("id"));
+      if (id) {
+        await env.DB.prepare("DELETE FROM batches WHERE id=?1").bind(id).run();
+      }
+    }
+  } catch {
+    return html(page({ notice: "Could not save changes.", rows: await listBatches(env) }), 500);
+  }
+
+  return Response.redirect(new URL("/admin/batches", request.url), 303);
+}
+
+function fieldsFrom(form) {
+  return [
+    str(form.get("course")),
+    str(form.get("batch_date")),
+    str(form.get("time")),
+    str(form.get("mode")),
+    str(form.get("duration")),
+    str(form.get("trainer")),
+    str(form.get("contact")),
+  ];
+}
+
+function statusFrom(form) {
+  return str(form.get("status")) || "active";
+}
+
+async function listBatches(env) {
+  try {
+    const res = await env.DB.prepare(
+      "SELECT id, course, batch_date, time, mode, duration, trainer, contact, status " +
+        "FROM batches ORDER BY batch_date ASC"
+    ).all();
+    return res.results || [];
+  } catch {
+    return [];
+  }
+}
+
+const WEEKDAYS = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"];
+
+function dayOf(iso) {
+  const [y, m, d] = String(iso || "").split("-").map(Number);
+  if (!y || !m || !d) return "";
+  return WEEKDAYS[new Date(Date.UTC(y, m - 1, d)).getUTCDay()];
+}
+
+function modeOptions(selected) {
+  return ["offline", "online", "hybrid"]
+    .map((m) => `<option value="${m}" ${m === selected ? "selected" : ""}>${m}</option>`)
+    .join("");
+}
+
+function statusOptions(selected) {
+  return ["active", "hidden"]
+    .map((s) => `<option value="${s}" ${s === selected ? "selected" : ""}>${s}</option>`)
+    .join("");
+}
+
+function rowHtml(r) {
+  return `<tr>
+    <td>${esc(r.course)}</td>
+    <td>${esc(r.batch_date)}<br/><span class="muted">${dayOf(r.batch_date)}</span></td>
+    <td>${esc(r.time) || "—"}</td>
+    <td>${esc(r.mode) || "—"}</td>
+    <td>${esc(r.duration) || "—"}</td>
+    <td>${esc(r.trainer) || "—"}</td>
+    <td>${esc(r.contact) || "—"}</td>
+    <td>${r.status === "active" ? '<span class="badge active">active</span>' : '<span class="badge hidden">hidden</span>'}</td>
+    <td class="actions">
+      <details>
+        <summary>Edit</summary>
+        <form method="post" class="edit-form">
+          <input type="hidden" name="action" value="update"/>
+          <input type="hidden" name="id" value="${r.id}"/>
+          <label>Course <input name="course" value="${esc(r.course)}" required/></label>
+          <label>Date <input type="date" name="batch_date" value="${esc(r.batch_date)}" required/></label>
+          <label>Time <input name="time" value="${esc(r.time || "")}"/></label>
+          <label>Mode <select name="mode">${modeOptions(r.mode)}</select></label>
+          <label>Duration <input name="duration" value="${esc(r.duration || "")}"/></label>
+          <label>Trainer <input name="trainer" value="${esc(r.trainer || "")}"/></label>
+          <label>Contact <input name="contact" value="${esc(r.contact || "")}"/></label>
+          <label>Status <select name="status">${statusOptions(r.status)}</select></label>
+          <button type="submit">Save</button>
+        </form>
+      </details>
+      <form method="post" class="delete-form">
+        <input type="hidden" name="action" value="delete"/>
+        <input type="hidden" name="id" value="${r.id}"/>
+        <button type="submit" class="danger">Delete</button>
+      </form>
+    </td>
+  </tr>`;
+}
+
+function page({ notice, rows }) {
+  const body = rows.length
+    ? rows.map(rowHtml).join("")
+    : `<tr><td colspan="9" class="empty">No batches yet — add one below.</td></tr>`;
+
+  return `<!doctype html>
+<html lang="en"><head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<meta name="robots" content="noindex, nofollow"/>
+<title>Batch Dates — Rest Coder Academy</title>
+<style>
+  :root { --navy:#03084C; --line:#e4e6ef; --muted:#5b6472; --green:#0f9d58; --red:#c0392b; }
+  * { box-sizing:border-box; }
+  body { margin:0; font-family:system-ui,-apple-system,Segoe UI,Roboto,sans-serif; color:#1b2030; background:#f5f6fa; }
+  header { background:var(--navy); color:#fff; padding:1rem 1.25rem; display:flex; align-items:baseline; gap:.75rem; }
+  header h1 { font-size:1.1rem; margin:0; }
+  header nav { margin-left:auto; }
+  header nav a { color:#fff; opacity:.8; font-size:.85rem; text-decoration:underline; }
+  .wrap { padding:1.25rem; overflow-x:auto; }
+  table { border-collapse:collapse; width:100%; min-width:900px; background:#fff; border:1px solid var(--line); border-radius:10px; overflow:hidden; }
+  th,td { text-align:left; padding:.6rem .8rem; border-bottom:1px solid var(--line); vertical-align:top; font-size:.9rem; }
+  th { background:#eef0f6; color:var(--navy); font-weight:600; white-space:nowrap; }
+  tr:last-child td { border-bottom:none; }
+  .muted { color:var(--muted); font-size:.8rem; }
+  .empty { text-align:center; color:var(--muted); padding:2rem; }
+  .notice { padding:1rem 1.25rem; color:var(--red); }
+  .badge { padding:.15rem .6rem; border-radius:999px; font-size:.75rem; font-weight:600; }
+  .badge.active { background:#e6f4ea; color:var(--green); }
+  .badge.hidden { background:#f1e6e6; color:var(--red); }
+  .actions { white-space:nowrap; }
+  .actions form { margin-top:.4rem; }
+  .actions .edit-form label { display:block; margin-top:.4rem; font-size:.8rem; }
+  .actions .edit-form input, .actions .edit-form select { width:100%; padding:.3rem; margin-top:.15rem; }
+  button { cursor:pointer; padding:.3rem .7rem; border-radius:6px; border:1px solid var(--line); background:#fff; }
+  button.danger { color:var(--red); border-color:var(--red); }
+  .add-batch { margin-top:1.5rem; background:#fff; border:1px solid var(--line); border-radius:10px; padding:1rem; max-width:420px; }
+  .add-batch h2 { margin:0 0 .3rem; font-size:1rem; }
+  .add-batch label { display:block; margin-top:.6rem; font-size:.85rem; }
+  .add-batch input, .add-batch select { width:100%; padding:.4rem; margin-top:.2rem; }
+  .add-batch button { margin-top:1rem; background:var(--navy); color:#fff; border:none; padding:.5rem 1rem; }
+</style></head>
+<body>
+  <header><h1>Batch Dates</h1><nav><a href="/admin">Enquiries →</a></nav></header>
+  ${notice ? `<div class="notice">${esc(notice)}</div>` : ""}
+  <div class="wrap">
+    <table>
+      <thead><tr><th>Course</th><th>Date</th><th>Time</th><th>Mode</th><th>Duration</th><th>Trainer</th><th>Contact</th><th>Status</th><th>Actions</th></tr></thead>
+      <tbody>${body}</tbody>
+    </table>
+
+    <form method="post" class="add-batch">
+      <h2>Add a new batch</h2>
+      <input type="hidden" name="action" value="create"/>
+      <label>Course <input name="course" required placeholder="e.g. Java Full Stack"/></label>
+      <label>Date <input type="date" name="batch_date" required/></label>
+      <label>Time <input name="time" placeholder="e.g. 10:00 AM"/></label>
+      <label>Mode <select name="mode">${modeOptions("offline")}</select></label>
+      <label>Duration <input name="duration" placeholder="e.g. 4 months"/></label>
+      <label>Trainer <input name="trainer" placeholder="e.g. Uday pawar S"/></label>
+      <label>Contact <input name="contact" placeholder="e.g. 8073762257"/></label>
+      <label>Status <select name="status">${statusOptions("active")}</select></label>
+      <button type="submit">Add batch</button>
+    </form>
+  </div>
+</body></html>`;
+}
+
+function esc(v) {
+  return String(v == null ? "" : v)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+function str(v) {
+  return typeof v === "string" ? v.trim().slice(0, 500) : "";
+}
+
+function html(bodyStr, status) {
+  return new Response(bodyStr, { status, headers: { "content-type": "text/html; charset=utf-8" } });
+}

--- a/functions/admin/batches.js
+++ b/functions/admin/batches.js
@@ -1,4 +1,5 @@
 import { requireAdminAuth } from "../_shared/auth.js";
+import { ADMIN_STYLES } from "../_shared/adminStyles.js";
 
 // GET/POST /admin/batches — password-protected screen for RCA to add, edit,
 // or hide batch entries without a code change (issue #15). Reads/writes D1
@@ -142,10 +143,10 @@ function rowHtml(r) {
           <label>Trainer <input name="trainer" value="${esc(r.trainer || "")}"/></label>
           <label>Contact <input name="contact" value="${esc(r.contact || "")}"/></label>
           <label>Status <select name="status">${statusOptions(r.status)}</select></label>
-          <button type="submit">Save</button>
+          <button type="submit" class="primary">Save</button>
         </form>
       </details>
-      <form method="post" class="delete-form">
+      <form method="post" class="delete-form" onsubmit="return confirm('Delete this batch entry? This cannot be undone.')">
         <input type="hidden" name="action" value="delete"/>
         <input type="hidden" name="id" value="${r.id}"/>
         <button type="submit" class="danger">Delete</button>
@@ -166,57 +167,53 @@ function page({ notice, rows }) {
 <meta name="robots" content="noindex, nofollow"/>
 <title>Batch Dates — Rest Coder Academy</title>
 <style>
-  :root { --navy:#03084C; --line:#e4e6ef; --muted:#5b6472; --green:#0f9d58; --red:#c0392b; }
-  * { box-sizing:border-box; }
-  body { margin:0; font-family:system-ui,-apple-system,Segoe UI,Roboto,sans-serif; color:#1b2030; background:#f5f6fa; }
-  header { background:var(--navy); color:#fff; padding:1rem 1.25rem; display:flex; align-items:baseline; gap:.75rem; }
-  header h1 { font-size:1.1rem; margin:0; }
-  header nav { margin-left:auto; }
-  header nav a { color:#fff; opacity:.8; font-size:.85rem; text-decoration:underline; }
-  .wrap { padding:1.25rem; overflow-x:auto; }
-  table { border-collapse:collapse; width:100%; min-width:900px; background:#fff; border:1px solid var(--line); border-radius:10px; overflow:hidden; }
-  th,td { text-align:left; padding:.6rem .8rem; border-bottom:1px solid var(--line); vertical-align:top; font-size:.9rem; }
-  th { background:#eef0f6; color:var(--navy); font-weight:600; white-space:nowrap; }
-  tr:last-child td { border-bottom:none; }
-  .muted { color:var(--muted); font-size:.8rem; }
-  .empty { text-align:center; color:var(--muted); padding:2rem; }
-  .notice { padding:1rem 1.25rem; color:var(--red); }
-  .badge { padding:.15rem .6rem; border-radius:999px; font-size:.75rem; font-weight:600; }
-  .badge.active { background:#e6f4ea; color:var(--green); }
-  .badge.hidden { background:#f1e6e6; color:var(--red); }
+${ADMIN_STYLES}
   .actions { white-space:nowrap; }
-  .actions form { margin-top:.4rem; }
-  .actions .edit-form label { display:block; margin-top:.4rem; font-size:.8rem; }
-  .actions .edit-form input, .actions .edit-form select { width:100%; padding:.3rem; margin-top:.15rem; }
-  button { cursor:pointer; padding:.3rem .7rem; border-radius:6px; border:1px solid var(--line); background:#fff; }
-  button.danger { color:var(--red); border-color:var(--red); }
-  .add-batch { margin-top:1.5rem; background:#fff; border:1px solid var(--line); border-radius:10px; padding:1rem; max-width:420px; }
-  .add-batch h2 { margin:0 0 .3rem; font-size:1rem; }
-  .add-batch label { display:block; margin-top:.6rem; font-size:.85rem; }
-  .add-batch input, .add-batch select { width:100%; padding:.4rem; margin-top:.2rem; }
-  .add-batch button { margin-top:1rem; background:var(--navy); color:#fff; border:none; padding:.5rem 1rem; }
+  .actions details { position:relative; display:inline-block; }
+  .actions summary { cursor:pointer; color:var(--navy); font-size:.82rem; font-weight:600; list-style:none; padding:.35rem .7rem; border:1px solid var(--line); border-radius:7px; }
+  .actions summary::-webkit-details-marker { display:none; }
+  .actions details[open] summary { background:#eef0f6; }
+  .actions .edit-form { position:absolute; right:0; top:calc(100% + .4rem); z-index:20; background:#fff; border:1px solid var(--line); border-radius:12px; box-shadow:0 14px 34px rgba(3,8,76,.2); padding:1rem; width:260px; text-align:left; }
+  .actions .edit-form label { display:block; margin-top:.5rem; font-size:.78rem; color:var(--muted); font-weight:600; }
+  .actions .edit-form input, .actions .edit-form select { width:100%; padding:.4rem; margin-top:.2rem; border:1px solid var(--line); border-radius:6px; font-size:.85rem; }
+  .actions .edit-form button { margin-top:.8rem; width:100%; }
+  .actions .delete-form { display:inline-block; margin-left:.4rem; }
+  .add-batch { margin-top:1.75rem; background:#fff; border:1px solid var(--line); border-radius:12px; padding:1.5rem; box-shadow:0 6px 24px rgba(3,8,76,.08); max-width:640px; }
+  .add-batch h2 { margin:0 0 1rem; font-size:1.05rem; color:var(--navy); }
+  .add-batch .grid { display:grid; grid-template-columns:1fr 1fr; gap:1rem; }
+  .add-batch label { display:block; font-size:.82rem; color:var(--muted); font-weight:600; }
+  .add-batch input, .add-batch select { width:100%; padding:.55rem .6rem; margin-top:.3rem; border:1px solid var(--line); border-radius:7px; font-size:.9rem; }
+  .add-batch input:focus, .add-batch select:focus { outline:none; border-color:var(--navy); box-shadow:0 0 0 3px rgba(3,8,76,.1); }
+  .add-batch button { margin-top:1.25rem; }
+  @media (max-width: 560px) {
+    .add-batch .grid { grid-template-columns:1fr; }
+  }
 </style></head>
 <body>
-  <header><h1>Batch Dates</h1><nav><a href="/admin">Enquiries →</a></nav></header>
-  ${notice ? `<div class="notice">${esc(notice)}</div>` : ""}
-  <div class="wrap">
-    <table>
-      <thead><tr><th>Course</th><th>Date</th><th>Time</th><th>Mode</th><th>Duration</th><th>Trainer</th><th>Contact</th><th>Status</th><th>Actions</th></tr></thead>
-      <tbody>${body}</tbody>
-    </table>
+  <header class="admin-header"><h1>Batch Dates</h1><nav><a href="/admin">Enquiries →</a></nav></header>
+  <div class="admin-wrap">
+    ${notice ? `<div class="notice">${esc(notice)}</div>` : ""}
+    <div class="scroll">
+      <table class="admin-table">
+        <thead><tr><th>Course</th><th>Date</th><th>Time</th><th>Mode</th><th>Duration</th><th>Trainer</th><th>Contact</th><th>Status</th><th>Actions</th></tr></thead>
+        <tbody>${body}</tbody>
+      </table>
+    </div>
 
     <form method="post" class="add-batch">
       <h2>Add a new batch</h2>
       <input type="hidden" name="action" value="create"/>
-      <label>Course <input name="course" required placeholder="e.g. Java Full Stack"/></label>
-      <label>Date <input type="date" name="batch_date" required/></label>
-      <label>Time <input name="time" placeholder="e.g. 10:00 AM"/></label>
-      <label>Mode <select name="mode">${modeOptions("offline")}</select></label>
-      <label>Duration <input name="duration" placeholder="e.g. 4 months"/></label>
-      <label>Trainer <input name="trainer" placeholder="e.g. Uday pawar S"/></label>
-      <label>Contact <input name="contact" placeholder="e.g. 8073762257"/></label>
-      <label>Status <select name="status">${statusOptions("active")}</select></label>
-      <button type="submit">Add batch</button>
+      <div class="grid">
+        <label>Course <input name="course" required placeholder="e.g. Java Full Stack"/></label>
+        <label>Date <input type="date" name="batch_date" required/></label>
+        <label>Time <input name="time" placeholder="e.g. 10:00 AM"/></label>
+        <label>Mode <select name="mode">${modeOptions("offline")}</select></label>
+        <label>Duration <input name="duration" placeholder="e.g. 4 months"/></label>
+        <label>Trainer <input name="trainer" placeholder="e.g. Uday pawar S"/></label>
+        <label>Contact <input name="contact" placeholder="e.g. 8073762257"/></label>
+        <label>Status <select name="status">${statusOptions("active")}</select></label>
+      </div>
+      <button type="submit" class="primary">Add batch</button>
     </form>
   </div>
 </body></html>`;

--- a/functions/api/batches.js
+++ b/functions/api/batches.js
@@ -1,0 +1,63 @@
+// GET /api/batches — public read of active batch entries for the "Upcoming
+// Batches" section and each course card's "Next batch" tag. Backed by D1
+// (table `batches`), edited via the /admin/batches admin screen (issue #15).
+//
+// Returns [] (not an error) if D1 or the table isn't ready yet, so the
+// frontend's static fallback list takes over instead of the site breaking —
+// same graceful-degradation approach as the enquiry form's WhatsApp fallback.
+export async function onRequestGet(context) {
+  const { env } = context;
+
+  if (!env.DB) {
+    return json([], 200);
+  }
+
+  try {
+    const res = await env.DB.prepare(
+      "SELECT course, batch_date, time, mode, duration, trainer, contact " +
+        "FROM batches WHERE status = 'active' ORDER BY batch_date ASC"
+    ).all();
+
+    const rows = (res.results || []).map((r) => {
+      const { display, day } = isoToDisplay(r.batch_date);
+      return {
+        name: r.course,
+        date: display,
+        day,
+        time: r.time || "",
+        mode: r.mode || "",
+        duration: r.duration || "",
+        trainer: r.trainer || "",
+        contact: r.contact || "",
+      };
+    });
+
+    return json(rows, 200);
+  } catch {
+    return json([], 200);
+  }
+}
+
+const WEEKDAYS = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"];
+
+// "YYYY-MM-DD" -> { display: "DD-MM-YYYY", day: "Wednesday" }
+// The frontend's batchDateUtils.parseBatchDate expects DD-MM-YYYY, so this
+// keeps the API contract matching the existing static batches.js shape.
+function isoToDisplay(iso) {
+  const [y, m, d] = String(iso).split("-").map(Number);
+  const pad = (n) => String(n).padStart(2, "0");
+  if (!y || !m || !d) {
+    return { display: "", day: "" };
+  }
+  return {
+    display: `${pad(d)}-${pad(m)}-${y}`,
+    day: WEEKDAYS[new Date(Date.UTC(y, m - 1, d)).getUTCDay()],
+  };
+}
+
+function json(body, status) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}

--- a/schema.sql
+++ b/schema.sql
@@ -11,3 +11,22 @@ CREATE TABLE IF NOT EXISTS enquiries (
 );
 
 CREATE INDEX IF NOT EXISTS idx_enquiries_created_at ON enquiries (created_at);
+
+-- Batch entries for the "Upcoming Batches" section (see issue #15).
+-- Admin-editable via /admin/batches so RCA can update dates without a
+-- code change or redeploy. Read publicly via GET /api/batches.
+CREATE TABLE IF NOT EXISTS batches (
+  id         INTEGER PRIMARY KEY AUTOINCREMENT,
+  course     TEXT NOT NULL,
+  batch_date TEXT NOT NULL, -- ISO YYYY-MM-DD
+  time       TEXT,
+  mode       TEXT,
+  duration   TEXT,
+  trainer    TEXT,
+  contact    TEXT,
+  status     TEXT NOT NULL DEFAULT 'active', -- 'active' | 'hidden'
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_batches_status_date ON batches (status, batch_date);

--- a/src/components/organism/Batches/Batches.jsx
+++ b/src/components/organism/Batches/Batches.jsx
@@ -1,14 +1,14 @@
 import { Box } from '@mui/material'
 import React from 'react'
 
-import { batches } from './batches'
+import { useBatches } from './useBatches'
 import TypoGraphyComponent from '../../atoms/TypoGraphyComponent/TypoGraphyComponent'
 import "./Batches.css"
 import CardGrid from '../../molecules/Grid/CardGrid'
 import BatchesGrid from './BatchesGrid'
 
 function Batches() {
-    let mapdataContent=["","",""]
+    let { batches }=useBatches()
     return (
         <Box className='batches' my={5} mx={12} id="Batches">
         <TypoGraphyComponent variant='h3' text='Upcoming Batches' component='h3' sx={{textAlign:"center",fontWeight:"bold"}} />

--- a/src/components/organism/Batches/useBatches.js
+++ b/src/components/organism/Batches/useBatches.js
@@ -1,0 +1,45 @@
+import { useEffect, useState } from 'react'
+import { batches as fallbackBatches } from './batches'
+
+// Fetches the live batch list from /api/batches (backed by D1, admin-editable
+// via /admin/batches — see issue #15) and falls back to the static
+// batches.js list if the request fails or the API isn't deployed yet.
+// The promise is memoized at module scope so every component calling this
+// hook (Batches, each CoursesCard) shares one request instead of firing one
+// per card.
+let cachedPromise = null
+
+function fetchBatches() {
+    if (!cachedPromise) {
+        cachedPromise = fetch('/api/batches')
+            .then((res) => {
+                if (!res.ok) {
+                    throw new Error('bad response')
+                }
+                return res.json()
+            })
+            .then((data) => (Array.isArray(data) && data.length ? data : fallbackBatches))
+            .catch(() => fallbackBatches)
+    }
+    return cachedPromise
+}
+
+export function useBatches() {
+    let [batches, setBatches] = useState(fallbackBatches)
+    let [loading, setLoading] = useState(true)
+
+    useEffect(() => {
+        let cancelled = false
+        fetchBatches().then((data) => {
+            if (!cancelled) {
+                setBatches(data)
+                setLoading(false)
+            }
+        })
+        return () => {
+            cancelled = true
+        }
+    }, [])
+
+    return { batches, loading }
+}

--- a/src/components/organism/courses/CoursesCard.jsx
+++ b/src/components/organism/courses/CoursesCard.jsx
@@ -9,12 +9,13 @@ import TypoGraphyComponent from '../../atoms/TypoGraphyComponent/TypoGraphyCompo
 import ButtonComponent from '../../atoms/ButtonComponent/ButtonComponent';
 import { List, ListItem, ListItemText } from '@mui/material';
 import { useAuth } from '../../../App';
-import { batches } from '../Batches/batches';
+import { useBatches } from '../Batches/useBatches';
 import { getNextBatchForCourse, formatBatchDateShort } from '../Batches/batchDateUtils';
 
 
  function CoursesCard({name,backend,audience,frontend,syllabus1,syllabus2}) {
     let {openModal}=useAuth()
+    let { batches }=useBatches()
     let nextBatch=getNextBatchForCourse(name,batches)
   return (
     <Card sx={{ }} className='card'>


### PR DESCRIPTION
## Summary

#3 fixed the immediately stale hardcoded date. This is the durable layer on top: **RCA (Uday) updates batch dates themselves, no developer and no code change** — closing #15.

- `functions/api/batches.js` — public `GET /api/batches`, returns active batch entries from D1 shaped to match the existing frontend contract (`DD-MM-YYYY` date, computed weekday), so `BatchesCard`/`CoursesCard`'s existing closed/waitlist/"Next batch" logic from #3 needs zero changes.
- `functions/admin/batches.js` — password-protected `/admin/batches` screen (same `ADMIN_PASSWORD` gate as the existing `/admin` leads page) to add, edit, or hide batch entries via plain HTML forms. POST redirects back to GET (303) so a refresh can't resubmit a mutation.
- `functions/_shared/auth.js` — extracted the Basic Auth guard that was duplicated between `/admin` and this new screen into one shared helper (also refactored `functions/admin.js` to use it).
- `src/components/organism/Batches/useBatches.js` — a hook that fetches `/api/batches` (deduped via a module-level cached promise so `Batches` + every `CoursesCard` share one request instead of firing N times) and falls back to the static `batches.js` list if the API is empty or unreachable — same graceful-degradation philosophy as the enquiry form's WhatsApp fallback, so the site can never break even if D1 is down or not yet populated.
- `schema.sql` — new `batches` table (`course`, `batch_date` ISO, `time`, `mode`, `duration`, `trainer`, `contact`, `status` active/hidden). Day-of-week is computed server-side from the date rather than stored, so it can't drift out of sync.
- `README.md` — documents the new routes, plus fixes a stale line still describing the already-shipped `/admin` leads page as a "planned follow-up".

Both admin screens now cross-link to each other in their headers, since the ticket notes this admin surface is meant to grow (hero copy was flagged as a possible future addition).

Fixes #15

## Test plan
- [x] `npm run build` succeeds
- [x] `npm run lint` shows no new errors (pre-existing repo-wide lint errors unaffected)
- [x] Tested end-to-end locally against a real local D1 instance via `wrangler pages dev`:
  - `GET /admin/batches` without credentials → `401`
  - `POST /admin/batches` without credentials → `401`, no mutation happens
  - Create a batch via the admin form → appears in both `/admin/batches` and public `/api/batches`
  - Edit a batch's time/mode → change reflected in `/api/batches`
  - Set a batch to `hidden` → disappears from public `/api/batches`, still visible (with a badge) in the admin list
  - Delete a batch → removed entirely
  - Date/weekday formatting verified correct (`2026-09-16` → `16-09-2026` / `Wednesday`)
- [ ] Apply `schema.sql`'s new `batches` table to the **remote** D1 database before/after merge: `npx wrangler d1 execute restcoder-enquiries --remote --file=schema.sql`
- [ ] RCA/Uday populates real batch entries via `/admin/batches` once deployed (the static `batches.js` fallback keeps the site correct in the meantime — see #3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MXdnvv2AAYSyXEsegoxNja