### PR TITLE
feat(seo): For-Parents / accountability page + fix route scroll position

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url><loc>https://restcoderacademy.in/</loc><changefreq>weekly</changefreq><priority>1.0</priority></url>
+  <url><loc>https://restcoderacademy.in/for-parents</loc><changefreq>monthly</changefreq><priority>0.9</priority></url>
   <url><loc>https://restcoderacademy.in/courses/forward-deployed-engineering</loc><changefreq>weekly</changefreq><priority>0.9</priority></url>
   <url><loc>https://restcoderacademy.in/courses/java-full-stack</loc><changefreq>weekly</changefreq><priority>0.8</priority></url>
   <url><loc>https://restcoderacademy.in/courses/python-full-stack</loc><changefreq>weekly</changefreq><priority>0.8</priority></url>

--- a/scripts/prerender.mjs
+++ b/scripts/prerender.mjs
@@ -18,6 +18,7 @@ const HOST = "127.0.0.1";
 
 const routes = [
   { path: "/", out: "index.html", waitFor: "#Courses" },
+  { path: "/for-parents", out: "for-parents.html", waitFor: "main.fp" },
   ...courses.map((c) => {
     const slug = c.slug || c.courseId;
     // Flat `.html` (not `<slug>/index.html`) so Cloudflare Pages serves the

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,6 +5,8 @@ import Footer from "./components/organism/Footer/FooterComponent"
 import Banner from './components/organism/Banner/Banner'
 import Home from "./components/Pages/Home";
 import CourseDetail from "./components/Pages/CourseDetail";
+import ForParents from "./components/Pages/ForParents";
+import ScrollToTop from "./components/ScrollToTop";
 import Modal from 'react-modal';
 import EnquiryForm from './components/forms/Enquiry Form/EnquiryForm';
 import EnrollForm from './components/forms/EnrollForm/EnrollForm';
@@ -74,9 +76,11 @@ function App() {
       >
         {enrollCourse && <EnrollForm course={enrollCourse} />}
       </Modal>
+      <ScrollToTop />
       <Routes>
         <Route path="/" element={<Home />} />
         <Route path="/courses/:slug" element={<CourseDetail />} />
+        <Route path="/for-parents" element={<ForParents />} />
         <Route path="*" element={<Navigate to="/" replace />} />
       </Routes>
       <FloatingIcons/>

--- a/src/components/Pages/CourseDetail.css
+++ b/src/components/Pages/CourseDetail.css
@@ -107,6 +107,15 @@
 }
 .cd-accountability h2 { margin: 0 0 8px; font-size: 19px; color: var(--rca-navy, #03084c); }
 .cd-accountability p { margin: 0; font-size: 15px; line-height: 1.6; color: #37424f; }
+.cd-parents-link {
+  display: inline-block;
+  margin-top: 12px;
+  font-size: 13.5px;
+  font-weight: 600;
+  color: var(--rca-blue, #146389);
+  text-decoration: none;
+}
+.cd-parents-link:hover { text-decoration: underline; }
 
 /* Syllabus */
 .cd-syllabus { margin-top: 34px; }

--- a/src/components/Pages/CourseDetail.jsx
+++ b/src/components/Pages/CourseDetail.jsx
@@ -97,6 +97,7 @@ function CourseDetail() {
             progress, scores and attendance — every week. You always know exactly how the learning
             is going, so nobody is left guessing.
           </p>
+          <Link className="cd-parents-link" to="/for-parents">See how it works for parents →</Link>
         </section>
 
         <section className="cd-syllabus">
@@ -115,7 +116,7 @@ function CourseDetail() {
             <button className="cd-book" type="button" onClick={() => openEnroll({ courseId: course.courseId, name: course.name, paid: course.paid, price: course.price })}>
               Book your seat
             </button>
-            <Link className="cd-back" to="/">← All courses</Link>
+            <Link className="cd-back" to="/" state={{ scrollTo: "Courses" }}>← All courses</Link>
           </div>
         </section>
       </main>

--- a/src/components/Pages/ForParents.css
+++ b/src/components/Pages/ForParents.css
@@ -1,0 +1,96 @@
+/* For-Parents / accountability page. Shared design tokens; below the fixed navbar. */
+.fp {
+  max-width: 860px;
+  margin: 0 auto;
+  padding: 92px 20px 72px;
+  font-family: var(--rca-font, "Montserrat", "Segoe UI", system-ui, sans-serif);
+  color: #1b2230;
+}
+.fp h2 { font-size: clamp(21px, 3vw, 26px); font-weight: 800; letter-spacing: -0.01em; color: var(--rca-navy, #03084c); margin: 0 0 12px; }
+.fp p { font-size: 15.5px; line-height: 1.65; color: #37424f; }
+
+/* Hero */
+.fp-hero {
+  background: linear-gradient(155deg, var(--rca-navy, #03084c) 0%, #070d3a 100%);
+  color: #fff;
+  border-radius: var(--rca-radius-lg, 12px);
+  padding: 40px 34px 34px;
+  box-shadow: 0 14px 36px rgba(3, 8, 76, 0.14);
+}
+.fp-eyebrow {
+  display: inline-block;
+  background: rgba(255, 152, 0, 0.16);
+  color: #ffb74d;
+  font-size: 11px; font-weight: 700; letter-spacing: 0.11em; text-transform: uppercase;
+  padding: 5px 12px; border-radius: 999px; margin-bottom: 16px;
+}
+.fp-hero h1 {
+  margin: 0 0 14px;
+  font-size: clamp(27px, 4.6vw, 40px);
+  font-weight: 800; line-height: 1.12; letter-spacing: -0.02em; text-wrap: balance;
+}
+.fp-hero p { color: #c3caf0; font-size: 16px; margin: 0; max-width: 60ch; }
+.fp-cta { display: flex; flex-wrap: wrap; gap: 12px; margin-top: 26px; }
+.fp-btn {
+  font-family: inherit; font-size: 15.5px; font-weight: 600;
+  height: 48px; padding: 0 26px; border: none; border-radius: var(--rca-radius-md, 8px);
+  background: #fff; color: var(--rca-navy, #03084c); cursor: pointer;
+  text-decoration: none; display: inline-flex; align-items: center;
+  transition: transform 0.12s ease, box-shadow 0.12s ease;
+}
+.fp-btn:hover { transform: translateY(-1px); box-shadow: 0 6px 18px rgba(0, 0, 0, 0.18); }
+.fp-btn--ghost { background: transparent; color: #fff; border: 1px solid rgba(255, 255, 255, 0.4); }
+.fp-btn--ghost:hover { background: rgba(255, 255, 255, 0.08); box-shadow: none; transform: none; }
+
+/* Problem */
+.fp-problem { margin-top: 36px; }
+.fp-problem em { color: var(--rca-navy, #03084c); font-style: italic; font-weight: 600; }
+
+/* What you'll see */
+.fp-see { margin-top: 40px; }
+.fp-grid { display: grid; grid-template-columns: 1fr; gap: 14px; }
+@media (min-width: 620px) { .fp-grid { grid-template-columns: 1fr 1fr; } }
+.fp-card {
+  background: #f5f7fb; border: 1px solid #e6e9f2; border-left: 4px solid var(--rca-blue, #146389);
+  border-radius: var(--rca-radius-md, 8px); padding: 18px 20px;
+}
+.fp-card h3 { margin: 0 0 6px; font-size: 16px; color: var(--rca-navy, #03084c); }
+.fp-card p { margin: 0; font-size: 14px; color: #45545d; }
+
+/* Sample weekly report */
+.fp-sample { margin-top: 44px; }
+.fp-sample-note { font-size: 13.5px; color: #6b7280; margin-bottom: 16px; }
+.fp-report {
+  border: 1px solid #e1e6f0; border-radius: var(--rca-radius-lg, 12px);
+  overflow: hidden; box-shadow: var(--rca-shadow-card, 0 1px 3px rgba(3, 8, 76, 0.08)); max-width: 480px;
+}
+.fp-report-head {
+  display: flex; justify-content: space-between; align-items: center;
+  background: var(--rca-navy, #03084c); color: #fff; padding: 12px 18px;
+  font-size: 12px; font-weight: 700; letter-spacing: 0.06em; text-transform: uppercase;
+}
+.fp-report-course { color: #ffb74d; }
+.fp-report ul { list-style: none; margin: 0; padding: 6px 18px; }
+.fp-report li {
+  display: flex; justify-content: space-between; align-items: center;
+  padding: 13px 0; border-bottom: 1px solid #eef1f7; font-size: 14.5px;
+}
+.fp-report li:last-child { border-bottom: none; }
+.fp-report li b { color: #45545d; font-weight: 600; }
+.fp-report li span { color: var(--rca-navy, #03084c); font-weight: 700; }
+.fp-report-foot { margin: 0; padding: 12px 18px; background: #f5f7fb; font-size: 12.5px; color: #6b7280; }
+
+/* Why */
+.fp-why { margin-top: 44px; }
+
+/* Closing */
+.fp-foot {
+  margin-top: 44px; text-align: center;
+  background: #f5f7fb; border: 1px solid #e6e9f2; border-radius: var(--rca-radius-lg, 12px);
+  padding: 34px 24px;
+}
+.fp-foot h2 { margin-bottom: 8px; }
+.fp-foot p { margin: 0 auto 22px; max-width: 52ch; }
+.fp-foot .fp-cta { justify-content: center; }
+.fp-foot .fp-btn { background: var(--rca-navy, #03084c); color: #fff; }
+.fp-foot .fp-btn--ghost { background: transparent; color: var(--rca-navy, #03084c); border: 1px solid var(--line-2, #d0d7e6); }

--- a/src/components/Pages/ForParents.jsx
+++ b/src/components/Pages/ForParents.jsx
@@ -1,0 +1,110 @@
+import React from "react";
+import { Link } from "react-router-dom";
+import { useAuth } from "../../App";
+import "./ForParents.css";
+
+const ORIGIN = "https://restcoderacademy.in";
+
+// What guardians see, each with a plain-language line. Kept honest: this is the
+// accountability commitment RCA delivers (weekly updates now, the guardian
+// dashboard as it rolls out) — not a claim that an app is already deployed.
+const SEE = [
+  { label: "Attendance", text: "Every class marked, so you know they're actually showing up." },
+  { label: "Scores", text: "Assignment and assessment scores as they happen — no waiting for results day." },
+  { label: "Project progress", text: "What they're building, and whether it's moving. Real work, visible." },
+  { label: "Placement-readiness", text: "An honest read on how job-ready they are, well before the course ends." },
+];
+
+function ForParents() {
+  const { openModal } = useAuth();
+  const url = `${ORIGIN}/for-parents`;
+  const description =
+    "Most coding institutes go dark after you pay. At Rest Coder Academy, guardians see " +
+    "attendance, scores and project progress every week — accountability, so you always know " +
+    "how your child is doing.";
+
+  return (
+    <>
+      <title>For Parents — Progress You Can Actually See | Rest Coder Academy</title>
+      <meta name="description" content={description} />
+      <link rel="canonical" href={url} />
+
+      <main className="fp">
+        <header className="fp-hero">
+          <span className="fp-eyebrow">For parents &amp; guardians</span>
+          <h1>You'll never have to wonder how your child is doing.</h1>
+          <p>
+            Most institutes take the fee and go quiet. Rest Coder Academy is built the opposite way:
+            the family sees the progress. Attendance, scores, what they're building, how job-ready
+            they are — every week, straight to you.
+          </p>
+          <div className="fp-cta">
+            <button className="fp-btn" type="button" onClick={openModal}>Talk to a counsellor</button>
+            <Link className="fp-btn fp-btn--ghost" to="/">See our courses</Link>
+          </div>
+        </header>
+
+        <section className="fp-problem">
+          <h2>The question every parent has after paying</h2>
+          <p>
+            <em>"Is my child actually attending, learning, and going to get placed — or is this
+            money gone?"</em> With most coding classes you simply can't tell until it's too late.
+            We think that's backwards. When you're investing in your child's career, you deserve to
+            see it working.
+          </p>
+        </section>
+
+        <section className="fp-see">
+          <h2>What you'll see</h2>
+          <div className="fp-grid">
+            {SEE.map((s) => (
+              <div className="fp-card" key={s.label}>
+                <h3>{s.label}</h3>
+                <p>{s.text}</p>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        <section className="fp-sample">
+          <h2>A weekly update, in plain language</h2>
+          <p className="fp-sample-note">Here's the kind of summary a guardian receives — a real one is personal to your child.</p>
+          <div className="fp-report" aria-label="Sample weekly update">
+            <div className="fp-report-head">
+              <span>Weekly update · Sample</span>
+              <span className="fp-report-course">Java Full Stack</span>
+            </div>
+            <ul>
+              <li><b>Attendance</b><span>4 of 4 classes</span></li>
+              <li><b>Latest score</b><span>Assignment — 88%</span></li>
+              <li><b>Project</b><span>Shipped a working REST API</span></li>
+              <li><b>Placement-readiness</b><span>On track</span></li>
+            </ul>
+            <p className="fp-report-foot">Delivered on WhatsApp &amp; email — and, as it rolls out, in the guardian dashboard.</p>
+          </div>
+        </section>
+
+        <section className="fp-why">
+          <h2>Why accountability matters</h2>
+          <p>
+            Visibility isn't just reassurance — it changes outcomes. When a student knows their
+            progress is seen, they show up and finish; and students who finish are the ones who get
+            placed. Transparency is how we keep everyone — student, family, and us — honest about
+            the goal: a real job at the end.
+          </p>
+        </section>
+
+        <section className="fp-foot">
+          <h2>Want to see how it works for your child?</h2>
+          <p>Talk to a counsellor — we'll walk you through the course, the fees and EMI, and exactly what you'll see each week.</p>
+          <div className="fp-cta">
+            <button className="fp-btn" type="button" onClick={openModal}>Talk to a counsellor</button>
+            <Link className="fp-btn fp-btn--ghost" to="/">Browse courses</Link>
+          </div>
+        </section>
+      </main>
+    </>
+  );
+}
+
+export default ForParents;

--- a/src/components/ScrollToTop.jsx
+++ b/src/components/ScrollToTop.jsx
@@ -1,0 +1,16 @@
+import { useEffect } from "react";
+import { useLocation } from "react-router-dom";
+
+// React Router keeps the scroll position across navigations, so moving between
+// pages can leave you stranded mid-page. Reset to the top on every route change
+// — unless the navigation asked to land on a specific section (`state.scrollTo`,
+// used by the navbar and "All courses"), which Home handles itself.
+function ScrollToTop() {
+  const { pathname, state } = useLocation();
+  useEffect(() => {
+    if (!state?.scrollTo) window.scrollTo(0, 0);
+  }, [pathname, state]);
+  return null;
+}
+
+export default ScrollToTop;


### PR DESCRIPTION
Adds **/for-parents** — the page that sells the accountability USP (what guardians see each week, a sample weekly-update card, honest framing, no fake testimonials). Prerendered + in sitemap + linked from each course page. Also fixes a routing bug where page→page nav kept the scroll position ("All courses" landed near Placements): adds ScrollToTop and makes "All courses" scroll to the Courses section. 64 tests pass. Closes #77, closes #89.