### PR TITLE
feat(batches): hide/status + computed weekday (folds in Pavan's #29)

### DIFF
--- a/functions/admin/batches.js
+++ b/functions/admin/batches.js
@@ -2,9 +2,10 @@
 // GET renders the current batches with an edit form each + an "add" form.
 // POST handles add / update / delete, writes to D1, then redirects back.
 // Same Basic Auth as /admin (ADMIN_PASSWORD secret, fails closed if unset).
-import { escapeHtml, isValidBatchDate, requireAdminAuth } from "../../shared/serverUtil.js";
+import { escapeHtml, isValidBatchDate, requireAdminAuth, weekdayFromDate } from "../../shared/serverUtil.js";
 
-const FIELDS = ["name", "date", "day", "time", "trainer", "duration", "mode", "contact"];
+// `day` is derived from the date (not entered), and `status` is handled separately.
+const FIELDS = ["name", "date", "time", "trainer", "duration", "mode", "contact"];
 
 export async function onRequestGet(context) {
   const { request, env } = context;
@@ -15,7 +16,7 @@ export async function onRequestGet(context) {
   let rows = [];
   try {
     const res = await env.DB.prepare(
-      "SELECT id, name, date, day, time, trainer, duration, mode, contact, sort_order " +
+      "SELECT id, name, date, day, time, trainer, duration, mode, contact, sort_order, status " +
         "FROM batches ORDER BY sort_order ASC, date ASC"
     ).all();
     rows = res.results || [];
@@ -60,21 +61,24 @@ export async function onRequestPost(context) {
   if (!isValidBatchDate(vals.date))
     return redirect(request, "err", "Date must be a real date in DD-MM-YYYY format.");
 
+  const day = weekdayFromDate(vals.date); // derived, never entered — can't drift
+  const status = form.get("status") === "hidden" ? "hidden" : "active";
+
   try {
     if (action === "update") {
       if (!id) return redirect(request, "err", "Missing id.");
       await env.DB.prepare(
-        "UPDATE batches SET name=?1, date=?2, day=?3, time=?4, trainer=?5, duration=?6, mode=?7, contact=?8, sort_order=?9, updated_at=datetime('now') WHERE id=?10"
+        "UPDATE batches SET name=?1, date=?2, day=?3, time=?4, trainer=?5, duration=?6, mode=?7, contact=?8, sort_order=?9, status=?10, updated_at=datetime('now') WHERE id=?11"
       )
-        .bind(vals.name, vals.date, vals.day, vals.time, vals.trainer, vals.duration, vals.mode, vals.contact, sortOrder, id)
+        .bind(vals.name, vals.date, day, vals.time, vals.trainer, vals.duration, vals.mode, vals.contact, sortOrder, status, id)
         .run();
       return redirect(request, "ok", "Batch updated.");
     }
     if (action === "add") {
       await env.DB.prepare(
-        "INSERT INTO batches (name, date, day, time, trainer, duration, mode, contact, sort_order) VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9)"
+        "INSERT INTO batches (name, date, day, time, trainer, duration, mode, contact, sort_order, status) VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10)"
       )
-        .bind(vals.name, vals.date, vals.day, vals.time, vals.trainer, vals.duration, vals.mode, vals.contact, sortOrder)
+        .bind(vals.name, vals.date, day, vals.time, vals.trainer, vals.duration, vals.mode, vals.contact, sortOrder, status)
         .run();
       return redirect(request, "ok", "Batch added.");
     }
@@ -158,16 +162,20 @@ function rowForm(r) {
 function fieldGrid(r) {
   const F = (name, label, ph = "") =>
     `<div><label>${label}</label><input name="${name}" value="${escapeHtml(r[name])}" placeholder="${escapeHtml(ph)}"/></div>`;
+  const status = r.status === "hidden" ? "hidden" : "active";
   return `<div class="grid">
     ${F("name", "Course name", "Java Full Stack")}
     ${F("date", "Date (DD-MM-YYYY)", "16-09-2026")}
-    ${F("day", "Day", "Wednesday")}
     ${F("time", "Time", "10:00 AM")}
     ${F("duration", "Duration", "4 months")}
     ${F("mode", "Mode", "offline")}
     ${F("trainer", "Trainer", "Uday pawar S")}
     ${F("contact", "Contact", "8073762257")}
     <div><label>Sort order</label><input name="sort_order" value="${escapeHtml(r.sort_order)}" placeholder="1"/></div>
+    <div><label>Status</label><select name="status">
+      <option value="active"${status === "active" ? " selected" : ""}>Active (shown on site)</option>
+      <option value="hidden"${status === "hidden" ? " selected" : ""}>Hidden</option>
+    </select></div>
   </div>`;
 }
 

--- a/functions/api/batches.js
+++ b/functions/api/batches.js
@@ -2,15 +2,20 @@
 // Batches section and the course-card "Next batch" tags read live data that the
 // academy edits from /admin/batches (no code change, no redeploy).
 // Fails soft: on any error returns [] and the frontend falls back to its bundled defaults.
+import { weekdayFromDate } from "../../shared/serverUtil.js";
+
 export async function onRequestGet(context) {
   const { env } = context;
   if (!env.DB) return json([]);
   try {
     const { results } = await env.DB.prepare(
       "SELECT id, name, date, day, time, trainer, duration, mode, contact " +
-        "FROM batches ORDER BY sort_order ASC, date ASC"
+        "FROM batches WHERE status = 'active' ORDER BY sort_order ASC, date ASC"
     ).all();
-    return json(results || []);
+    // Derive the weekday from the date so it can never drift; keep the stored
+    // value only as a fallback for an unparseable date.
+    const rows = (results || []).map((r) => ({ ...r, day: weekdayFromDate(r.date) || r.day }));
+    return json(rows);
   } catch {
     return json([]);
   }

--- a/schema-batches.sql
+++ b/schema-batches.sql
@@ -10,5 +10,6 @@ CREATE TABLE IF NOT EXISTS batches (
   mode       TEXT,
   contact    TEXT,
   sort_order INTEGER NOT NULL DEFAULT 0,
+  status     TEXT NOT NULL DEFAULT 'active',   -- 'active' (shown on site) | 'hidden'
   updated_at TEXT NOT NULL DEFAULT (datetime('now'))
 );

--- a/shared/serverUtil.js
+++ b/shared/serverUtil.js
@@ -23,6 +23,15 @@ export function isValidBatchDate(s) {
   return dt.getFullYear() === y && dt.getMonth() === m - 1 && dt.getDate() === d;
 }
 
+// Derive the weekday name from a DD-MM-YYYY date, so the day shown on the site is
+// always computed from the date and can't drift out of sync with it. "" if invalid.
+const WEEKDAYS = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"];
+export function weekdayFromDate(s) {
+  if (!isValidBatchDate(s)) return "";
+  const [d, m, y] = String(s).split("-").map(Number);
+  return WEEKDAYS[new Date(y, m - 1, d).getDay()];
+}
+
 // Length-independent early-out plus constant-time compare of equal-length strings,
 // so a wrong admin password can't be discovered by timing.
 export function safeEqual(a, b) {

--- a/shared/serverUtil.test.js
+++ b/shared/serverUtil.test.js
@@ -2,10 +2,22 @@ import { describe, it, expect } from "vitest";
 import {
   escapeHtml,
   isValidBatchDate,
+  weekdayFromDate,
   safeEqual,
   parseBasicAuth,
   requireAdminAuth,
 } from "./serverUtil.js";
+
+describe("weekdayFromDate (derived, can't drift)", () => {
+  it("derives the correct weekday name", () => {
+    expect(weekdayFromDate("16-09-2026")).toBe("Wednesday");
+    expect(weekdayFromDate("20-09-2026")).toBe("Sunday");
+  });
+  it("returns '' for an invalid date", () => {
+    expect(weekdayFromDate("31-04-2026")).toBe("");
+    expect(weekdayFromDate("")).toBe("");
+  });
+});
 
 describe("escapeHtml (XSS)", () => {
   it("escapes the dangerous characters", () => {

--- a/tests/functions.integration.test.js
+++ b/tests/functions.integration.test.js
@@ -19,17 +19,21 @@ function makeDB(seed = {}) {
           if (/INSERT INTO enquiries/i.test(sql))
             t.enquiries.push({ id: ++ids.enquiries, fullname: args[0], mobile: args[1], email: args[2], experience: args[3], message: args[4] });
           else if (/INSERT INTO batches/i.test(sql))
-            t.batches.push({ id: ++ids.batches, name: args[0], date: args[1], day: args[2], time: args[3], trainer: args[4], duration: args[5], mode: args[6], contact: args[7], sort_order: args[8] });
+            t.batches.push({ id: ++ids.batches, name: args[0], date: args[1], day: args[2], time: args[3], trainer: args[4], duration: args[5], mode: args[6], contact: args[7], sort_order: args[8], status: args[9] });
           else if (/UPDATE batches/i.test(sql)) {
             const row = t.batches.find((b) => String(b.id) === String(args[args.length - 1]));
-            if (row) Object.assign(row, { name: args[0], date: args[1], day: args[2], time: args[3], trainer: args[4], duration: args[5], mode: args[6], contact: args[7], sort_order: args[8] });
+            if (row) Object.assign(row, { name: args[0], date: args[1], day: args[2], time: args[3], trainer: args[4], duration: args[5], mode: args[6], contact: args[7], sort_order: args[8], status: args[9] });
           } else if (/DELETE FROM batches/i.test(sql)) {
             t.batches = t.batches.filter((b) => String(b.id) !== String(args[0]));
           }
           return { success: true };
         },
         async all() {
-          if (/FROM batches/i.test(sql)) return { results: t.batches };
+          if (/FROM batches/i.test(sql)) {
+            let rows = t.batches;
+            if (/status\s*=\s*'active'/i.test(sql)) rows = rows.filter((b) => (b.status || "active") === "active");
+            return { results: rows };
+          }
           if (/FROM enquiries/i.test(sql)) return { results: t.enquiries };
           return { results: [] };
         },
@@ -80,6 +84,18 @@ describe("GET /api/batches", () => {
     const res = await batchesGet(ctx(new Request("https://x/api/batches"), {}));
     expect(await res.json()).toEqual([]);
   });
+  it("returns only ACTIVE batches, with the weekday computed from the date", async () => {
+    const db = makeDB({
+      batches: [
+        { id: 1, name: "Java Full Stack", date: "16-09-2026", day: "WRONGDAY", status: "active" },
+        { id: 2, name: "Hidden Course", date: "23-09-2026", status: "hidden" },
+      ],
+    });
+    const data = await (await batchesGet(ctx(new Request("https://x/api/batches"), { DB: db }))).json();
+    expect(data).toHaveLength(1); // hidden one excluded
+    expect(data[0].name).toBe("Java Full Stack");
+    expect(data[0].day).toBe("Wednesday"); // computed — overrides the stored "WRONGDAY"
+  });
 });
 
 describe("GET /admin (enquiries)", () => {
@@ -123,6 +139,14 @@ describe("POST /admin/batches (CRUD)", () => {
     expect(res.status).toBe(303);
     expect(res.headers.get("location")).toContain("err=");
     expect(db.tables.batches).toHaveLength(0);
+  });
+  it("stores status=hidden and DERIVES the weekday when adding (Pavan's improvements)", async () => {
+    const db = makeDB();
+    const res = await batchAdminPost(ctx(formReq("https://x/admin/batches", { action: "add", name: "X", date: "16-09-2026", status: "hidden" }), env(db)));
+    expect(res.status).toBe(303);
+    expect(db.tables.batches).toHaveLength(1);
+    expect(db.tables.batches[0].status).toBe("hidden");
+    expect(db.tables.batches[0].day).toBe("Wednesday"); // derived from 16-09-2026, not entered
   });
   it("deletes a batch by id", async () => {
     const db = makeDB({ batches: [{ id: 5, name: "X", date: "16-09-2026" }] });


### PR DESCRIPTION
Folds the two better ideas from @Pavankulli's parallel PR #29 into the live batch admin:
- **status (active/hidden)** — hide a batch without deleting it.
- **computed weekday** — derived from the date, can't drift (the day input is gone from the admin form).

Credit to Pavan for both. +4 tests; 42 total green; live D1 already has the `status` column. **Supersedes #29.**

Closes #34