### PR TITLE
feat(courses): premium flagship card for the FDE course

### DIFF
--- a/src/components/organism/courses/CoursesCard.jsx
+++ b/src/components/organism/courses/CoursesCard.jsx
@@ -11,9 +11,12 @@ import { List, ListItem, ListItemText } from '@mui/material';
 import { useAuth } from '../../../App';
 import { useBatches } from '../Batches/useBatches';
 import { getNextBatchForCourse, formatBatchDateShort } from '../Batches/batchDateUtils';
+import FdeCard from './FdeCard';
 
 
- function CoursesCard({name,courseId,paid,price,badge,backend,audience,frontend,syllabus1,syllabus2}) {
+ function CoursesCard({name,courseId,paid,price,badge,trainer,backend,audience,frontend,syllabus1,syllabus2}) {
+    // The paid/flagship course (FDE) gets its own premium card.
+    if (paid) return <FdeCard courseId={courseId} name={name} price={price} trainer={trainer} syllabus1={syllabus1} syllabus2={syllabus2} />;
     let {openEnroll}=useAuth()
     let batches=useBatches()
     let nextBatch=getNextBatchForCourse(name,batches)

--- a/src/components/organism/courses/FdeCard.css
+++ b/src/components/organism/courses/FdeCard.css
@@ -1,0 +1,208 @@
+/* FDE flagship card (Option A — bold navy header). Uses the RCA tokens. */
+.fde-card {
+  width: 100%;
+  max-width: 384px;
+  background: var(--rca-surface, #ffffff);
+  border: 1px solid #e6e9f2;
+  border-radius: var(--rca-radius-lg, 12px);
+  overflow: hidden;
+  box-shadow: 0 14px 36px rgba(3, 8, 76, 0.16);
+  font-family: var(--rca-font, "Montserrat", "Segoe UI", system-ui, sans-serif);
+  text-align: left;
+}
+.fde-card *,
+.fde-card *::before,
+.fde-card *::after {
+  box-sizing: border-box;
+}
+
+/* --- Navy header --- */
+.fde-head {
+  background: var(--rca-navy, #03084c);
+  padding: 22px 24px 20px;
+}
+.fde-flagship {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  background: rgba(255, 152, 0, 0.16);
+  color: #ffb74d;
+  font-size: 10.5px;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  padding: 5px 11px;
+  border-radius: var(--rca-radius-pill, 999px);
+}
+.fde-title {
+  margin: 14px 0 0;
+  color: #ffffff;
+  font-size: 23px;
+  font-weight: 700;
+  line-height: 1.22;
+}
+.fde-sub {
+  margin: 9px 0 0;
+  color: #aeb6e0;
+  font-size: 13.5px;
+  line-height: 1.5;
+}
+.fde-trainer {
+  display: flex;
+  align-items: center;
+  gap: 11px;
+  margin-top: 17px;
+  padding-top: 15px;
+  border-top: 1px solid rgba(255, 255, 255, 0.13);
+}
+.fde-avatar {
+  width: 36px;
+  height: 36px;
+  flex-shrink: 0;
+  border-radius: var(--rca-radius-pill, 999px);
+  background: var(--rca-blue, #146389);
+  color: #fff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 13px;
+  font-weight: 700;
+}
+.fde-trainer-text {
+  display: flex;
+  flex-direction: column;
+  line-height: 1.35;
+}
+.fde-trainer-text b {
+  color: #ffffff;
+  font-size: 13px;
+  font-weight: 600;
+}
+.fde-trainer-text span {
+  color: #8e96c8;
+  font-size: 11.5px;
+}
+
+/* --- Body --- */
+.fde-body {
+  padding: 20px 24px 24px;
+}
+.fde-price-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+.fde-price {
+  font-size: 31px;
+  font-weight: 800;
+  color: var(--rca-navy, #03084c);
+  letter-spacing: -0.6px;
+}
+.fde-price em {
+  font-size: 12px;
+  font-weight: 400;
+  font-style: normal;
+  color: #45545d;
+  margin-left: 3px;
+}
+.fde-emi {
+  background: var(--rca-success-bg, #edf7ed);
+  color: var(--rca-success, #2e7d32);
+  font-size: 11px;
+  font-weight: 700;
+  padding: 6px 11px;
+  border-radius: var(--rca-radius-pill, 999px);
+  white-space: nowrap;
+}
+.fde-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 7px;
+  margin-top: 14px;
+}
+.fde-chips span {
+  background: #f0f3f8;
+  color: #33415c;
+  font-size: 11.5px;
+  font-weight: 600;
+  padding: 5px 10px;
+  border-radius: var(--rca-radius-pill, 999px);
+}
+
+.fde-syllabus {
+  margin-top: 20px;
+}
+.fde-syllabus-label {
+  font-size: 10.5px;
+  font-weight: 700;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+  color: var(--rca-blue, #146389);
+  margin-bottom: 12px;
+}
+.fde-syllabus ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 9px;
+}
+.fde-syllabus li {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+}
+.fde-syllabus li span {
+  font-size: 13px;
+  color: #333333;
+  line-height: 1.4;
+}
+.fde-syllabus li.fde-capstone span {
+  color: var(--rca-navy, #03084c);
+  font-weight: 600;
+}
+.fde-check {
+  flex-shrink: 0;
+  margin-top: 1px;
+}
+
+.fde-nextbatch {
+  margin-top: 16px;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--rca-blue, #146389);
+}
+
+.fde-enroll {
+  margin-top: 20px;
+  width: 100%;
+  background: var(--rca-navy, #03084c);
+  color: #ffffff;
+  border: none;
+  border-radius: var(--rca-radius-md, 8px);
+  padding: 15px;
+  font-size: 15px;
+  font-weight: 700;
+  font-family: inherit;
+  cursor: pointer;
+  transition: background 0.15s ease;
+}
+.fde-enroll:hover {
+  background: var(--rca-navy-hover, #0a1270);
+}
+.fde-enroll:active {
+  background: var(--rca-navy-pressed, #01062f);
+}
+.fde-secure {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  margin-top: 11px;
+}
+.fde-secure span {
+  font-size: 11.5px;
+  color: #45545d;
+}

--- a/src/components/organism/courses/FdeCard.jsx
+++ b/src/components/organism/courses/FdeCard.jsx
@@ -1,0 +1,104 @@
+import React from "react";
+import { useAuth } from "../../../App";
+import { useBatches } from "../Batches/useBatches";
+import { getNextBatchForCourse, formatBatchDateShort } from "../Batches/batchDateUtils";
+import "./FdeCard.css";
+
+// Credibility line under the trainer name (specific to the FDE flagship).
+const TRAINER_TITLE = "ex-Head of Engineering, Organic Mandya";
+
+function initials(name = "") {
+  return name
+    .split(/\s+/)
+    .filter(Boolean)
+    .slice(0, 2)
+    .map((w) => w[0])
+    .join("")
+    .toUpperCase();
+}
+
+function Check({ filled }) {
+  return (
+    <svg width="17" height="17" viewBox="0 0 24 24" fill="none" className="fde-check" aria-hidden="true">
+      <circle cx="12" cy="12" r="11" fill={filled ? "#03084C" : "#EAF0F6"} />
+      <path d="M7.5 12.3l3 3 6-6.3" stroke={filled ? "#FFFFFF" : "#03084C"} strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  );
+}
+
+// Premium flagship course card (the paid FDE course). Distinct from the plain
+// CoursesCard template so it visibly outranks the free courses.
+function FdeCard({ courseId, name, price, trainer, syllabus1 = [], syllabus2 = [] }) {
+  const { openEnroll } = useAuth();
+  const batches = useBatches();
+  const nextBatch = getNextBatchForCourse(name, batches);
+  const modules = [...syllabus1, ...syllabus2].filter(Boolean);
+  const enroll = () => openEnroll({ courseId, name, paid: true, price });
+
+  return (
+    <div className="fde-card">
+      {/* Navy header band */}
+      <div className="fde-head">
+        <span className="fde-flagship">
+          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+            <path d="M12 2.5l2.85 6.05 6.65.7-4.95 4.5 1.35 6.55L12 17.6 6.1 20.8l1.35-6.55L2.5 9.25l6.65-.7L12 2.5z" fill="#FFB74D" />
+          </svg>
+          Flagship
+        </span>
+        <h3 className="fde-title">{name}</h3>
+        <p className="fde-sub">The program that turns juniors into engineers who ship to production.</p>
+        <div className="fde-trainer">
+          <span className="fde-avatar">{initials(trainer)}</span>
+          <span className="fde-trainer-text">
+            <b>Taught by {trainer}</b>
+            <span>{TRAINER_TITLE}</span>
+          </span>
+        </div>
+      </div>
+
+      {/* Body */}
+      <div className="fde-body">
+        <div className="fde-price-row">
+          <span className="fde-price">
+            ₹{Number(price).toLocaleString("en-IN")} <em>one-time</em>
+          </span>
+          <span className="fde-emi">EMI available</span>
+        </div>
+
+        <div className="fde-chips">
+          <span>Project-based</span>
+          <span>Live cohort</span>
+          <span>Ship to production</span>
+        </div>
+
+        <div className="fde-syllabus">
+          <div className="fde-syllabus-label">What you'll master</div>
+          <ul>
+            {modules.map((m, i) => (
+              <li key={i} className={i === modules.length - 1 ? "fde-capstone" : ""}>
+                <Check filled={i === modules.length - 1} />
+                <span>{m}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+
+        {nextBatch && (
+          <div className="fde-nextbatch">Next batch · {formatBatchDateShort(nextBatch.date)}</div>
+        )}
+
+        <button className="fde-enroll" type="button" onClick={enroll}>
+          Enroll Now
+        </button>
+        <div className="fde-secure">
+          <svg width="13" height="13" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+            <path d="M6 10V8a6 6 0 1112 0v2m-9 0h6a3 3 0 013 3v4a3 3 0 01-3 3H9a3 3 0 01-3-3v-4a3 3 0 013-3z" stroke="#45545D" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" />
+          </svg>
+          <span>Secure Razorpay checkout · pay in full or EMI</span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default FdeCard;


### PR DESCRIPTION
Redesigns the FDE course card as a premium flagship (Option A — bold navy header), distinct from the plain free-course template it reused.

- Navy header: orange "Flagship" pill, title, one-line promise, trainer credibility (Nikshep Kulli — ex-Head of Engineering, Organic Mandya).
- ₹50,000 + "EMI available" pill, Project-based / Live cohort / Ship-to-production chips.
- 8-module syllabus with check icons (Capstone emphasized), filled navy "Enroll Now" CTA + Razorpay microcopy.
- Built on the merged design tokens (#14/#52); free courses keep the plain template.

Verified against a local build — matches the approved design and clearly outranks the plain cards. 61 tests + build green locally.

Closes #54