### PR TITLE
feat(courses): consolidate Courses + Upcoming Batches into one card

### DIFF
--- a/src/components/Pages/Home.jsx
+++ b/src/components/Pages/Home.jsx
@@ -5,7 +5,6 @@ import Mentors from '../organism/mentors/Mentors.jsx'
 import Reviews from '../organism/reviews/Reviews.jsx'
 import Clients from '../organism/clients/Clients.jsx'
 import Placement from '../organism/placements/Placements.jsx'
-import Batches from '../organism/Batches/Batches.jsx'
 import EnquiryForm from '../forms/Enquiry Form/EnquiryForm.jsx'
 
 
@@ -17,7 +16,6 @@ function Home() {
         <Mentors/>
         <Reviews/>
         <Clients/>
-        <Batches/>
         <Placement/>
 
        

--- a/src/components/molecules/Navbar/Navbar.jsx
+++ b/src/components/molecules/Navbar/Navbar.jsx
@@ -21,7 +21,7 @@ import { useAuth } from '../../../App';
 import { Link, animateScroll as scroll } from 'react-scroll';
 const drawerWidth = 240;
 // const navItems = ['Home', 'Fish', 'Stones','Plants','Food','Lights','Air Pumps','Tanks & Bowls'];
-const navItems = ['Courses',  'Reviews','Clients','Placements','Batches'];
+const navItems = ['Courses',  'Reviews','Clients','Placements'];
 
 
 function Navbar(props) {

--- a/src/components/organism/courses/CourseCard.css
+++ b/src/components/organism/courses/CourseCard.css
@@ -115,6 +115,39 @@
   color: var(--rca-disabled-ink, #9aa3aa);
 }
 
+/* Batch schedule, folded into the card (Courses + Upcoming Batches, one place). */
+.cc-schedule {
+  margin-top: 14px;
+  padding: 11px 14px;
+  background: #f5f7fb;
+  border: 1px solid #e6e9f2;
+  border-radius: var(--rca-radius-md, 8px);
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.cc-sched-label {
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+  color: var(--rca-blue, #146389);
+}
+.cc-sched-main {
+  font-size: 13.5px;
+  font-weight: 600;
+  color: var(--rca-navy, #03084c);
+}
+.cc-sched-meta {
+  font-size: 12px;
+  color: #45545d;
+}
+.cc-schedule--soon {
+  color: #45545d;
+  font-size: 13px;
+  font-style: italic;
+}
+
 .cc-chips {
   display: flex;
   flex-wrap: wrap;

--- a/src/components/organism/courses/CoursesCard.jsx
+++ b/src/components/organism/courses/CoursesCard.jsx
@@ -68,9 +68,22 @@ function CoursesCard({ name, courseId, paid, price, trainer, audience, backend, 
           ) : (
             <span className="cc-price cc-price--request">Fee on request</span>
           )}
-          <span className={"cc-tag" + (nextBatch ? "" : " cc-tag--muted")}>
-            {nextBatch ? `Next batch · ${formatBatchDateShort(nextBatch.date)}` : "New dates coming soon"}
-          </span>
+        </div>
+
+        <div className={"cc-schedule" + (nextBatch ? "" : " cc-schedule--soon")}>
+          {nextBatch ? (
+            <>
+              <span className="cc-sched-label">Next batch</span>
+              <span className="cc-sched-main">
+                {[nextBatch.day, formatBatchDateShort(nextBatch.date), nextBatch.time].filter(Boolean).join(" · ")}
+              </span>
+              <span className="cc-sched-meta">
+                {[nextBatch.mode, nextBatch.duration, nextBatch.trainer && `Trainer: ${nextBatch.trainer}`].filter(Boolean).join(" · ")}
+              </span>
+            </>
+          ) : (
+            "New dates coming soon"
+          )}
         </div>
 
         {chips.length > 0 && (


### PR DESCRIPTION
Folds the batch schedule (day · date · time · mode · duration · trainer) into each course card and removes the duplicate Upcoming Batches section + its nav link. One card per course; /admin/batches unchanged. Verified locally. Closes #62