### PR TITLE
feat(enroll): FDE course + Enroll Now funnel + Razorpay (EMI) checkout

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,35 @@ admin ->  /admin/trainers (GET/POST)   (functions/admin/trainers.js, password-pr
   the API is ever unreachable, so the section always renders.
 - Set a trainer to **Hidden** to keep the profile but take it off the site.
 
+## Enrolments & payments (FDE)
+
+Course cards say **Enroll Now**. A paid course (FDE, ₹50,000) opens a Razorpay
+checkout; any other course opens a free "register interest" form. Enrolments
+(paid + registered) are viewable at **`/admin/enrollments`**.
+
+```
+Enroll Now (FDE)  -> checkout -> POST /api/enroll/order  (server creates the Razorpay order)
+                              -> Razorpay Checkout (EMI available)
+                              -> POST /api/enroll/verify (server verifies the signature, records it)
+Enroll Now (other) ->            POST /api/enroll/register (free interest, status='registered')
+```
+
+**Money rules (enforced in code):**
+- The amount is decided on the **server** (`shared/enroll.js` → `COURSE_PRICES`),
+  never taken from the browser. Add a course id + price there to make it payable.
+- The Razorpay **signature is verified server-side** before an enrolment is
+  recorded — a redirect alone can be forged.
+- Recording is **idempotent** (one row per Razorpay order id).
+- The referral (`?ref=…`) rides into the Razorpay order `notes` and the row.
+
+**Going live (you, in the Razorpay dashboard — the app never sees the keys):**
+1. Set the Pages secrets `RAZORPAY_KEY_ID` and `RAZORPAY_KEY_SECRET` (test first,
+   then live). Until they're set, `/api/enroll/order` returns 503 and the form
+   falls back to recording interest — nothing breaks.
+2. Enable **EMI** on the Razorpay account so it's offered at checkout.
+3. `npx wrangler d1 execute restcoder-enquiries --remote --file=schema-enrollments.sql`
+   to create the `enrollments` table.
+
 ## History / context
 
 - The previous backend (`trcabe.onrender.com`) was a separate repo by the prior

--- a/e2e/smoke.spec.js
+++ b/e2e/smoke.spec.js
@@ -17,8 +17,19 @@ test("/admin is password-protected (401)", async ({ request }) => {
   expect((await request.get("/admin/batches")).status()).toBe(401);
 });
 
-test("enquiry CTA opens the form", async ({ page }) => {
+test("enroll CTA opens the enrolment form", async ({ page }) => {
   await page.goto("/");
-  await page.getByRole("button", { name: /enquire/i }).first().click();
+  await page.getByRole("button", { name: /enroll now/i }).first().click();
+  await expect(page.getByRole("button", { name: /pay ₹|register my seat/i })).toBeVisible();
+});
+
+test("apply CTA opens the enquiry form", async ({ page }) => {
+  await page.goto("/");
+  await page.getByRole("button", { name: /apply now|register now/i }).first().click();
   await expect(page.getByRole("button", { name: /submit|sending/i })).toBeVisible();
+});
+
+test("/api/enroll/order is inert until Razorpay keys are set (503)", async ({ request }) => {
+  const res = await request.post("/api/enroll/order", { data: { course: "fde" } });
+  expect(res.status()).toBe(503);
 });

--- a/functions/admin/batches.js
+++ b/functions/admin/batches.js
@@ -127,7 +127,7 @@ function page(rows, error, notice) {
   .hint{font-size:.75rem;color:var(--muted);margin:.3rem 0 0}
 </style></head>
 <body>
-  <header><h1>Batches</h1><a href="/admin/trainers">Trainers</a><a href="/admin/batches">Batches</a><a href="/admin">Enquiries →</a></header>
+  <header><h1>Batches</h1><a href="/admin/enrollments">Enrolments</a><a href="/admin/trainers">Trainers</a><a href="/admin/batches">Batches</a><a href="/admin">Enquiries →</a></header>
   <div class="wrap">
     ${error ? `<div class="banner err">${escapeHtml(error)}</div>` : ""}
     ${notice ? `<div class="banner ok">${escapeHtml(notice)}</div>` : ""}

--- a/functions/admin/enrollments.js
+++ b/functions/admin/enrollments.js
@@ -1,45 +1,49 @@
-// GET /admin — password-protected lead list for the academy.
-// Reads enquiries from D1 (binding `DB`) and server-renders an HTML table.
-// Auth: HTTP Basic Auth against the `ADMIN_PASSWORD` Pages secret (user = ADMIN_USER
-// or "admin"). Fails CLOSED — if ADMIN_PASSWORD isn't set, nobody gets in.
-import { escapeHtml, requireAdminAuth } from "../shared/serverUtil.js";
+// GET /admin/enrollments — password-protected list of enrolments (paid + free
+// "register interest"). Same Basic Auth as /admin (ADMIN_PASSWORD, fails closed).
+import { escapeHtml, requireAdminAuth } from "../../shared/serverUtil.js";
 
 export async function onRequestGet(context) {
   const { request, env } = context;
-
   const auth = requireAdminAuth(request, env);
   if (auth) return auth;
-
-  if (!env.DB) {
-    return html(page("Storage not configured.", 0, ""), 500);
-  }
+  if (!env.DB) return html(page("Storage not configured.", 0, ""), 500);
 
   let rows = [];
   try {
     const res = await env.DB.prepare(
-      "SELECT id, fullname, mobile, email, experience, message, created_at " +
-        "FROM enquiries ORDER BY created_at DESC"
+      "SELECT id, fullname, mobile, email, course, course_name, batch, referral, amount, status, razorpay_payment_id, created_at " +
+        "FROM enrollments ORDER BY created_at DESC"
     ).all();
     rows = res.results || [];
   } catch {
-    return html(page("Could not load enquiries.", 0, ""), 500);
+    return html(page("Could not load enrolments.", 0, ""), 500);
   }
 
   const body = rows.length
     ? rows.map(rowHtml).join("")
-    : `<tr><td colspan="6" class="empty">No enquiries yet.</td></tr>`;
-
+    : `<tr><td colspan="8" class="empty">No enrolments yet.</td></tr>`;
   return html(page(null, rows.length, body), 200);
 }
 
+function rupees(paise) {
+  if (typeof paise !== "number") return "—";
+  return "₹" + (paise / 100).toLocaleString("en-IN");
+}
+
 function rowHtml(r) {
+  const paid = r.status === "paid";
+  const badge = paid
+    ? `<span class="badge paid">paid</span>`
+    : `<span class="badge reg">registered</span>`;
   return (
     "<tr>" +
     `<td>${escapeHtml(r.fullname)}</td>` +
     `<td><a href="tel:${escapeHtml(r.mobile)}">${escapeHtml(r.mobile)}</a></td>` +
     `<td>${r.email ? `<a href="mailto:${escapeHtml(r.email)}">${escapeHtml(r.email)}</a>` : "—"}</td>` +
-    `<td>${escapeHtml(r.experience) || "—"}</td>` +
-    `<td class="msg">${escapeHtml(r.message) || "—"}</td>` +
+    `<td>${escapeHtml(r.course_name || r.course)}</td>` +
+    `<td>${escapeHtml(r.batch) || "—"}</td>` +
+    `<td>${badge}${paid ? ` <span class="amt">${rupees(r.amount)}</span>` : ""}</td>` +
+    `<td>${escapeHtml(r.referral) || "—"}</td>` +
     `<td class="when">${escapeHtml(r.created_at)}</td>` +
     "</tr>"
   );
@@ -51,7 +55,7 @@ function page(notice, count, body) {
 <meta charset="utf-8"/>
 <meta name="viewport" content="width=device-width, initial-scale=1"/>
 <meta name="robots" content="noindex, nofollow"/>
-<title>Enquiries — Rest Coder Academy</title>
+<title>Enrolments — Rest Coder Academy</title>
 <style>
   :root { --navy:#03084C; --line:#e4e6ef; --muted:#5b6472; }
   * { box-sizing:border-box; }
@@ -61,22 +65,25 @@ function page(notice, count, body) {
   header .count { font-size:.85rem; opacity:.8; }
   header a { color:#cdd6ea; font-size:.85rem; margin-left:.5rem; }
   .wrap { padding:1.25rem; overflow-x:auto; }
-  table { border-collapse:collapse; width:100%; min-width:760px; background:#fff; border:1px solid var(--line); border-radius:10px; overflow:hidden; }
+  table { border-collapse:collapse; width:100%; min-width:820px; background:#fff; border:1px solid var(--line); border-radius:10px; overflow:hidden; }
   th,td { text-align:left; padding:.6rem .8rem; border-bottom:1px solid var(--line); vertical-align:top; font-size:.9rem; }
   th { background:#eef0f6; color:var(--navy); font-weight:600; white-space:nowrap; }
   tr:last-child td { border-bottom:none; }
   a { color:var(--navy); }
-  .msg { max-width:340px; }
   .when { white-space:nowrap; color:var(--muted); }
   .empty { text-align:center; color:var(--muted); padding:2rem; }
   .notice { padding:1rem 1.25rem; color:#b3261e; }
+  .badge { font-size:.72rem; font-weight:700; padding:.1rem .45rem; border-radius:999px; text-transform:uppercase; }
+  .badge.paid { background:#e7f6ec; color:#1b6b3a; }
+  .badge.reg { background:#eef1f8; color:#334; }
+  .amt { font-weight:600; white-space:nowrap; }
 </style></head>
 <body>
-  <header><h1>Enquiries</h1><span class="count">${count} total</span><a href="/admin/enrollments">Enrolments</a><a href="/admin/batches">Batches</a><a href="/admin/trainers">Trainers →</a></header>
+  <header><h1>Enrolments</h1><span class="count">${count} total</span><a href="/admin/trainers">Trainers</a><a href="/admin/batches">Batches</a><a href="/admin">Enquiries →</a></header>
   ${notice ? `<div class="notice">${escapeHtml(notice)}</div>` : ""}
   <div class="wrap">
     <table>
-      <thead><tr><th>Name</th><th>Mobile</th><th>Email</th><th>Experience</th><th>Message</th><th>Received</th></tr></thead>
+      <thead><tr><th>Name</th><th>Mobile</th><th>Email</th><th>Course</th><th>Batch</th><th>Status</th><th>Referral</th><th>When</th></tr></thead>
       <tbody>${body}</tbody>
     </table>
   </div>

--- a/functions/admin/trainers.js
+++ b/functions/admin/trainers.js
@@ -150,7 +150,7 @@ function page(rows, error, notice) {
   .hint{font-size:.75rem;color:var(--muted);margin:.3rem 0 1rem}
 </style></head>
 <body>
-  <header><h1>Trainers</h1><a href="/admin/trainers">Trainers</a><a href="/admin/batches">Batches</a><a href="/admin">Enquiries →</a></header>
+  <header><h1>Trainers</h1><a href="/admin/enrollments">Enrolments</a><a href="/admin/trainers">Trainers</a><a href="/admin/batches">Batches</a><a href="/admin">Enquiries →</a></header>
   <div class="wrap">
     ${error ? `<div class="banner err">${escapeHtml(error)}</div>` : ""}
     ${notice ? `<div class="banner ok">${escapeHtml(notice)}</div>` : ""}

--- a/functions/api/enroll/order.js
+++ b/functions/api/enroll/order.js
@@ -1,0 +1,60 @@
+// POST /api/enroll/order — creates a Razorpay order SERVER-SIDE for a paid
+// course (currently FDE). The amount is looked up on the server from the course
+// id; it is never read from the request body. Returns the order id + the public
+// key id the browser needs to open Razorpay Checkout. The secret never leaves
+// the server.
+//
+// Inert until keys exist: with no RAZORPAY_KEY_ID / RAZORPAY_KEY_SECRET secrets,
+// it returns 503 so the frontend can show "enrolment opening soon" instead of
+// a broken checkout.
+import { priceForCourse } from "../../../shared/enroll.js";
+
+export async function onRequestPost(context) {
+  const { request, env } = context;
+  const keyId = env.RAZORPAY_KEY_ID;
+  const keySecret = env.RAZORPAY_KEY_SECRET;
+  if (!keyId || !keySecret) return json({ error: "Payments are not enabled yet." }, 503);
+
+  let body;
+  try {
+    body = await request.json();
+  } catch {
+    return json({ error: "Bad request." }, 400);
+  }
+
+  const courseId = String(body.course || "").trim();
+  const amount = priceForCourse(courseId); // paise, server-decided
+  if (!amount) return json({ error: "This course isn't available for online payment." }, 400);
+
+  const referral = String(body.referral || "").trim().slice(0, 120);
+
+  let res;
+  try {
+    res = await fetch("https://api.razorpay.com/v1/orders", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        Authorization: "Basic " + btoa(`${keyId}:${keySecret}`),
+      },
+      body: JSON.stringify({
+        amount,
+        currency: "INR",
+        receipt: `${courseId}_${Date.now()}`,
+        notes: { course: courseId, referral },
+      }),
+    });
+  } catch {
+    return json({ error: "Could not reach the payment gateway. Please try again." }, 502);
+  }
+  if (!res.ok) return json({ error: "Could not start payment. Please try again." }, 502);
+
+  const order = await res.json();
+  return json({ orderId: order.id, amount, currency: "INR", keyId });
+}
+
+function json(body, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}

--- a/functions/api/enroll/register.js
+++ b/functions/api/enroll/register.js
@@ -1,0 +1,43 @@
+// POST /api/enroll/register — records a free "register interest" enrolment for a
+// course that isn't priced for online payment yet (Java / Python / MERN). Same
+// fields as a paid enrolment, status='registered', no payment. The academy
+// follows up from /admin/enrollments.
+export async function onRequestPost(context) {
+  const { request, env } = context;
+  if (!env.DB) return json({ error: "Storage not configured." }, 500);
+
+  let b;
+  try {
+    b = await request.json();
+  } catch {
+    return json({ error: "Bad request." }, 400);
+  }
+
+  const fullname = str(b.fullname);
+  const mobile = str(b.mobile);
+  if (!fullname || !mobile) return json({ error: "Name and mobile are required." }, 400);
+
+  try {
+    await env.DB.prepare(
+      "INSERT INTO enrollments (fullname, mobile, email, experience, course, course_name, batch, referral, status) " +
+        "VALUES (?1,?2,?3,?4,?5,?6,?7,?8,'registered')"
+    )
+      .bind(
+        fullname, mobile, str(b.email), str(b.experience),
+        str(b.course), str(b.course_name), str(b.batch), str(b.referral)
+      )
+      .run();
+    return json({ ok: true }, 201);
+  } catch {
+    return json({ error: "Could not register. Please try again." }, 500);
+  }
+}
+
+const str = (v) => String(v || "").trim().slice(0, 300);
+
+function json(body, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}

--- a/functions/api/enroll/verify.js
+++ b/functions/api/enroll/verify.js
@@ -1,0 +1,62 @@
+// POST /api/enroll/verify — verifies a completed Razorpay payment SERVER-SIDE
+// (a browser redirect/callback alone can be forged) and records the paid
+// enrolment. Idempotent: a retried verify for the same order does not create a
+// second row.
+import { priceForCourse, verifyRazorpaySignature } from "../../../shared/enroll.js";
+
+export async function onRequestPost(context) {
+  const { request, env } = context;
+  const keySecret = env.RAZORPAY_KEY_SECRET;
+  if (!keySecret) return json({ error: "Payments are not enabled yet." }, 503);
+  if (!env.DB) return json({ error: "Storage not configured." }, 500);
+
+  let b;
+  try {
+    b = await request.json();
+  } catch {
+    return json({ error: "Bad request." }, 400);
+  }
+
+  const orderId = String(b.razorpay_order_id || "");
+  const paymentId = String(b.razorpay_payment_id || "");
+  const signature = String(b.razorpay_signature || "");
+
+  const valid = await verifyRazorpaySignature(orderId, paymentId, signature, keySecret);
+  if (!valid) return json({ error: "Payment could not be verified." }, 400);
+
+  const courseId = String(b.course || "").trim();
+  const amount = priceForCourse(courseId);
+
+  try {
+    const existing = await env.DB.prepare(
+      "SELECT id FROM enrollments WHERE razorpay_order_id = ?1"
+    )
+      .bind(orderId)
+      .first();
+    if (!existing) {
+      await env.DB.prepare(
+        "INSERT INTO enrollments (fullname, mobile, email, experience, course, course_name, batch, referral, amount, currency, razorpay_order_id, razorpay_payment_id, status) " +
+          "VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,'INR',?10,?11,'paid')"
+      )
+        .bind(
+          str(b.fullname), str(b.mobile), str(b.email), str(b.experience),
+          courseId, str(b.course_name), str(b.batch), str(b.referral),
+          amount || null, orderId, paymentId
+        )
+        .run();
+    }
+  } catch {
+    // The payment IS verified — never fail the student because our write hiccupped.
+    return json({ ok: true, recorded: false });
+  }
+  return json({ ok: true, recorded: true });
+}
+
+const str = (v) => String(v || "").trim().slice(0, 300);
+
+function json(body, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}

--- a/schema-enrollments.sql
+++ b/schema-enrollments.sql
@@ -1,0 +1,27 @@
+-- Enrolments, viewable at /admin/enrollments.
+-- Two kinds share this table:
+--   status='paid'       — a completed, signature-verified Razorpay payment (FDE).
+--   status='registered' — a free "register interest" for an unpriced course.
+CREATE TABLE IF NOT EXISTS enrollments (
+  id                INTEGER PRIMARY KEY AUTOINCREMENT,
+  fullname          TEXT NOT NULL,
+  mobile            TEXT NOT NULL,
+  email             TEXT,
+  experience        TEXT,
+  course            TEXT NOT NULL,      -- course id, e.g. 'fde'
+  course_name       TEXT,               -- human label at time of enrolment
+  batch             TEXT,               -- chosen batch (name + date), optional
+  referral          TEXT,               -- from ?ref= — also lands in Razorpay notes
+  amount            INTEGER,            -- paise, for paid enrolments
+  currency          TEXT NOT NULL DEFAULT 'INR',
+  razorpay_order_id TEXT,
+  razorpay_payment_id TEXT,
+  status            TEXT NOT NULL DEFAULT 'registered',  -- 'registered' | 'paid'
+  created_at        TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+-- One row per Razorpay order — makes payment recording idempotent (a retried
+-- verify can't create a second paid enrolment for the same order).
+CREATE UNIQUE INDEX IF NOT EXISTS idx_enrollments_order
+  ON enrollments (razorpay_order_id)
+  WHERE razorpay_order_id IS NOT NULL;

--- a/shared/enroll.js
+++ b/shared/enroll.js
@@ -1,0 +1,41 @@
+// Server-side source of truth for enrolment pricing + Razorpay signature
+// verification. The amount a student pays is decided HERE, never taken from the
+// browser — a price posted from the client is a price the client can change.
+
+// Course id -> price in paise. Only ids listed here can be paid online; every
+// other course routes to the (free) "register interest" path. Add a course +
+// price here to make it payable.
+export const COURSE_PRICES = {
+  fde: 5000000, // FDE — Forward Deployed Engineering — ₹50,000
+};
+
+export function priceForCourse(courseId) {
+  const p = COURSE_PRICES[String(courseId || "").trim()];
+  return typeof p === "number" && p > 0 ? p : null;
+}
+
+// Verify Razorpay's payment signature: HMAC-SHA256(`${order_id}|${payment_id}`)
+// keyed with the account secret, compared against razorpay_signature. Done with
+// Web Crypto so it runs in the Cloudflare Workers runtime.
+export async function verifyRazorpaySignature(orderId, paymentId, signature, secret) {
+  if (!orderId || !paymentId || !signature || !secret) return false;
+  const enc = new TextEncoder();
+  const key = await crypto.subtle.importKey(
+    "raw",
+    enc.encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"]
+  );
+  const mac = await crypto.subtle.sign("HMAC", key, enc.encode(`${orderId}|${paymentId}`));
+  const hex = [...new Uint8Array(mac)].map((b) => b.toString(16).padStart(2, "0")).join("");
+  return timingSafeEqualHex(hex, String(signature));
+}
+
+// Constant-time hex comparison — never leak how much of the signature matched.
+function timingSafeEqualHex(a, b) {
+  if (typeof a !== "string" || typeof b !== "string" || a.length !== b.length) return false;
+  let diff = 0;
+  for (let i = 0; i < a.length; i++) diff |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  return diff === 0;
+}

--- a/shared/enroll.test.js
+++ b/shared/enroll.test.js
@@ -1,0 +1,43 @@
+import { describe, it, expect } from "vitest";
+import { priceForCourse, verifyRazorpaySignature } from "./enroll.js";
+
+// Reproduce Razorpay's signature the same way the server verifies it, so we can
+// feed a genuinely-valid signature to the verifier in tests.
+async function sign(orderId, paymentId, secret) {
+  const enc = new TextEncoder();
+  const key = await crypto.subtle.importKey("raw", enc.encode(secret), { name: "HMAC", hash: "SHA-256" }, false, ["sign"]);
+  const mac = await crypto.subtle.sign("HMAC", key, enc.encode(`${orderId}|${paymentId}`));
+  return [...new Uint8Array(mac)].map((b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+describe("priceForCourse (server-side source of truth)", () => {
+  it("returns the FDE price in paise", () => {
+    expect(priceForCourse("fde")).toBe(5000000);
+  });
+  it("returns null for a course with no online price", () => {
+    expect(priceForCourse("java-fs")).toBeNull();
+    expect(priceForCourse("")).toBeNull();
+    expect(priceForCourse(undefined)).toBeNull();
+  });
+});
+
+describe("verifyRazorpaySignature", () => {
+  const secret = "test_secret_key";
+  it("accepts a correctly-signed payment", async () => {
+    const sig = await sign("order_abc", "pay_123", secret);
+    expect(await verifyRazorpaySignature("order_abc", "pay_123", sig, secret)).toBe(true);
+  });
+  it("rejects a tampered signature", async () => {
+    const sig = await sign("order_abc", "pay_123", secret);
+    expect(await verifyRazorpaySignature("order_abc", "pay_999", sig, secret)).toBe(false);
+    expect(await verifyRazorpaySignature("order_abc", "pay_123", sig.slice(0, -1) + "0", secret)).toBe(false);
+  });
+  it("rejects the wrong secret", async () => {
+    const sig = await sign("order_abc", "pay_123", secret);
+    expect(await verifyRazorpaySignature("order_abc", "pay_123", sig, "other_secret")).toBe(false);
+  });
+  it("rejects missing pieces", async () => {
+    expect(await verifyRazorpaySignature("", "pay", "sig", secret)).toBe(false);
+    expect(await verifyRazorpaySignature("order", "pay", "sig", "")).toBe(false);
+  });
+});

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,6 +5,7 @@ import Banner from './components/organism/Banner/Banner'
 import Home from "./components/Pages/Home";
 import Modal from 'react-modal';
 import EnquiryForm from './components/forms/Enquiry Form/EnquiryForm';
+import EnrollForm from './components/forms/EnrollForm/EnrollForm';
 import "./App.css"
 import FloatingIcons from './components/molecules/Floating Icons Components/FloatingIcons';
 import { ToastContainer, toast } from 'react-toastify';
@@ -13,7 +14,8 @@ import { ToastContainer, toast } from 'react-toastify';
 
 function App() {
   const [modalIsOpen, setIsOpen] = useState(false);
-  
+  const [enrollCourse, setEnrollCourse] = useState(null);
+
   let openModal=()=> {
     setIsOpen(true);
   }
@@ -21,6 +23,15 @@ function App() {
   let closeModal=()=> {
     setIsOpen(false);
   }
+
+  // Enrolment modal — opened per course (paid → checkout, else → register).
+  let openEnroll=(course)=> {
+    setEnrollCourse(course);
+  }
+  let closeEnroll=()=> {
+    setEnrollCourse(null);
+  }
+
   const notify = (message) => toast(message);
 
   const customStyles = {
@@ -41,7 +52,7 @@ function App() {
   
 
   return (
-    <AuthContext.Provider className="app" value={{ openModal, closeModal,notify }}>
+    <AuthContext.Provider className="app" value={{ openModal, closeModal, openEnroll, closeEnroll, notify }}>
       <Navbar />
       <ToastContainer className={"toast"} autoClose={2500}/>
       <Modal
@@ -49,9 +60,17 @@ function App() {
         onRequestClose={closeModal}
         className="modal-enquiry-form"
         style={customStyles}
-        
+
       >
         <EnquiryForm />
+      </Modal>
+      <Modal
+        isOpen={!!enrollCourse}
+        onRequestClose={closeEnroll}
+        className="modal-enquiry-form"
+        style={customStyles}
+      >
+        {enrollCourse && <EnrollForm course={enrollCourse} />}
       </Modal>
       <Home />
       <FloatingIcons/>

--- a/src/components/forms/EnrollForm/EnrollForm.css
+++ b/src/components/forms/EnrollForm/EnrollForm.css
@@ -1,0 +1,73 @@
+.enroll-form {
+  background: #fff;
+  border-radius: 0.6rem;
+  padding: 1.5rem;
+  width: 100%;
+  max-width: 460px;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.enroll-form .form-heading {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  border-bottom: 1px solid #e4e6ef;
+  padding-bottom: 0.75rem;
+}
+.enroll-form .form-heading p {
+  color: #5b6472;
+  margin: 0.2rem 0 0;
+  font-size: 0.85rem;
+}
+
+.enroll-price {
+  display: flex;
+  align-items: baseline;
+  gap: 0.75rem;
+  background: #f5f6fa;
+  border: 1px solid #e4e6ef;
+  border-radius: 0.5rem;
+  padding: 0.75rem 1rem;
+}
+.enroll-price .amt {
+  font-size: 1.6rem;
+  font-weight: 800;
+  color: #03084c;
+}
+.enroll-price .emi {
+  font-size: 0.82rem;
+  font-weight: 600;
+  color: #1b6b3a;
+  background: #e7f6ec;
+  padding: 0.15rem 0.5rem;
+  border-radius: 999px;
+}
+
+.enroll-fields {
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+}
+.enroll-fields .MuiTextField-root,
+.enroll-fields .MuiFormControl-root {
+  width: 100%;
+}
+
+.enroll-error {
+  background: #fdecea;
+  color: #b3261e;
+  border: 1px solid #f1b5ac;
+  border-radius: 0.4rem;
+  padding: 0.6rem 0.8rem;
+}
+
+.enroll-done {
+  text-align: center;
+  align-items: center;
+  gap: 1rem;
+}
+.enroll-done p {
+  color: #5b6472;
+}

--- a/src/components/forms/EnrollForm/EnrollForm.jsx
+++ b/src/components/forms/EnrollForm/EnrollForm.jsx
@@ -1,0 +1,238 @@
+import { Box, CircularProgress } from "@mui/material";
+import React, { useMemo, useState } from "react";
+import InputBoxComponent from "../../atoms/InputBoxComponent/InputBoxComponent";
+import DropdownComponent from "../../atoms/DropdownComponent/DropdownComponent";
+import TypoGraphyComponent from "../../atoms/TypoGraphyComponent/TypoGraphyComponent";
+import ButtonComponent from "../../atoms/ButtonComponent/ButtonComponent";
+import { useAuth } from "../../../App";
+import { regex } from "../../../regex/regex";
+import { useBatches } from "../../organism/Batches/useBatches";
+import { isBatchUpcoming, formatBatchDateShort } from "../../organism/Batches/batchDateUtils";
+import { getReferral, loadRazorpay, createOrder, verifyPayment, registerInterest } from "./enrollApi";
+import "./EnrollForm.css";
+
+const EXPERIENCE_OPTIONS = [
+  { label: "Working professional - Technical roles", id: 1 },
+  { label: "Working professional - Non technical", id: 2 },
+  { label: "College student - Final year", id: 3 },
+  { label: "College student - 1st to pre-final year", id: 4 },
+  { label: "Others", id: 5 },
+];
+
+function EnrollForm({ course }) {
+  const { closeEnroll, notify } = useAuth();
+  const batches = useBatches();
+  const paid = !!(course && course.paid);
+
+  const [data, setData] = useState({
+    fullname: "", mobile: "", email: "", experience: "", batch: "", referral: getReferral(),
+  });
+  const [errors, setErrors] = useState({});
+  const [busy, setBusy] = useState(false);
+  const [failed, setFailed] = useState("");
+  const [done, setDone] = useState(""); // "" | "paid" | "registered"
+
+  // Upcoming batches for this course, for the (optional) batch selector.
+  const batchOptions = useMemo(
+    () =>
+      (batches || [])
+        .filter((b) => b.name === course.name && isBatchUpcoming(b.date))
+        .map((b, i) => ({
+          id: i + 1,
+          label: `${b.day ? b.day + " · " : ""}${formatBatchDateShort(b.date)}${b.time ? " · " + b.time : ""}`,
+        })),
+    [batches, course]
+  );
+
+  const change = ({ target: { name, value } }) => setData((d) => ({ ...d, [name]: value }));
+  const changeExp = (v) => setData((d) => ({ ...d, experience: v.label }));
+  const changeBatch = (v) => setData((d) => ({ ...d, batch: v.label }));
+
+  function validate() {
+    const e = {};
+    if (!data.fullname) e.fullname = "Full Name is Required";
+    else if (data.fullname.length < 3) e.fullname = "Full Name should be more than 3 characters";
+    else if (!regex.nameRegex.test(data.fullname)) e.fullname = "Full Name Should Contain Only Alphabets";
+    if (!data.mobile) e.mobile = "Mobile is Required";
+    else if (!regex.mobileRegex.test(data.mobile)) e.mobile = "Invalid Mobile Number";
+    if (!data.email) e.email = "Email is Required";
+    else if (!regex.emailRegex.test(data.email)) e.email = "Invalid Email";
+    return e;
+  }
+
+  const payload = () => ({
+    course: course.courseId,
+    course_name: course.name,
+    fullname: data.fullname,
+    mobile: data.mobile,
+    email: data.email,
+    experience: data.experience,
+    batch: data.batch,
+    referral: data.referral,
+  });
+
+  async function handleSubmit(ev) {
+    ev.preventDefault();
+    if (busy) return;
+    const e = validate();
+    setErrors(e);
+    if (Object.keys(e).length) return;
+    setFailed("");
+    setBusy(true);
+    try {
+      if (paid) await payFlow();
+      else await registerFlow();
+    } catch {
+      setBusy(false);
+      setFailed("Something went wrong. Please try again, or message us on WhatsApp.");
+    }
+  }
+
+  async function registerFlow() {
+    const r = await registerInterest(payload());
+    setBusy(false);
+    if (r.ok) {
+      setDone("registered");
+      notify && notify("Seat registered — we'll be in touch!");
+    } else {
+      setFailed(r.body.error || "Could not register. Please try again.");
+    }
+  }
+
+  async function payFlow() {
+    const order = await createOrder(course.courseId, data.referral);
+    // Payments not enabled yet → save their interest so nothing is lost.
+    if (order.status === 503) {
+      const r = await registerInterest(payload());
+      setBusy(false);
+      if (r.ok) setDone("registered");
+      else setFailed("Enrolment is opening soon — please message us on WhatsApp to reserve your seat.");
+      return;
+    }
+    if (!order.ok || !order.body.orderId) {
+      setBusy(false);
+      setFailed(order.body.error || "Could not start payment. Please try again.");
+      return;
+    }
+    const loaded = await loadRazorpay();
+    if (!loaded || !window.Razorpay) {
+      setBusy(false);
+      setFailed("Could not load the payment window. Check your connection and try again.");
+      return;
+    }
+    const rzp = new window.Razorpay({
+      key: order.body.keyId,
+      order_id: order.body.orderId,
+      amount: order.body.amount,
+      currency: order.body.currency,
+      name: "Rest Coder Academy",
+      description: course.name,
+      image: "/favicon.png",
+      prefill: { name: data.fullname, email: data.email, contact: data.mobile },
+      notes: { course: course.courseId, referral: data.referral },
+      theme: { color: "#03084C" },
+      handler: async (resp) => {
+        const v = await verifyPayment({ ...resp, ...payload() });
+        setBusy(false);
+        if (v.ok && v.body.ok) {
+          setDone("paid");
+          notify && notify("Enrolment confirmed! 🎉");
+        } else {
+          setFailed(
+            "Your payment went through but we couldn't confirm it here. Keep your payment ID and message us — we'll sort it out."
+          );
+        }
+      },
+      modal: { ondismiss: () => setBusy(false) },
+    });
+    rzp.on("payment.failed", () => {
+      setBusy(false);
+      setFailed("Payment failed or was cancelled. You can try again.");
+    });
+    rzp.open();
+  }
+
+  if (done) {
+    const isPaid = done === "paid";
+    return (
+      <Box className="enroll-form enroll-done">
+        <TypoGraphyComponent component="h6" variant="h6" text={isPaid ? "You're enrolled 🎉" : "Seat registered ✅"} />
+        <TypoGraphyComponent
+          component="p"
+          variant="body2"
+          text={
+            isPaid
+              ? `Welcome to ${course.name}. A confirmation is on its way to ${data.email}.`
+              : "Thanks! We've saved your details and the team will reach out with the next steps and dates."
+          }
+        />
+        <ButtonComponent label="Done" onBtnClick={closeEnroll} />
+      </Box>
+    );
+  }
+
+  return (
+    <form className="enroll-form" onSubmit={handleSubmit}>
+      <Box className="form-heading">
+        <Box>
+          <TypoGraphyComponent component="h6" variant="h6" text={paid ? "Enroll Now" : "Register Interest"} />
+          <TypoGraphyComponent component="p" variant="body2" text={course.name} />
+        </Box>
+        <ButtonComponent paddingX={1} paddingY={1} onBtnClick={closeEnroll}>
+          ×
+        </ButtonComponent>
+      </Box>
+
+      {paid && (
+        <Box className="enroll-price">
+          <span className="amt">₹{Number(course.price).toLocaleString("en-IN")}</span>
+          <span className="emi">EMI available at checkout</span>
+        </Box>
+      )}
+
+      <Box className="enroll-fields">
+        <InputBoxComponent value={data.fullname} label="Full Name" variant="outlined" onChange={change} name="fullname" error={!!errors.fullname} helperText={errors.fullname} />
+        <InputBoxComponent value={data.mobile} label="Mobile" variant="outlined" onChange={change} name="mobile" error={!!errors.mobile} helperText={errors.mobile} />
+        <InputBoxComponent value={data.email} label="Email" variant="outlined" onChange={change} name="email" error={!!errors.email} helperText={errors.email} />
+        <DropdownComponent label="Experience" options={EXPERIENCE_OPTIONS} name="experience" onChange={changeExp} value={EXPERIENCE_OPTIONS} />
+        {batchOptions.length > 0 && (
+          <DropdownComponent label="Preferred batch" options={batchOptions} name="batch" onChange={changeBatch} value={batchOptions} />
+        )}
+
+        <Box className="enroll-referral">
+          <InputBoxComponent
+            value={data.referral}
+            label="Referral code (optional)"
+            variant="outlined"
+            onChange={change}
+            name="referral"
+          />
+        </Box>
+
+        {failed && (
+          <Box className="enroll-error" role="alert">
+            <TypoGraphyComponent component="p" variant="body2" text={failed} />
+          </Box>
+        )}
+
+        <ButtonComponent
+          type="submit"
+          fullWidth
+          disabled={busy}
+          label={busy ? "" : paid ? `Pay ₹${Number(course.price).toLocaleString("en-IN")}` : "Register my seat"}
+        >
+          {busy && <CircularProgress size={20} sx={{ color: "#fff" }} />}
+        </ButtonComponent>
+        {paid && (
+          <TypoGraphyComponent
+            component="p"
+            variant="caption"
+            text="Secure payment via Razorpay. Pay in full or choose EMI on the next screen."
+          />
+        )}
+      </Box>
+    </form>
+  );
+}
+
+export default EnrollForm;

--- a/src/components/forms/EnrollForm/enrollApi.js
+++ b/src/components/forms/EnrollForm/enrollApi.js
@@ -1,0 +1,58 @@
+// Client helpers for the enrolment flow. All money logic lives on the server
+// (functions/api/enroll/*); these just move data to/from it and load Razorpay
+// Checkout. The amount is never sent from here — the server decides it.
+
+const REF_KEY = "rca_ref";
+
+// Capture ?ref= once and remember it while the visitor browses, so a referral
+// isn't lost if they don't enrol on the first page they land on.
+export function getReferral() {
+  try {
+    const url = new URL(window.location.href);
+    const ref = url.searchParams.get("ref");
+    if (ref) localStorage.setItem(REF_KEY, ref.slice(0, 120));
+    return localStorage.getItem(REF_KEY) || "";
+  } catch {
+    return "";
+  }
+}
+
+// Inject Razorpay Checkout once, on demand (not on every page load).
+let razorpayPromise = null;
+export function loadRazorpay() {
+  if (typeof window !== "undefined" && window.Razorpay) return Promise.resolve(true);
+  if (razorpayPromise) return razorpayPromise;
+  razorpayPromise = new Promise((resolve) => {
+    const s = document.createElement("script");
+    s.src = "https://checkout.razorpay.com/v1/checkout.js";
+    s.onload = () => resolve(true);
+    s.onerror = () => resolve(false);
+    document.body.appendChild(s);
+  });
+  return razorpayPromise;
+}
+
+async function postJson(url, data) {
+  const res = await fetch(url, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(data),
+  });
+  let body = {};
+  try {
+    body = (await res.json()) || {};
+  } catch {
+    /* non-JSON response */
+  }
+  return { ok: res.ok, status: res.status, body };
+}
+
+export function createOrder(courseId, referral) {
+  return postJson("/api/enroll/order", { course: courseId, referral });
+}
+export function verifyPayment(payload) {
+  return postJson("/api/enroll/verify", payload);
+}
+export function registerInterest(data) {
+  return postJson("/api/enroll/register", data);
+}

--- a/src/components/organism/Batches/BatchesCard.jsx
+++ b/src/components/organism/Batches/BatchesCard.jsx
@@ -18,11 +18,19 @@ import PersonIcon from '@mui/icons-material/Person';
 import CallIcon from '@mui/icons-material/Call';
 import AlarmOnIcon from '@mui/icons-material/AlarmOn';
 import { useAuth } from '../../../App';
+import { courses } from '../courses/courses';
 
 
  function BatchesCard({name,date,day,time,trainer,duration,mode,contact}) {
-    let {openModal}=useAuth()
+    let {openModal,openEnroll}=useAuth()
     let upcoming=isBatchUpcoming(date)
+    // Funnel an upcoming batch straight into its course's enrolment flow.
+    let course=courses.find((c)=>c.name===name)
+    let canEnroll=upcoming && !!course
+    let onCta=canEnroll
+      ? ()=>openEnroll({courseId:course.courseId,name:course.name,paid:course.paid,price:course.price})
+      : openModal
+    let ctaLabel=canEnroll ? "Enroll Now" : (upcoming ? "Enquire Now" : "Join the Waitlist")
   return (
     <Card sx={{}} className="card">
       <Box className="course-header">
@@ -56,11 +64,11 @@ import { useAuth } from '../../../App';
       <CardActions sx={{}} className="card-actions">
         <ButtonComponent
           size="large"
-          variant="outlined"
-          label={upcoming ? "Enquire Now" : "Join the Waitlist"}
+          variant={canEnroll && course.paid ? "contained" : "outlined"}
+          label={ctaLabel}
           borderRadius="0"
           sx={{}}
-          onBtnClick={openModal}
+          onBtnClick={onCta}
         />
       </CardActions>
     </Card>

--- a/src/components/organism/courses/Courses.css
+++ b/src/components/organism/courses/Courses.css
@@ -166,3 +166,27 @@
 
            
         }
+/* FDE / paid-course accents on the course card */
+.courses .course-badge {
+  display: inline-block;
+  background: #ff9800;
+  color: #fff;
+  font-size: 0.72rem;
+  font-weight: 700;
+  padding: 0.15rem 0.55rem;
+  border-radius: 999px;
+  margin-bottom: 0.5rem;
+  letter-spacing: 0.02em;
+}
+.courses .course-price {
+  display: inline-block;
+  margin-top: 0.5rem;
+  font-size: 1.15rem;
+  font-weight: 800;
+  color: #03084c;
+}
+.courses .course-price .course-emi {
+  font-size: 0.78rem;
+  font-weight: 600;
+  color: #1b6b3a;
+}

--- a/src/components/organism/courses/CoursesCard.jsx
+++ b/src/components/organism/courses/CoursesCard.jsx
@@ -13,13 +13,15 @@ import { useBatches } from '../Batches/useBatches';
 import { getNextBatchForCourse, formatBatchDateShort } from '../Batches/batchDateUtils';
 
 
- function CoursesCard({name,backend,audience,frontend,syllabus1,syllabus2}) {
-    let {openModal}=useAuth()
+ function CoursesCard({name,courseId,paid,price,badge,backend,audience,frontend,syllabus1,syllabus2}) {
+    let {openEnroll}=useAuth()
     let batches=useBatches()
     let nextBatch=getNextBatchForCourse(name,batches)
+    let enroll=()=>openEnroll({courseId,name,paid,price})
   return (
     <Card sx={{ }} className='card'>
         <Box className="course-header">
+            {badge && <Box component="span" className="course-badge">{badge}</Box>}
             <TypoGraphyComponent
             variant="h5"
             sx={{mb:".3rem"}}
@@ -29,6 +31,11 @@ import { getNextBatchForCourse, formatBatchDateShort } from '../Batches/batchDat
         <Box component="span" className="next-batch-tag">
             {nextBatch ? `Next batch · ${formatBatchDateShort(nextBatch.date)}` : "New dates coming soon"}
         </Box>
+        {paid && (
+          <Box component="span" className="course-price">
+            ₹{Number(price).toLocaleString("en-IN")} <span className="course-emi">· EMI available</span>
+          </Box>
+        )}
          <TypoGraphyComponent
             variant="text"
             sx={{}}
@@ -105,7 +112,7 @@ import { getNextBatchForCourse, formatBatchDateShort } from '../Batches/batchDat
 </CardContent>
 <CardActions sx={{}} className='card-actions'>
   
-  <ButtonComponent size='large' variant='outlined' label='Enquire Now'  borderRadius='0' sx={{}} onBtnClick={openModal}/>
+  <ButtonComponent size='large' variant={paid?'contained':'outlined'} label='Enroll Now'  borderRadius='0' sx={{}} onBtnClick={enroll}/>
 </CardActions>
 </Card>
   );

--- a/src/components/organism/courses/courses.js
+++ b/src/components/organism/courses/courses.js
@@ -1,46 +1,57 @@
-export let courses=[
-    {
-        id:"1",
-        name:"Java Full Stack",
-        audience:"For Freshers & Working Professionals",
-        backend:["Core Java","Advance Java","Springs","Hibernate","Microservices","Rest Api"],
-        frontend:["HTML","CSS","Javascript","Tailwind CSS","","",""]
-    },
-    {
-        id:"2",
-        name:"Python Full Stack",
-        audience:"For Freshers & Working Professionals",
-        backend:["Python","Advance Python","Django","Microservices","Rest Api"],
-        frontend:["HTML","CSS","Javascript","Tailwind CSS","","",""]
-    },
-    {
-        id:"3",
-        name:"MERN Stack",
-        audience:"For Freshers & Working Professionals",
-        backend:["MongoDB","ExpressJs","NodeJs","Microservices","Rest Api"],
-        frontend:["HTML","CSS","Javascript","Typescript","Tailwind CSS","Reactjs","Nextjs"]
-    },
-    // {
-    //     id:"4",
-    //     name:"Devops",
-    //     audience:"For Freshers and Working Professionals",
-    //     // backend:["Core Java","Advance Java","Springs","Hybernate","Microservices","Rest Api's"],
-    //     // frontend:["HTML","CSS","Javascript","Tailwind CSS","Microservices","Rest Api's"],
-    //     syllabus1:["SDLC","Waterfall Model","Agile Methodology","DevOps Overview","AWS","GIT","Linux OS",],
-    //     syllabus2:["Shell Scripting","Maven","Jenkins","Docker","Kubernetes","Projects"]
-    // },
-    // {
-    //     id:"5",
-    //     name:"Artificial Intelligence",
-    //     audience:"For Freshers and Working Professionals",
-    //     backend:["Core Java","Advance Java","Springs","Hybernate","Microservices","Rest Api's"],
-    //     frontend:["HTML","CSS","Javascript","Tailwind CSS","Microservices","Rest Api's","",]
-    // },
-    // {
-    //     id:"6",
-    //     name:"Machine Learning",
-    //     audience:"For Freshers and Working Professionals",
-    //     backend:["Core Java","Advance Java","Springs","Hybernate","Microservices","Rest Api's"],
-    //     frontend:["HTML","CSS","Javascript","Tailwind CSS","Microservices","Rest Api's",""]
-    // }
-]
+// `courseId` is the stable slug the enrolment endpoints key on (must match the
+// server price map in shared/enroll.js for paid courses). `paid: true` routes
+// "Enroll Now" through Razorpay checkout; otherwise it opens the free
+// "register interest" form. For the "Next batch" tag to show, a batch added in
+// /admin/batches must use the EXACT same `name`.
+export let courses = [
+  {
+    id: "0",
+    courseId: "fde",
+    name: "Forward Deployed Engineering",
+    badge: "FDE · New",
+    audience:
+      "Become an engineer who ships in production — the program a former Head of Engineering used to train his own team.",
+    paid: true,
+    price: 50000,
+    trainer: "Nikshep Kulli",
+    syllabus1: [
+      "Engineer's foundations — Git, PRs, code review",
+      "Full-stack build — React/Next.js, APIs, Postgres",
+      "Ship it — AWS/Cloudflare, staging vs prod, IaC",
+      "CI/CD & testing — pipelines, gated deploys",
+    ],
+    syllabus2: [
+      "Real integrations — payments, webhooks, APIs",
+      "AI-assisted engineering",
+      "Production ownership — monitoring, data integrity",
+      "Capstone — build & deploy a real product",
+    ],
+  },
+  {
+    id: "1",
+    courseId: "java-fs",
+    name: "Java Full Stack",
+    audience: "For Freshers & Working Professionals",
+    paid: false,
+    backend: ["Core Java", "Advance Java", "Springs", "Hibernate", "Microservices", "Rest Api"],
+    frontend: ["HTML", "CSS", "Javascript", "Tailwind CSS", "", "", ""],
+  },
+  {
+    id: "2",
+    courseId: "python-fs",
+    name: "Python Full Stack",
+    audience: "For Freshers & Working Professionals",
+    paid: false,
+    backend: ["Python", "Advance Python", "Django", "Microservices", "Rest Api"],
+    frontend: ["HTML", "CSS", "Javascript", "Tailwind CSS", "", "", ""],
+  },
+  {
+    id: "3",
+    courseId: "mern",
+    name: "MERN Stack",
+    audience: "For Freshers & Working Professionals",
+    paid: false,
+    backend: ["MongoDB", "ExpressJs", "NodeJs", "Microservices", "Rest Api"],
+    frontend: ["HTML", "CSS", "Javascript", "Typescript", "Tailwind CSS", "Reactjs", "Nextjs"],
+  },
+];

--- a/tests/functions.integration.test.js
+++ b/tests/functions.integration.test.js
@@ -5,6 +5,9 @@ import { onRequestGet as adminGet } from "../functions/admin.js";
 import { onRequestPost as batchAdminPost } from "../functions/admin/batches.js";
 import { onRequestGet as trainersGet } from "../functions/api/trainers.js";
 import { onRequestPost as trainerAdminPost } from "../functions/admin/trainers.js";
+import { onRequestPost as enrollOrder } from "../functions/api/enroll/order.js";
+import { onRequestPost as enrollVerify } from "../functions/api/enroll/verify.js";
+import { onRequestPost as enrollRegister } from "../functions/api/enroll/register.js";
 
 // Fake D1 — mocks only the DB boundary (prepare/bind/run/all), so tests exercise
 // the real handler logic without a live database and without flake.
@@ -13,8 +16,9 @@ function makeDB(seed = {}) {
     enquiries: [...(seed.enquiries || [])],
     batches: [...(seed.batches || [])],
     trainers: [...(seed.trainers || [])],
+    enrollments: [...(seed.enrollments || [])],
   };
-  let ids = { enquiries: 1000, batches: 1000, trainers: 2000 };
+  let ids = { enquiries: 1000, batches: 1000, trainers: 2000, enrollments: 3000 };
   return {
     tables: t,
     prepare(sql) {
@@ -48,6 +52,19 @@ function makeDB(seed = {}) {
               });
           } else if (/DELETE FROM trainers/i.test(sql)) {
             t.trainers = t.trainers.filter((b) => String(b.id) !== String(args[0]));
+          } else if (/INSERT INTO enrollments/i.test(sql)) {
+            if (/'paid'/.test(sql)) {
+              t.enrollments.push({
+                id: ++ids.enrollments, fullname: args[0], mobile: args[1], email: args[2], experience: args[3],
+                course: args[4], course_name: args[5], batch: args[6], referral: args[7], amount: args[8],
+                razorpay_order_id: args[9], razorpay_payment_id: args[10], status: "paid",
+              });
+            } else {
+              t.enrollments.push({
+                id: ++ids.enrollments, fullname: args[0], mobile: args[1], email: args[2], experience: args[3],
+                course: args[4], course_name: args[5], batch: args[6], referral: args[7], status: "registered",
+              });
+            }
           }
           return { success: true };
         },
@@ -62,8 +79,18 @@ function makeDB(seed = {}) {
             if (/status\s*=\s*'active'/i.test(sql)) rows = rows.filter((b) => (b.status || "active") === "active");
             return { results: rows };
           }
+          if (/FROM enrollments/i.test(sql)) return { results: t.enrollments };
           if (/FROM enquiries/i.test(sql)) return { results: t.enquiries };
           return { results: [] };
+        },
+        async first() {
+          // The only .first() query is the idempotency lookup in verify.js:
+          // SELECT id FROM enrollments WHERE razorpay_order_id = ?1
+          if (/FROM enrollments/i.test(sql) && /razorpay_order_id\s*=/i.test(sql)) {
+            return t.enrollments.find((e) => e.razorpay_order_id === args[0]) || null;
+          }
+          const r = await stmt.all();
+          return (r.results && r.results[0]) || null;
         },
       };
       return stmt;
@@ -74,6 +101,14 @@ const ctx = (request, env) => ({ request, env });
 const authH = (u = "admin", p = "secret") => ({ Authorization: "Basic " + btoa(`${u}:${p}`) });
 const jsonReq = (body) =>
   new Request("https://x/api/enquiry", { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify(body) });
+const jsonReqTo = (url, body) =>
+  new Request(url, { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify(body) });
+async function rzpSign(orderId, paymentId, secret) {
+  const enc = new TextEncoder();
+  const key = await crypto.subtle.importKey("raw", enc.encode(secret), { name: "HMAC", hash: "SHA-256" }, false, ["sign"]);
+  const mac = await crypto.subtle.sign("HMAC", key, enc.encode(`${orderId}|${paymentId}`));
+  return [...new Uint8Array(mac)].map((b) => b.toString(16).padStart(2, "0")).join("");
+}
 const formReq = (url, obj) =>
   new Request(url, { method: "POST", headers: { ...authH(), "content-type": "application/x-www-form-urlencoded" }, body: new URLSearchParams(obj).toString() });
 
@@ -239,5 +274,62 @@ describe("POST /admin/trainers (CRUD)", () => {
     const res = await trainerAdminPost(ctx(formReq("https://x/admin/trainers", { action: "delete", id: "7" }), env(db)));
     expect(res.status).toBe(303);
     expect(db.tables.trainers).toHaveLength(0);
+  });
+});
+
+describe("POST /api/enroll/order", () => {
+  it("503 when Razorpay keys are not configured (inert until keys)", async () => {
+    const res = await enrollOrder(ctx(jsonReqTo("https://x/api/enroll/order", { course: "fde" }), { DB: makeDB() }));
+    expect(res.status).toBe(503);
+  });
+  it("400 for a course that has no online price, even with keys", async () => {
+    const env = { DB: makeDB(), RAZORPAY_KEY_ID: "k", RAZORPAY_KEY_SECRET: "s" };
+    const res = await enrollOrder(ctx(jsonReqTo("https://x/api/enroll/order", { course: "java-fs" }), env));
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("POST /api/enroll/register (free interest)", () => {
+  it("records a registration (201)", async () => {
+    const db = makeDB();
+    const res = await enrollRegister(
+      ctx(jsonReqTo("https://x/api/enroll/register", { fullname: "Asha", mobile: "9000000000", course: "java-fs", course_name: "Java Full Stack" }), { DB: db })
+    );
+    expect(res.status).toBe(201);
+    expect(db.tables.enrollments).toHaveLength(1);
+    expect(db.tables.enrollments[0].status).toBe("registered");
+  });
+  it("400 without name/mobile", async () => {
+    const res = await enrollRegister(ctx(jsonReqTo("https://x/api/enroll/register", { fullname: "" }), { DB: makeDB() }));
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("POST /api/enroll/verify", () => {
+  const env = (db) => ({ DB: db, RAZORPAY_KEY_SECRET: "sekret" });
+  it("400 on an invalid signature — no row written", async () => {
+    const db = makeDB();
+    const res = await enrollVerify(
+      ctx(jsonReqTo("https://x/api/enroll/verify", { razorpay_order_id: "o1", razorpay_payment_id: "p1", razorpay_signature: "bad", course: "fde" }), env(db))
+    );
+    expect(res.status).toBe(400);
+    expect(db.tables.enrollments).toHaveLength(0);
+  });
+  it("records a verified paid enrolment, idempotently (no duplicate on retry)", async () => {
+    const db = makeDB();
+    const sig = await rzpSign("o1", "p1", "sekret");
+    const body = {
+      razorpay_order_id: "o1", razorpay_payment_id: "p1", razorpay_signature: sig,
+      course: "fde", course_name: "Forward Deployed Engineering", fullname: "Asha", mobile: "9", email: "a@b.c",
+    };
+    const r1 = await enrollVerify(ctx(jsonReqTo("https://x/api/enroll/verify", body), env(db)));
+    expect(r1.status).toBe(200);
+    expect(db.tables.enrollments).toHaveLength(1);
+    expect(db.tables.enrollments[0].status).toBe("paid");
+    expect(db.tables.enrollments[0].amount).toBe(5000000); // server-decided, not from the body
+
+    const r2 = await enrollVerify(ctx(jsonReqTo("https://x/api/enroll/verify", body), env(db)));
+    expect(r2.status).toBe(200);
+    expect(db.tables.enrollments).toHaveLength(1); // still one — idempotent
   });
 });


### PR DESCRIPTION
## What & why

Introduces **FDE (Forward Deployed Engineering)** — ₹50,000, taught by the founder — and shifts the site from enquiry-first to **enrolment-first**, built to your design PR #1.

- New flagship **FDE** course card (priced, badged, 8-module syllabus).
- Every course CTA: **Enquire Now → Enroll Now**. Batch cards funnel into their course's enrolment too.
- **FDE → Razorpay checkout with EMI** (bank-EMI — student's bank splits it, you receive ₹50k upfront). Other courses → free **register interest**.
- **/admin/enrollments** to see paid + registered enrolments.

## Money rules (enforced in code, per design #1)
- Amount is **server-decided** (`shared/enroll.js` → `COURSE_PRICES`), never from the browser.
- Razorpay **signature verified server-side**; recording is **idempotent** (one row per order id).
- Referral (`?ref=`) rides into the Razorpay `notes` + the row.
- **Inert until keys**: with no `RAZORPAY_KEY_ID`/`RAZORPAY_KEY_SECRET`, `/api/enroll/order` returns 503 and the form falls back to recording interest — nothing breaks.

## To activate (you — the app never sees the keys)
1. Set Pages secrets `RAZORPAY_KEY_ID` + `RAZORPAY_KEY_SECRET` (test first, then live).
2. Enable **EMI** on the Razorpay account.
3. Create the `enrollments` table: `wrangler d1 execute restcoder-enquiries --remote --file=schema-enrollments.sql`.
4. Add the **FDE batch** in `/admin/batches` (name must be exactly `Forward Deployed Engineering`).

## Tests
- `shared/enroll` — pricing + Razorpay signature verify.
- integration — order 503 (inert), register 201/400, verify valid/invalid + **idempotent**.
- e2e — enroll modal opens with "Pay ₹50,000"; `/api/enroll/order` inert 503.
- Local: build ✅, 61 unit/integration ✅, 6 e2e ✅.

## 🔗 Issue
Closes #39
