### PR TITLE
feat(enroll): open Razorpay directly on Book-your-seat (no form)

### DIFF
--- a/e2e/smoke.spec.js
+++ b/e2e/smoke.spec.js
@@ -17,10 +17,14 @@ test("/admin is password-protected (401)", async ({ request }) => {
   expect((await request.get("/admin/batches")).status()).toBe(401);
 });
 
-test("book-a-seat CTA opens the enrolment form", async ({ page }) => {
+test("book-a-seat CTA launches checkout directly (no form)", async ({ page }) => {
   await page.goto("/");
   await page.getByRole("button", { name: /book your seat/i }).first().click();
-  await expect(page.getByRole("button", { name: /pay ₹|register my seat/i })).toBeVisible();
+  // No form on our side — it opens Razorpay directly. Without keys the order is
+  // 503, so the launcher shows the opening/opening-soon state (never a form).
+  await expect(
+    page.getByText(/opening secure checkout|enrolment is opening soon/i)
+  ).toBeVisible();
 });
 
 test("apply CTA opens the enquiry form", async ({ page }) => {

--- a/functions/api/enroll/verify.js
+++ b/functions/api/enroll/verify.js
@@ -27,6 +27,28 @@ export async function onRequestPost(context) {
   const courseId = String(b.course || "").trim();
   const amount = priceForCourse(courseId);
 
+  // There is no form on our side — the student enters their phone + email in
+  // Razorpay Checkout — so pull those from the verified payment. Any values in
+  // the body are only a fallback. Best-effort: the payment is already verified,
+  // so a failed lookup must never fail the student.
+  let email = str(b.email);
+  let mobile = str(b.mobile);
+  if (env.RAZORPAY_KEY_ID && keySecret) {
+    try {
+      const pr = await fetch(
+        `https://api.razorpay.com/v1/payments/${encodeURIComponent(paymentId)}`,
+        { headers: { Authorization: "Basic " + btoa(`${env.RAZORPAY_KEY_ID}:${keySecret}`) } }
+      );
+      if (pr.ok) {
+        const p = await pr.json();
+        if (p.email) email = str(p.email);
+        if (p.contact) mobile = str(p.contact);
+      }
+    } catch {
+      /* keep the fallbacks */
+    }
+  }
+
   try {
     const existing = await env.DB.prepare(
       "SELECT id FROM enrollments WHERE razorpay_order_id = ?1"
@@ -39,7 +61,7 @@ export async function onRequestPost(context) {
           "VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,'INR',?10,?11,'paid')"
       )
         .bind(
-          str(b.fullname), str(b.mobile), str(b.email), str(b.experience),
+          str(b.fullname), mobile, email, str(b.experience),
           courseId, str(b.course_name), str(b.batch), str(b.referral),
           amount || null, orderId, paymentId
         )

--- a/src/components/forms/EnrollForm/EnrollForm.css
+++ b/src/components/forms/EnrollForm/EnrollForm.css
@@ -71,3 +71,18 @@
 .enroll-done p {
   color: var(--rca-ink-muted);
 }
+
+.enroll-launching {
+  text-align: center;
+  align-items: center;
+  gap: 0.9rem;
+  padding: 2rem 1.5rem;
+}
+.enroll-launching p {
+  color: var(--rca-ink-muted);
+}
+.enroll-spinner {
+  display: flex;
+  justify-content: center;
+  padding: 0.5rem 0;
+}

--- a/src/components/forms/EnrollForm/EnrollForm.jsx
+++ b/src/components/forms/EnrollForm/EnrollForm.jsx
@@ -1,113 +1,61 @@
 import { Box, CircularProgress } from "@mui/material";
-import React, { useMemo, useState } from "react";
-import InputBoxComponent from "../../atoms/InputBoxComponent/InputBoxComponent";
+import React, { useEffect, useRef, useState } from "react";
 import TypoGraphyComponent from "../../atoms/TypoGraphyComponent/TypoGraphyComponent";
 import ButtonComponent from "../../atoms/ButtonComponent/ButtonComponent";
 import { useAuth } from "../../../App";
-import { regex } from "../../../regex/regex";
-import { useBatches } from "../../organism/Batches/useBatches";
-import { isBatchUpcoming, formatBatchDateShort } from "../../organism/Batches/batchDateUtils";
-import { getReferral, loadRazorpay, createOrder, verifyPayment, registerInterest } from "./enrollApi";
+import { getReferral, loadRazorpay, createOrder, verifyPayment } from "./enrollApi";
 import "./EnrollForm.css";
 
-// Deliberately low-friction: a buyer who clicked "Book your seat" wants to pay,
-// not fill a form (the "talk to a counsellor" path is where we gather details).
-// So we ask only email + phone; the referral rides in silently from the URL and
-// the batch is auto-set to the soonest upcoming one. Razorpay collects the name
-// at payment.
+// No form. "Book your seat" opens Razorpay Checkout directly — Razorpay collects
+// the student's phone + email + payment, and the server reads those back from
+// the verified payment (functions/api/enroll/verify.js). This component is only
+// the launcher + result: a spinner while checkout opens, then the booked
+// confirmation (or an error with retry). The "talk to a counsellor" path (a
+// separate button on the card) is where detailed enquiries are gathered.
 function EnrollForm({ course }) {
   const { closeEnroll, notify } = useAuth();
-  const batches = useBatches();
-  const paid = !!(course && course.paid);
-
-  const [data, setData] = useState({
-    mobile: "", email: "", referral: getReferral(),
-  });
-  const [errors, setErrors] = useState({});
-  const [busy, setBusy] = useState(false);
+  const [phase, setPhase] = useState("launching"); // launching | done | failed
   const [failed, setFailed] = useState("");
-  const [done, setDone] = useState(""); // "" | "paid" | "registered"
+  const started = useRef(false);
+  const settled = useRef(false); // paid+confirmed — so a late ondismiss can't close it
 
-  // Soonest upcoming batch for this course — auto-recorded, no picker shown.
-  const nextBatchLabel = useMemo(() => {
-    const b = (batches || [])
-      .filter((x) => x.name === course.name && isBatchUpcoming(x.date))
-      .sort((x, y) => new Date(x.date) - new Date(y.date))[0];
-    if (!b) return "";
-    return `${b.day ? b.day + " · " : ""}${formatBatchDateShort(b.date)}${b.time ? " · " + b.time : ""}`;
-  }, [batches, course]);
+  useEffect(() => {
+    if (started.current) return;
+    started.current = true;
+    startCheckout();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
-  const change = ({ target: { name, value } }) => setData((d) => ({ ...d, [name]: value }));
-
-  function validate() {
-    const e = {};
-    if (!data.mobile) e.mobile = "Mobile is Required";
-    else if (!regex.mobileRegex.test(data.mobile)) e.mobile = "Invalid Mobile Number";
-    if (!data.email) e.email = "Email is Required";
-    else if (!regex.emailRegex.test(data.email)) e.email = "Invalid Email";
-    return e;
+  function fail(msg) {
+    setFailed(msg);
+    setPhase("failed");
   }
 
-  const payload = () => ({
-    course: course.courseId,
-    course_name: course.name,
-    fullname: "",
-    mobile: data.mobile,
-    email: data.email,
-    experience: "",
-    batch: nextBatchLabel,
-    referral: data.referral,
-  });
-
-  async function handleSubmit(ev) {
-    ev.preventDefault();
-    if (busy) return;
-    const e = validate();
-    setErrors(e);
-    if (Object.keys(e).length) return;
+  async function startCheckout() {
     setFailed("");
-    setBusy(true);
+    setPhase("launching");
+    const referral = getReferral();
+
+    let order;
     try {
-      if (paid) await payFlow();
-      else await registerFlow();
+      order = await createOrder(course.courseId, referral);
     } catch {
-      setBusy(false);
-      setFailed("Something went wrong. Please try again, or message us on WhatsApp.");
+      return fail("Something went wrong starting checkout. Please try again.");
     }
-  }
-
-  async function registerFlow() {
-    const r = await registerInterest(payload());
-    setBusy(false);
-    if (r.ok) {
-      setDone("registered");
-      notify && notify("Seat registered — we'll be in touch!");
-    } else {
-      setFailed(r.body.error || "Could not register. Please try again.");
-    }
-  }
-
-  async function payFlow() {
-    const order = await createOrder(course.courseId, data.referral);
-    // Payments not enabled yet → save their interest so nothing is lost.
     if (order.status === 503) {
-      const r = await registerInterest(payload());
-      setBusy(false);
-      if (r.ok) setDone("registered");
-      else setFailed("Enrolment is opening soon — please message us on WhatsApp to reserve your seat.");
-      return;
+      return fail(
+        "Enrolment is opening soon — please use “Talk to a counsellor” or message us on WhatsApp to reserve your seat."
+      );
     }
     if (!order.ok || !order.body.orderId) {
-      setBusy(false);
-      setFailed(order.body.error || "Could not start payment. Please try again.");
-      return;
+      return fail(order.body.error || "Could not start payment. Please try again.");
     }
+
     const loaded = await loadRazorpay();
     if (!loaded || !window.Razorpay) {
-      setBusy(false);
-      setFailed("Could not load the payment window. Check your connection and try again.");
-      return;
+      return fail("Could not load the payment window. Check your connection and try again.");
     }
+
     const rzp = new window.Razorpay({
       key: order.body.keyId,
       order_id: order.body.orderId,
@@ -116,98 +64,97 @@ function EnrollForm({ course }) {
       name: "Rest Coder Academy",
       description: course.name,
       image: "/favicon.png",
-      prefill: { email: data.email, contact: data.mobile },
-      notes: { course: course.courseId, referral: data.referral },
-      theme: { color: "var(--rca-navy)" },
+      notes: { course: course.courseId, referral },
+      theme: { color: "#03084C" },
       handler: async (resp) => {
-        const v = await verifyPayment({ ...resp, ...payload() });
-        setBusy(false);
-        if (v.ok && v.body.ok) {
-          setDone("paid");
-          notify && notify("Enrolment confirmed! 🎉");
-        } else {
-          setFailed(
+        try {
+          const v = await verifyPayment({
+            razorpay_order_id: resp.razorpay_order_id,
+            razorpay_payment_id: resp.razorpay_payment_id,
+            razorpay_signature: resp.razorpay_signature,
+            course: course.courseId,
+            course_name: course.name,
+            referral,
+          });
+          if (v.ok && v.body.ok) {
+            settled.current = true;
+            setPhase("done");
+            notify && notify("Enrolment confirmed! 🎉");
+          } else {
+            fail(
+              "Your payment went through but we couldn't confirm it here. Keep your payment ID and message us — we'll sort it out."
+            );
+          }
+        } catch {
+          fail(
             "Your payment went through but we couldn't confirm it here. Keep your payment ID and message us — we'll sort it out."
           );
         }
       },
-      modal: { ondismiss: () => setBusy(false) },
+      modal: {
+        // Closed Razorpay without paying → close our launcher too (unless a
+        // payment already settled, in which case the confirmation is showing).
+        ondismiss: () => {
+          if (!settled.current) closeEnroll();
+        },
+      },
     });
-    rzp.on("payment.failed", () => {
-      setBusy(false);
-      setFailed("Payment failed or was cancelled. You can try again.");
-    });
+    rzp.on("payment.failed", () => fail("Payment failed or was cancelled. You can try again."));
     rzp.open();
   }
 
-  if (done) {
-    const isPaid = done === "paid";
+  if (phase === "done") {
     return (
       <Box className="enroll-form enroll-done">
-        <TypoGraphyComponent component="h6" variant="h6" text={isPaid ? "Your seat is booked 🎉" : "You're registered ✅"} />
+        <TypoGraphyComponent component="h6" variant="h6" text="Your seat is booked 🎉" />
         <TypoGraphyComponent
           component="p"
           variant="body2"
-          text={
-            isPaid
-              ? `₹${Number(course.price).toLocaleString("en-IN")} received. A receipt is on its way to your email and WhatsApp — we'll call you within a day to confirm your batch.`
-              : "Thanks! We've saved your details and the team will reach out with the next steps and dates."
-          }
+          text={`₹${Number(course.price).toLocaleString("en-IN")} received. A receipt is on its way to your email and WhatsApp — we'll call you within a day to confirm your batch.`}
         />
         <ButtonComponent label="Done" onBtnClick={closeEnroll} />
       </Box>
     );
   }
 
-  return (
-    <form className="enroll-form" onSubmit={handleSubmit}>
-      <Box className="form-heading">
-        <Box>
-          <TypoGraphyComponent component="h6" variant="h6" text={paid ? "Book your seat" : "Register your seat"} />
-          <TypoGraphyComponent component="p" variant="body2" text={course.name} />
-        </Box>
-        <ButtonComponent paddingX={1} paddingY={1} onBtnClick={closeEnroll}>
-          ×
-        </ButtonComponent>
-      </Box>
-
-      {paid && (
-        <Box className="enroll-price">
-          <span className="amt">₹{Number(course.price).toLocaleString("en-IN")}</span>
-          <span className="emi">EMI available at checkout</span>
-        </Box>
-      )}
-
-      <Box className="enroll-fields">
-        <InputBoxComponent value={data.email} label="Email" variant="outlined" onChange={change} name="email" error={!!errors.email} helperText={errors.email} />
-        <InputBoxComponent value={data.mobile} label="Phone" variant="outlined" onChange={change} name="mobile" error={!!errors.mobile} helperText={errors.mobile} />
-        {nextBatchLabel && (
-          <TypoGraphyComponent component="p" variant="caption" text={`Next batch: ${nextBatchLabel}`} />
-        )}
-
-        {failed && (
-          <Box className="enroll-error" role="alert">
-            <TypoGraphyComponent component="p" variant="body2" text={failed} />
+  if (phase === "failed") {
+    return (
+      <Box className="enroll-form">
+        <Box className="form-heading">
+          <Box>
+            <TypoGraphyComponent component="h6" variant="h6" text="Couldn't complete checkout" />
+            <TypoGraphyComponent component="p" variant="body2" text={course.name} />
           </Box>
-        )}
-
-        <ButtonComponent
-          type="submit"
-          fullWidth
-          disabled={busy}
-          label={busy ? "" : paid ? `Pay ₹${Number(course.price).toLocaleString("en-IN")} securely` : "Register my seat"}
-        >
-          {busy && <CircularProgress size={20} sx={{ color: "var(--rca-surface)" }} />}
-        </ButtonComponent>
-        {paid && (
-          <TypoGraphyComponent
-            component="p"
-            variant="caption"
-            text="Secured by Razorpay · UPI, cards, net banking · EMI"
-          />
-        )}
+          <ButtonComponent paddingX={1} paddingY={1} onBtnClick={closeEnroll}>
+            ×
+          </ButtonComponent>
+        </Box>
+        <Box className="enroll-error" role="alert">
+          <TypoGraphyComponent component="p" variant="body2" text={failed} />
+        </Box>
+        <ButtonComponent label="Try again" fullWidth onBtnClick={startCheckout} />
       </Box>
-    </form>
+    );
+  }
+
+  // launching
+  return (
+    <Box className="enroll-form enroll-launching">
+      <TypoGraphyComponent component="h6" variant="h6" text="Opening secure checkout…" />
+      <TypoGraphyComponent
+        component="p"
+        variant="body2"
+        text={`${course.name} · ₹${Number(course.price).toLocaleString("en-IN")}`}
+      />
+      <Box className="enroll-spinner">
+        <CircularProgress size={30} sx={{ color: "var(--rca-navy)" }} />
+      </Box>
+      <TypoGraphyComponent
+        component="p"
+        variant="caption"
+        text="Razorpay will ask for your phone, email and payment. Secured by Razorpay · UPI, cards, net banking · EMI."
+      />
+    </Box>
   );
 }
 

--- a/tests/functions.integration.test.js
+++ b/tests/functions.integration.test.js
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, afterEach } from "vitest";
 import { onRequestPost as enquiryPost } from "../functions/api/enquiry.js";
 import { onRequestGet as batchesGet } from "../functions/api/batches.js";
 import { onRequestGet as adminGet } from "../functions/admin.js";
@@ -331,5 +331,33 @@ describe("POST /api/enroll/verify", () => {
     const r2 = await enrollVerify(ctx(jsonReqTo("https://x/api/enroll/verify", body), env(db)));
     expect(r2.status).toBe(200);
     expect(db.tables.enrollments).toHaveLength(1); // still one — idempotent
+  });
+
+  it("records phone + email pulled from the verified Razorpay payment", async () => {
+    const db = makeDB();
+    const sig = await rzpSign("o9", "p9", "sekret");
+    // Razorpay is where the student entered their details (no form on our side).
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: true,
+      json: async () => ({ email: "student@rzp.test", contact: "+919876500000" }),
+    });
+    const res = await enrollVerify(
+      ctx(
+        jsonReqTo("https://x/api/enroll/verify", {
+          razorpay_order_id: "o9", razorpay_payment_id: "p9", razorpay_signature: sig,
+          course: "java-fs", course_name: "Java Full Stack",
+        }),
+        { DB: db, RAZORPAY_KEY_ID: "rzp_test_x", RAZORPAY_KEY_SECRET: "sekret" }
+      )
+    );
+    expect(res.status).toBe(200);
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "https://api.razorpay.com/v1/payments/p9",
+      expect.objectContaining({ headers: expect.objectContaining({ Authorization: expect.stringMatching(/^Basic /) }) })
+    );
+    expect(db.tables.enrollments[0].email).toBe("student@rzp.test");
+    expect(db.tables.enrollments[0].mobile).toBe("+919876500000");
+    expect(db.tables.enrollments[0].amount).toBe(3500000);
+    fetchSpy.mockRestore();
   });
 });


### PR DESCRIPTION
Book your seat opens Razorpay Checkout directly — no form. Razorpay collects phone+email+payment; verify.js reads phone+email back from the verified payment to record the enrolment. Modal is now a launcher -> confirmation. 62 tests pass. Closes #66