### PR TITLE
fix(courses): even out card heights (FDE no longer an odd duck)

### DIFF
--- a/src/components/organism/courses/Courses.css
+++ b/src/components/organism/courses/Courses.css
@@ -22,7 +22,7 @@
     /* border: 2px solid green; */
     margin: 0;
     justify-content: center;
-    align-items: center;
+    align-items: stretch;
     padding: .7rem;
 
 }
@@ -33,15 +33,19 @@
 .courses .MuiGrid-container .MuiGrid-item .card
 {
     width: 100%!important;
+    height: 100%;
+    display: flex;
+    flex-direction: column;
     /* border: purple 2px solid; */
     box-shadow: 1px 1px 10px 1px var(--rca-navy);
- 
+
 }
 
 .courses .card-content
 {
     padding: 1rem 3rem;
     display: flex;
+    flex: 1 1 auto;
     /* flex-direction: row-reverse; */
     justify-content: space-between;
     /* border: 2px solid red; */
@@ -76,9 +80,10 @@
     border-top: .5px solid var(--rca-border);
     display: flex;
     justify-content: center;
+    margin-top: auto;
     padding-bottom: .8rem;
     padding-top: .8rem;
-    
+
 }
 
 .courses .card-actions button

--- a/src/components/organism/courses/CoursesGrid.jsx
+++ b/src/components/organism/courses/CoursesGrid.jsx
@@ -9,7 +9,7 @@ function CoursesGrid({xs=12,sm=6,md=6,lg=3, spacing=1,children="",mapdata=[],bgc
         {mapdata.map((data,id)=>
         {
             return <Fragment key={id}>
-                <Grid item display={"flex"} justifyContent={"center"} alignItems={"center"}  xs={xs} sm={sm} md={md} lg={lg}>
+                <Grid item display={"flex"} justifyContent={"center"} alignItems={"stretch"}  xs={xs} sm={sm} md={md} lg={lg}>
                    <CoursesCard {...data} />
                 </Grid>
             </Fragment>

--- a/src/components/organism/courses/FdeCard.css
+++ b/src/components/organism/courses/FdeCard.css
@@ -2,6 +2,9 @@
 .fde-card {
   width: 100%;
   max-width: 384px;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
   background: var(--rca-surface, #ffffff);
   border: 1px solid #e6e9f2;
   border-radius: var(--rca-radius-lg, 12px);
@@ -85,6 +88,7 @@
 
 /* --- Body --- */
 .fde-body {
+  flex: 1 1 auto;
   padding: 20px 24px 24px;
 }
 .fde-price-row {


### PR DESCRIPTION
Stretch every card in a grid row to equal height with the Enroll button pinned to the bottom, so the tall FDE flagship lines up with the plain courses instead of towering over them. Verified locally — row cards all match (868px). Closes #56