### PR TITLE
fix(seo): prerender course pages as flat .html for clean no-slash URLs

### DIFF
--- a/scripts/prerender.mjs
+++ b/scripts/prerender.mjs
@@ -20,7 +20,10 @@ const routes = [
   { path: "/", out: "index.html", waitFor: "#Courses" },
   ...courses.map((c) => {
     const slug = c.slug || c.courseId;
-    return { path: `/courses/${slug}`, out: `courses/${slug}/index.html`, waitFor: "main.cd" };
+    // Flat `.html` (not `<slug>/index.html`) so Cloudflare Pages serves the
+    // clean, no-trailing-slash URL directly (200) — matching the canonical +
+    // sitemap and avoiding a 308 redirect hop.
+    return { path: `/courses/${slug}`, out: `courses/${slug}.html`, waitFor: "main.cd" };
   }),
 ];
 


### PR DESCRIPTION
Follow-up to #69: emit `courses/<slug>.html` instead of `courses/<slug>/index.html` so Cloudflare Pages serves `/courses/<slug>` directly (200) — matching the canonical tag + sitemap, and dropping the 308 trailing-slash redirect hop.