### PR TITLE
feat(founder): admin-managed founder/About page (CRUD, hide-if-empty)

### DIFF
--- a/functions/admin.js
+++ b/functions/admin.js
@@ -72,7 +72,7 @@ function page(notice, count, body) {
   .notice { padding:1rem 1.25rem; color:#b3261e; }
 </style></head>
 <body>
-  <header><h1>Enquiries</h1><span class="count">${count} total</span><a href="/admin/enrollments">Enrolments</a><a href="/admin/batches">Batches</a><a href="/admin/trainers">Trainers →</a></header>
+  <header><h1>Enquiries</h1><span class="count">${count} total</span><a href="/admin/enrollments">Enrolments</a><a href="/admin/batches">Batches</a><a href="/admin/trainers">Trainers</a><a href="/admin/founder">Founder →</a></header>
   ${notice ? `<div class="notice">${escapeHtml(notice)}</div>` : ""}
   <div class="wrap">
     <table>

--- a/functions/admin/batches.js
+++ b/functions/admin/batches.js
@@ -127,7 +127,7 @@ function page(rows, error, notice) {
   .hint{font-size:.75rem;color:var(--muted);margin:.3rem 0 0}
 </style></head>
 <body>
-  <header><h1>Batches</h1><a href="/admin/enrollments">Enrolments</a><a href="/admin/trainers">Trainers</a><a href="/admin/batches">Batches</a><a href="/admin">Enquiries →</a></header>
+  <header><h1>Batches</h1><a href="/admin/enrollments">Enrolments</a><a href="/admin/trainers">Trainers</a><a href="/admin/batches">Batches</a><a href="/admin/founder">Founder</a><a href="/admin">Enquiries →</a></header>
   <div class="wrap">
     ${error ? `<div class="banner err">${escapeHtml(error)}</div>` : ""}
     ${notice ? `<div class="banner ok">${escapeHtml(notice)}</div>` : ""}

--- a/functions/admin/enrollments.js
+++ b/functions/admin/enrollments.js
@@ -79,7 +79,7 @@ function page(notice, count, body) {
   .amt { font-weight:600; white-space:nowrap; }
 </style></head>
 <body>
-  <header><h1>Enrolments</h1><span class="count">${count} total</span><a href="/admin/trainers">Trainers</a><a href="/admin/batches">Batches</a><a href="/admin">Enquiries →</a></header>
+  <header><h1>Enrolments</h1><span class="count">${count} total</span><a href="/admin/trainers">Trainers</a><a href="/admin/batches">Batches</a><a href="/admin/founder">Founder</a><a href="/admin">Enquiries →</a></header>
   ${notice ? `<div class="notice">${escapeHtml(notice)}</div>` : ""}
   <div class="wrap">
     <table>

--- a/functions/admin/founder.js
+++ b/functions/admin/founder.js
@@ -1,0 +1,131 @@
+// /admin/founder — password-protected editor for the founder / About page (one
+// record, id = 1). GET renders the form; POST upserts it. Same Basic Auth as the
+// rest of /admin (ADMIN_PASSWORD secret, fails closed if unset). Leave the name
+// blank to keep the About page hidden; set Status to Hidden to take it down while
+// keeping the content.
+import { escapeHtml, requireAdminAuth } from "../../shared/serverUtil.js";
+
+const FIELDS = ["name", "title", "tagline", "intro", "story", "mission", "vision", "photo_url", "linkedin_url"];
+
+export async function onRequestGet(context) {
+  const { request, env } = context;
+  const auth = requireAdminAuth(request, env);
+  if (auth) return auth;
+  if (!env.DB) return html(page({}, "Storage not configured.", null), 500);
+
+  let row = {};
+  try {
+    row = (await env.DB.prepare(
+      "SELECT name, title, tagline, intro, story, mission, vision, photo_url, linkedin_url, status FROM founder WHERE id = 1"
+    ).first()) || {};
+  } catch {
+    return html(page({}, "Could not load founder content.", null), 500);
+  }
+  const url = new URL(request.url);
+  return html(page(row, url.searchParams.get("err"), url.searchParams.get("ok")), 200);
+}
+
+export async function onRequestPost(context) {
+  const { request, env } = context;
+  const auth = requireAdminAuth(request, env);
+  if (auth) return auth;
+  if (!env.DB) return redirect(request, "err", "Storage not configured.");
+
+  let form;
+  try {
+    form = await request.formData();
+  } catch {
+    return redirect(request, "err", "Bad form submission.");
+  }
+
+  const vals = {};
+  for (const f of FIELDS) vals[f] = String(form.get(f) || "").trim().slice(0, 8000);
+  const status = form.get("status") === "hidden" ? "hidden" : "active";
+
+  try {
+    await env.DB.prepare(
+      "INSERT INTO founder (id, name, title, tagline, intro, story, mission, vision, photo_url, linkedin_url, status, updated_at) " +
+        "VALUES (1,?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,datetime('now')) " +
+        "ON CONFLICT(id) DO UPDATE SET name=?1, title=?2, tagline=?3, intro=?4, story=?5, mission=?6, " +
+        "vision=?7, photo_url=?8, linkedin_url=?9, status=?10, updated_at=datetime('now')"
+    )
+      .bind(vals.name, vals.title, vals.tagline, vals.intro, vals.story, vals.mission, vals.vision, vals.photo_url, vals.linkedin_url, status)
+      .run();
+    return redirect(request, "ok", "Founder page saved.");
+  } catch {
+    return redirect(request, "err", "Database error — please try again.");
+  }
+}
+
+function redirect(request, key, msg) {
+  const u = new URL("/admin/founder", request.url);
+  u.searchParams.set(key, msg);
+  return Response.redirect(u.toString(), 303);
+}
+
+function page(r, error, notice) {
+  const status = r.status === "hidden" ? "hidden" : "active";
+  const F = (name, label, ph = "") =>
+    `<div><label>${label}</label><input name="${name}" value="${escapeHtml(r[name])}" placeholder="${escapeHtml(ph)}"/></div>`;
+  const T = (name, label, ph = "") =>
+    `<div class="wide"><label>${label}</label><textarea name="${name}" placeholder="${escapeHtml(ph)}">${escapeHtml(r[name])}</textarea></div>`;
+  return `<!doctype html>
+<html lang="en"><head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<meta name="robots" content="noindex, nofollow"/>
+<title>Founder page — Rest Coder Academy</title>
+<style>
+  :root { --navy:#03084C; --line:#e4e6ef; --muted:#5b6472; }
+  *{box-sizing:border-box}
+  body{margin:0;font-family:system-ui,-apple-system,Segoe UI,Roboto,sans-serif;color:#1b2030;background:#f5f6fa}
+  header{background:var(--navy);color:#fff;padding:1rem 1.25rem;display:flex;align-items:center;gap:1rem}
+  header h1{font-size:1.1rem;margin:0}
+  header a{color:#cdd6ea;font-size:.85rem}
+  .wrap{padding:1.25rem;max-width:820px;margin:0 auto}
+  .banner{padding:.7rem 1rem;border-radius:8px;margin-bottom:1rem;font-size:.9rem}
+  .ok{background:#e7f6ec;color:#1b6b3a;border:1px solid #b6e0c4}
+  .err{background:#fdecea;color:#b3261e;border:1px solid #f1b5ac}
+  .card{background:#fff;border:1px solid var(--line);border-radius:10px;padding:1.25rem}
+  .grid{display:grid;grid-template-columns:1fr 1fr;gap:.7rem}
+  label{display:block;font-size:.72rem;color:var(--muted);margin-bottom:.15rem}
+  input,textarea,select{width:100%;padding:.45rem .55rem;border:1px solid var(--line);border-radius:6px;font-size:.9rem;font-family:inherit}
+  textarea{min-height:5rem;resize:vertical}
+  .wide{grid-column:1 / -1}
+  .actions{margin-top:1rem}
+  button{padding:.55rem 1.3rem;border:none;border-radius:6px;font-weight:600;font-size:.9rem;cursor:pointer;background:var(--navy);color:#fff}
+  .hint{font-size:.8rem;color:var(--muted);margin:.3rem 0 1rem;line-height:1.5}
+</style></head>
+<body>
+  <header><h1>Founder page</h1><a href="/admin/enrollments">Enrolments</a><a href="/admin/trainers">Trainers</a><a href="/admin/batches">Batches</a><a href="/admin/founder">Founder</a><a href="/admin">Enquiries →</a></header>
+  <div class="wrap">
+    ${error ? `<div class="banner err">${escapeHtml(error)}</div>` : ""}
+    ${notice ? `<div class="banner ok">${escapeHtml(notice)}</div>` : ""}
+    <p class="hint">This fills the public <b>/about</b> page. The page stays hidden until <b>Name</b> is filled in; empty fields simply don't show. In <b>Story</b>, leave a blank line between paragraphs. Set <b>Status → Hidden</b> to take the page down while keeping the content.</p>
+    <div class="card">
+      <form method="post">
+        <div class="grid">
+          ${F("name", "Name", "Uday Pawar S")}
+          ${F("title", "Title", "Founder")}
+          ${F("tagline", "Headline (H1)", "Why I started Rest Coder Academy")}
+          ${F("photo_url", "Photo URL", "/trainers/uday.png")}
+          ${F("linkedin_url", "LinkedIn URL", "https://linkedin.com/in/…")}
+          <div><label>Status</label><select name="status">
+            <option value="active"${status === "active" ? " selected" : ""}>Active (shown on site)</option>
+            <option value="hidden"${status === "hidden" ? " selected" : ""}>Hidden</option>
+          </select></div>
+          ${T("intro", "Intro (short hero paragraph)", "One or two sentences that open the page.")}
+          ${T("story", "Story (the main narrative)", "Who Uday is, and why he started Rest Coder Academy. Blank line = new paragraph.")}
+          ${T("mission", "Mission", "What the academy is here to do.")}
+          ${T("vision", "Vision", "Where it's headed.")}
+        </div>
+        <div class="actions"><button type="submit">Save founder page</button></div>
+      </form>
+    </div>
+  </div>
+</body></html>`;
+}
+
+function html(b, status) {
+  return new Response(b, { status, headers: { "content-type": "text/html; charset=utf-8" } });
+}

--- a/functions/admin/trainers.js
+++ b/functions/admin/trainers.js
@@ -150,7 +150,7 @@ function page(rows, error, notice) {
   .hint{font-size:.75rem;color:var(--muted);margin:.3rem 0 1rem}
 </style></head>
 <body>
-  <header><h1>Trainers</h1><a href="/admin/enrollments">Enrolments</a><a href="/admin/trainers">Trainers</a><a href="/admin/batches">Batches</a><a href="/admin">Enquiries →</a></header>
+  <header><h1>Trainers</h1><a href="/admin/enrollments">Enrolments</a><a href="/admin/trainers">Trainers</a><a href="/admin/batches">Batches</a><a href="/admin/founder">Founder</a><a href="/admin">Enquiries →</a></header>
   <div class="wrap">
     ${error ? `<div class="banner err">${escapeHtml(error)}</div>` : ""}
     ${notice ? `<div class="banner ok">${escapeHtml(notice)}</div>` : ""}

--- a/functions/api/founder.js
+++ b/functions/api/founder.js
@@ -1,0 +1,25 @@
+// GET /api/founder — public. Returns the founder/About content from D1 (edited at
+// /admin/founder). Returns {} when there's no active founder set, so the site
+// hides the About page entirely until Uday's team fills it in.
+// Fails soft: any error → {}.
+export async function onRequestGet(context) {
+  const { env } = context;
+  if (!env.DB) return json({});
+  try {
+    const row = await env.DB.prepare(
+      "SELECT name, title, tagline, intro, story, mission, vision, photo_url, linkedin_url " +
+        "FROM founder WHERE id = 1 AND status = 'active'"
+    ).first();
+    // Hidden, unset, or blank name → treat as "no founder page".
+    if (!row || !String(row.name || "").trim()) return json({});
+    return json(row);
+  } catch {
+    return json({});
+  }
+}
+
+function json(body) {
+  return new Response(JSON.stringify(body), {
+    headers: { "content-type": "application/json", "cache-control": "public, max-age=60" },
+  });
+}

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url><loc>https://restcoderacademy.in/</loc><changefreq>weekly</changefreq><priority>1.0</priority></url>
+  <url><loc>https://restcoderacademy.in/about</loc><changefreq>monthly</changefreq><priority>0.8</priority></url>
   <url><loc>https://restcoderacademy.in/for-parents</loc><changefreq>monthly</changefreq><priority>0.9</priority></url>
   <url><loc>https://restcoderacademy.in/courses/forward-deployed-engineering</loc><changefreq>weekly</changefreq><priority>0.9</priority></url>
   <url><loc>https://restcoderacademy.in/courses/java-full-stack</loc><changefreq>weekly</changefreq><priority>0.8</priority></url>

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url><loc>https://restcoderacademy.in/</loc><changefreq>weekly</changefreq><priority>1.0</priority></url>
-  <url><loc>https://restcoderacademy.in/about</loc><changefreq>monthly</changefreq><priority>0.8</priority></url>
   <url><loc>https://restcoderacademy.in/for-parents</loc><changefreq>monthly</changefreq><priority>0.9</priority></url>
   <url><loc>https://restcoderacademy.in/courses/forward-deployed-engineering</loc><changefreq>weekly</changefreq><priority>0.9</priority></url>
   <url><loc>https://restcoderacademy.in/courses/java-full-stack</loc><changefreq>weekly</changefreq><priority>0.8</priority></url>

--- a/schema-founder.sql
+++ b/schema-founder.sql
@@ -1,0 +1,21 @@
+-- Founder / About content, edited at /admin/founder (no code change, no redeploy).
+-- A single row (id = 1). The public site fetches it from /api/founder and hides
+-- the About page entirely until a name is set (same "fill it in yourself, empty
+-- doesn't show" model as trainers).
+CREATE TABLE IF NOT EXISTS founder (
+  id         INTEGER PRIMARY KEY,          -- always 1
+  name       TEXT NOT NULL DEFAULT '',     -- page is hidden while this is empty
+  title      TEXT NOT NULL DEFAULT '',     -- e.g. "Founder", "Founder & Lead Trainer"
+  tagline    TEXT NOT NULL DEFAULT '',     -- the big headline (H1)
+  intro      TEXT NOT NULL DEFAULT '',     -- short hero paragraph
+  story      TEXT NOT NULL DEFAULT '',     -- the main narrative; blank lines = new paragraphs
+  mission    TEXT NOT NULL DEFAULT '',
+  vision     TEXT NOT NULL DEFAULT '',
+  photo_url  TEXT NOT NULL DEFAULT '',
+  linkedin_url TEXT NOT NULL DEFAULT '',
+  status     TEXT NOT NULL DEFAULT 'active', -- 'active' shows the page, 'hidden' takes it down
+  updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+-- Seed the single empty row so the admin editor always has something to edit.
+INSERT OR IGNORE INTO founder (id, name) VALUES (1, '');

--- a/scripts/prerender.mjs
+++ b/scripts/prerender.mjs
@@ -19,6 +19,7 @@ const HOST = "127.0.0.1";
 const routes = [
   { path: "/", out: "index.html", waitFor: "#Courses" },
   { path: "/for-parents", out: "for-parents.html", waitFor: "main.fp" },
+  { path: "/about", out: "about.html", waitFor: "main.ab" },
   ...courses.map((c) => {
     const slug = c.slug || c.courseId;
     // Flat `.html` (not `<slug>/index.html`) so Cloudflare Pages serves the

--- a/scripts/prerender.mjs
+++ b/scripts/prerender.mjs
@@ -19,7 +19,9 @@ const HOST = "127.0.0.1";
 const routes = [
   { path: "/", out: "index.html", waitFor: "#Courses" },
   { path: "/for-parents", out: "for-parents.html", waitFor: "main.fp" },
-  { path: "/about", out: "about.html", waitFor: "main.ab" },
+  // /about is intentionally NOT prerendered: it's admin-managed (/api/founder)
+  // and hides itself until content exists, so there's nothing static to snapshot.
+  // It renders client-side (Googlebot executes JS) once a founder is set.
   ...courses.map((c) => {
     const slug = c.slug || c.courseId;
     // Flat `.html` (not `<slug>/index.html`) so Cloudflare Pages serves the

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6,6 +6,7 @@ import Banner from './components/organism/Banner/Banner'
 import Home from "./components/Pages/Home";
 import CourseDetail from "./components/Pages/CourseDetail";
 import ForParents from "./components/Pages/ForParents";
+import About from "./components/Pages/About";
 import ScrollToTop from "./components/ScrollToTop";
 import Modal from 'react-modal';
 import EnquiryForm from './components/forms/Enquiry Form/EnquiryForm';
@@ -81,6 +82,7 @@ function App() {
         <Route path="/" element={<Home />} />
         <Route path="/courses/:slug" element={<CourseDetail />} />
         <Route path="/for-parents" element={<ForParents />} />
+        <Route path="/about" element={<About />} />
         <Route path="*" element={<Navigate to="/" replace />} />
       </Routes>
       <FloatingIcons/>

--- a/src/components/Pages/About.css
+++ b/src/components/Pages/About.css
@@ -1,0 +1,94 @@
+/* Founder / About page. Shared design tokens; below the fixed navbar. */
+.ab {
+  max-width: 820px;
+  margin: 0 auto;
+  padding: 92px 20px 72px;
+  font-family: var(--rca-font, "Montserrat", "Segoe UI", system-ui, sans-serif);
+  color: #1b2230;
+}
+.ab h2 { font-size: 13px; letter-spacing: 0.11em; text-transform: uppercase; color: var(--rca-blue, #146389); margin: 0 0 12px; }
+.ab p { font-size: 16px; line-height: 1.7; color: #37424f; }
+
+/* Hero */
+.ab-hero {
+  display: flex;
+  flex-direction: column-reverse;
+  gap: 24px;
+  background: linear-gradient(155deg, var(--rca-navy, #03084c) 0%, #070d3a 100%);
+  color: #fff;
+  border-radius: var(--rca-radius-lg, 12px);
+  padding: 34px 32px;
+  box-shadow: 0 14px 36px rgba(3, 8, 76, 0.14);
+}
+@media (min-width: 680px) { .ab-hero { flex-direction: row; align-items: center; } }
+.ab-hero-text { flex: 1; }
+.ab-eyebrow {
+  display: inline-block;
+  background: rgba(255, 152, 0, 0.16); color: #ffb74d;
+  font-size: 11px; font-weight: 700; letter-spacing: 0.11em; text-transform: uppercase;
+  padding: 5px 12px; border-radius: 999px; margin-bottom: 16px;
+}
+.ab-hero h1 {
+  margin: 0 0 14px;
+  font-size: clamp(25px, 4.2vw, 36px);
+  font-weight: 800; line-height: 1.14; letter-spacing: -0.02em; text-wrap: balance;
+}
+.ab-hero p { color: #c3caf0; font-size: 15.5px; margin: 0; }
+
+/* Photo / avatar */
+.ab-photo { flex-shrink: 0; display: flex; flex-direction: column; align-items: center; gap: 10px; }
+.ab-photo img {
+  width: 150px; height: 150px; object-fit: cover; border-radius: 18px;
+  border: 3px solid rgba(255, 255, 255, 0.15);
+}
+.ab-avatar {
+  width: 150px; height: 150px; border-radius: 18px;
+  background: var(--rca-blue, #146389); color: #fff;
+  display: flex; align-items: center; justify-content: center;
+  font-size: 48px; font-weight: 800; letter-spacing: 1px;
+}
+.ab-photo-name { display: flex; flex-direction: column; align-items: center; font-size: 14px; font-weight: 700; color: #fff; }
+.ab-photo-name small { font-size: 12px; font-weight: 500; color: #8e96c8; margin-top: 2px; }
+
+/* Story blocks */
+.ab-block { margin-top: 34px; }
+
+/* Inline link */
+.ab-inline-link {
+  display: inline-block; margin-top: 10px;
+  font-size: 14px; font-weight: 600; color: var(--rca-blue, #146389); text-decoration: none;
+}
+.ab-inline-link:hover { text-decoration: underline; }
+
+/* Mission / Vision */
+.ab-values { display: grid; grid-template-columns: 1fr; gap: 14px; margin-top: 40px; }
+@media (min-width: 620px) { .ab-values { grid-template-columns: 1fr 1fr; } }
+.ab-value {
+  background: #f5f7fb; border: 1px solid #e6e9f2; border-top: 4px solid var(--rca-navy, #03084c);
+  border-radius: var(--rca-radius-md, 8px); padding: 20px 22px;
+}
+.ab-value-label {
+  display: block; font-size: 11px; font-weight: 700; letter-spacing: 0.1em; text-transform: uppercase;
+  color: var(--rca-blue, #146389); margin-bottom: 8px;
+}
+.ab-value p { margin: 0; font-size: 14.5px; line-height: 1.6; color: #37424f; }
+
+/* Sign-off */
+.ab-signoff {
+  margin-top: 40px; text-align: center;
+  background: #f5f7fb; border: 1px solid #e6e9f2; border-radius: var(--rca-radius-lg, 12px);
+  padding: 34px 24px;
+}
+.ab-signoff p { margin: 0 auto 12px; max-width: 52ch; }
+.ab-sign { display: block; font-weight: 700; color: var(--rca-navy, #03084c); margin-bottom: 22px; }
+.ab-cta { display: flex; flex-wrap: wrap; gap: 12px; justify-content: center; }
+.ab-btn {
+  font-family: inherit; font-size: 15.5px; font-weight: 600;
+  height: 48px; padding: 0 26px; border: none; border-radius: var(--rca-radius-md, 8px);
+  background: var(--rca-navy, #03084c); color: #fff; cursor: pointer;
+  text-decoration: none; display: inline-flex; align-items: center;
+  transition: transform 0.12s ease, box-shadow 0.12s ease;
+}
+.ab-btn:hover { transform: translateY(-1px); box-shadow: 0 6px 18px rgba(3, 8, 76, 0.18); }
+.ab-btn--ghost { background: transparent; color: var(--rca-navy, #03084c); border: 1px solid var(--line-2, #d0d7e6); }
+.ab-btn--ghost:hover { box-shadow: none; transform: none; background: #eef2f9; }

--- a/src/components/Pages/About.jsx
+++ b/src/components/Pages/About.jsx
@@ -1,0 +1,118 @@
+import React from "react";
+import { Link } from "react-router-dom";
+import { useAuth } from "../../App";
+import "./About.css";
+
+const ORIGIN = "https://restcoderacademy.in";
+const FOUNDER = "Nikshep Kulli";
+// TODO: replace the initials avatar with a real photo — drop the file in
+// src/assets and set PHOTO to the import, or a /public path.
+const PHOTO = null;
+
+function initials(name) {
+  return name.split(/\s+/).filter(Boolean).slice(0, 2).map((w) => w[0]).join("").toUpperCase();
+}
+
+function About() {
+  const { openModal } = useAuth();
+  const url = `${ORIGIN}/about`;
+  const description =
+    `${FOUNDER}, founder of Rest Coder Academy and a former Head of Engineering, on why he built ` +
+    `a coding academy around shipping real production software — and full accountability to students and their families.`;
+
+  const jsonLd = {
+    "@context": "https://schema.org",
+    "@type": "Person",
+    name: FOUNDER,
+    jobTitle: "Founder, Rest Coder Academy",
+    description,
+    url,
+    worksFor: { "@type": "EducationalOrganization", name: "Rest Coder Academy", sameAs: `${ORIGIN}/` },
+    sameAs: ["https://www.linkedin.com/in/nikshepkulli"],
+  };
+
+  return (
+    <>
+      <title>{`About the Founder — ${FOUNDER} | Rest Coder Academy`}</title>
+      <meta name="description" content={description} />
+      <link rel="canonical" href={url} />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }} />
+
+      <main className="ab">
+        <header className="ab-hero">
+          <div className="ab-hero-text">
+            <span className="ab-eyebrow">The founder</span>
+            <h1>The academy I wish existed when I was learning to code.</h1>
+            <p>
+              I'm {FOUNDER} — an engineer, a former Head of Engineering, and the founder of
+              Rest Coder Academy. I started it to train people the way I train the engineers on my
+              own teams: build real things, ship them to production, and be accountable for the
+              outcome.
+            </p>
+          </div>
+          <div className="ab-photo">
+            {PHOTO ? (
+              <img src={PHOTO} alt={`${FOUNDER}, founder of Rest Coder Academy`} />
+            ) : (
+              <span className="ab-avatar" aria-hidden="true">{initials(FOUNDER)}</span>
+            )}
+            <span className="ab-photo-name">{FOUNDER}<small>Founder</small></span>
+          </div>
+        </header>
+
+        <section className="ab-block">
+          <h2>Where I come from</h2>
+          <p>
+            I've spent my career building and leading engineering — including as Head of Engineering
+            for a 21-store omnichannel retail business, and running an engineering practice that ships
+            production software for startups. I've hired engineers, and more importantly, I've grown
+            junior people into engineers who can own real systems. That's the part I love most.
+          </p>
+        </section>
+
+        <section className="ab-block">
+          <h2>What I kept seeing</h2>
+          <p>
+            Too many coding institutes sell a certificate. They teach theory, run you through
+            exercises, take the fee — and then go quiet. Students finish without ever shipping
+            something real, families have no idea whether it's working, and the job at the end never
+            quite shows up. I watched capable people lose months and money to that, and it bothered me.
+          </p>
+        </section>
+
+        <section className="ab-block">
+          <h2>So I built it differently</h2>
+          <p>
+            Rest Coder Academy teaches the way I actually train engineers: live cohorts, real
+            projects, shipping to production — not slideware. And it's built on something no other
+            institute does — <b>accountability to your family</b>. Guardians see progress, scores and
+            attendance every week, so nobody is left guessing whether the investment is paying off.
+          </p>
+          <Link className="ab-inline-link" to="/for-parents">See how accountability works for parents →</Link>
+        </section>
+
+        <div className="ab-values">
+          <div className="ab-value">
+            <span className="ab-value-label">Mission</span>
+            <p>Turn out production-ready engineers — not certificate-holders — with complete transparency to the students and families investing in them.</p>
+          </div>
+          <div className="ab-value">
+            <span className="ab-value-label">Vision</span>
+            <p>A place where every learner, and the family behind them, has real visibility and real outcomes — a job at the end, earned on real work.</p>
+          </div>
+        </div>
+
+        <section className="ab-signoff">
+          <p>If that's the kind of learning you want — for yourself or your child — I'd love to have you.</p>
+          <span className="ab-sign">— {FOUNDER}, Founder</span>
+          <div className="ab-cta">
+            <button className="ab-btn" type="button" onClick={openModal}>Talk to a counsellor</button>
+            <Link className="ab-btn ab-btn--ghost" to="/">See our courses</Link>
+          </div>
+        </section>
+      </main>
+    </>
+  );
+}
+
+export default About;

--- a/src/components/Pages/About.jsx
+++ b/src/components/Pages/About.jsx
@@ -1,39 +1,48 @@
 import React from "react";
-import { Link } from "react-router-dom";
+import { Link, Navigate } from "react-router-dom";
 import { useAuth } from "../../App";
+import { useFounder, hasFounder } from "./useFounder";
 import "./About.css";
 
 const ORIGIN = "https://restcoderacademy.in";
-const FOUNDER = "Nikshep Kulli";
-// TODO: replace the initials avatar with a real photo — drop the file in
-// src/assets and set PHOTO to the import, or a /public path.
-const PHOTO = null;
 
 function initials(name) {
   return name.split(/\s+/).filter(Boolean).slice(0, 2).map((w) => w[0]).join("").toUpperCase();
 }
+function paragraphs(text) {
+  return String(text || "").split(/\n\s*\n/).map((p) => p.trim()).filter(Boolean);
+}
 
+// The founder / About page is entirely admin-managed (/admin/founder → D1 →
+// /api/founder). It hides itself until a founder name is set, so nothing
+// placeholder or wrong is ever shown.
 function About() {
   const { openModal } = useAuth();
+  const { founder, loaded } = useFounder();
+
+  if (!loaded) return null; // brief: waiting on /api/founder
+  if (!hasFounder(founder)) return <Navigate to="/" replace />;
+
+  const { name, title, tagline, intro, story, mission, vision, photo_url, linkedin_url } = founder;
   const url = `${ORIGIN}/about`;
-  const description =
-    `${FOUNDER}, founder of Rest Coder Academy and a former Head of Engineering, on why he built ` +
-    `a coding academy around shipping real production software — and full accountability to students and their families.`;
+  const heading = String(tagline || "").trim() || `${name} — ${title || "Founder"} of Rest Coder Academy`;
+  const description = String(intro || "").trim() || `${name}, ${title || "founder"} of Rest Coder Academy.`;
+  const body = paragraphs(story);
 
   const jsonLd = {
     "@context": "https://schema.org",
     "@type": "Person",
-    name: FOUNDER,
-    jobTitle: "Founder, Rest Coder Academy",
+    name,
+    jobTitle: title || "Founder, Rest Coder Academy",
     description,
     url,
     worksFor: { "@type": "EducationalOrganization", name: "Rest Coder Academy", sameAs: `${ORIGIN}/` },
-    sameAs: ["https://www.linkedin.com/in/nikshepkulli"],
+    ...(linkedin_url ? { sameAs: [linkedin_url] } : {}),
   };
 
   return (
     <>
-      <title>{`About the Founder — ${FOUNDER} | Rest Coder Academy`}</title>
+      <title>{`About ${name} — Rest Coder Academy`}</title>
       <meta name="description" content={description} />
       <link rel="canonical" href={url} />
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }} />
@@ -42,72 +51,55 @@ function About() {
         <header className="ab-hero">
           <div className="ab-hero-text">
             <span className="ab-eyebrow">The founder</span>
-            <h1>The academy I wish existed when I was learning to code.</h1>
-            <p>
-              I'm {FOUNDER} — an engineer, a former Head of Engineering, and the founder of
-              Rest Coder Academy. I started it to train people the way I train the engineers on my
-              own teams: build real things, ship them to production, and be accountable for the
-              outcome.
-            </p>
+            <h1>{heading}</h1>
+            {intro && <p>{intro}</p>}
           </div>
           <div className="ab-photo">
-            {PHOTO ? (
-              <img src={PHOTO} alt={`${FOUNDER}, founder of Rest Coder Academy`} />
+            {photo_url ? (
+              <img src={photo_url} alt={`${name}, founder of Rest Coder Academy`} />
             ) : (
-              <span className="ab-avatar" aria-hidden="true">{initials(FOUNDER)}</span>
+              <span className="ab-avatar" aria-hidden="true">{initials(name)}</span>
             )}
-            <span className="ab-photo-name">{FOUNDER}<small>Founder</small></span>
+            <span className="ab-photo-name">
+              {name}
+              <small>{title || "Founder"}</small>
+            </span>
           </div>
         </header>
 
-        <section className="ab-block">
-          <h2>Where I come from</h2>
-          <p>
-            I've spent my career building and leading engineering — including as Head of Engineering
-            for a 21-store omnichannel retail business, and running an engineering practice that ships
-            production software for startups. I've hired engineers, and more importantly, I've grown
-            junior people into engineers who can own real systems. That's the part I love most.
-          </p>
-        </section>
+        {body.length > 0 && (
+          <section className="ab-block">
+            {body.map((p, i) => (
+              <p key={i}>{p}</p>
+            ))}
+          </section>
+        )}
 
-        <section className="ab-block">
-          <h2>What I kept seeing</h2>
-          <p>
-            Too many coding institutes sell a certificate. They teach theory, run you through
-            exercises, take the fee — and then go quiet. Students finish without ever shipping
-            something real, families have no idea whether it's working, and the job at the end never
-            quite shows up. I watched capable people lose months and money to that, and it bothered me.
-          </p>
-        </section>
-
-        <section className="ab-block">
-          <h2>So I built it differently</h2>
-          <p>
-            Rest Coder Academy teaches the way I actually train engineers: live cohorts, real
-            projects, shipping to production — not slideware. And it's built on something no other
-            institute does — <b>accountability to your family</b>. Guardians see progress, scores and
-            attendance every week, so nobody is left guessing whether the investment is paying off.
-          </p>
-          <Link className="ab-inline-link" to="/for-parents">See how accountability works for parents →</Link>
-        </section>
-
-        <div className="ab-values">
-          <div className="ab-value">
-            <span className="ab-value-label">Mission</span>
-            <p>Turn out production-ready engineers — not certificate-holders — with complete transparency to the students and families investing in them.</p>
+        {(mission || vision) && (
+          <div className="ab-values">
+            {mission && (
+              <div className="ab-value">
+                <span className="ab-value-label">Mission</span>
+                <p>{mission}</p>
+              </div>
+            )}
+            {vision && (
+              <div className="ab-value">
+                <span className="ab-value-label">Vision</span>
+                <p>{vision}</p>
+              </div>
+            )}
           </div>
-          <div className="ab-value">
-            <span className="ab-value-label">Vision</span>
-            <p>A place where every learner, and the family behind them, has real visibility and real outcomes — a job at the end, earned on real work.</p>
-          </div>
-        </div>
+        )}
 
         <section className="ab-signoff">
-          <p>If that's the kind of learning you want — for yourself or your child — I'd love to have you.</p>
-          <span className="ab-sign">— {FOUNDER}, Founder</span>
+          <span className="ab-sign">— {name}, {title || "Founder"}</span>
           <div className="ab-cta">
             <button className="ab-btn" type="button" onClick={openModal}>Talk to a counsellor</button>
             <Link className="ab-btn ab-btn--ghost" to="/">See our courses</Link>
+            {linkedin_url && (
+              <a className="ab-btn ab-btn--ghost" href={linkedin_url} target="_blank" rel="noopener noreferrer">LinkedIn</a>
+            )}
           </div>
         </section>
       </main>

--- a/src/components/Pages/useFounder.js
+++ b/src/components/Pages/useFounder.js
@@ -1,0 +1,47 @@
+import { useEffect, useState } from "react";
+
+// Reads the founder / About content from /api/founder (D1, editable at
+// /admin/founder). Returns { founder, loaded } — founder is {} when nothing is
+// set (the About page then hides itself). Cached at module level.
+let cache = null; // the founder object, or {} once we know there is none
+let inflight = null;
+
+function loadFounder() {
+  if (cache) return Promise.resolve(cache);
+  if (!inflight) {
+    inflight = fetch("/api/founder")
+      .then((r) => (r.ok ? r.json() : {}))
+      .then((data) => {
+        cache = data && typeof data === "object" ? data : {};
+        return cache;
+      })
+      .catch(() => {
+        cache = {};
+        return cache;
+      });
+  }
+  return inflight;
+}
+
+export function useFounder() {
+  const [founder, setFounder] = useState(cache || null);
+  const [loaded, setLoaded] = useState(!!cache);
+  useEffect(() => {
+    let cancelled = false;
+    loadFounder().then((data) => {
+      if (!cancelled) {
+        setFounder(data);
+        setLoaded(true);
+      }
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+  return { founder: founder || {}, loaded };
+}
+
+// True when there's a real founder to show (a name is set).
+export function hasFounder(founder) {
+  return !!(founder && String(founder.name || "").trim());
+}

--- a/src/components/organism/courses/CourseCard.css
+++ b/src/components/organism/courses/CourseCard.css
@@ -74,6 +74,15 @@
 .cc-trainer-text { display: flex; flex-direction: column; line-height: 1.35; }
 .cc-trainer-text b { font-size: 13px; font-weight: 600; }
 .cc-trainer-text span { font-size: 11.5px; color: #8e96c8; }
+.cc-founder-link {
+  display: inline-block;
+  margin-top: 12px;
+  font-size: 12.5px;
+  font-weight: 600;
+  color: #ffb74d;
+  text-decoration: none;
+}
+.cc-founder-link:hover { text-decoration: underline; }
 
 /* --- Body --- */
 .cc-body {

--- a/src/components/organism/courses/CoursesCard.jsx
+++ b/src/components/organism/courses/CoursesCard.jsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { Link } from "react-router-dom";
 import { useAuth } from "../../../App";
+import { useFounder, hasFounder } from "../../Pages/useFounder";
 import { useBatches } from "../Batches/useBatches";
 import { getNextBatchForCourse, formatBatchDateShort } from "../Batches/batchDateUtils";
 import "./CourseCard.css";
@@ -27,6 +28,7 @@ function Check({ filled }) {
 // equal heights, and "Book your seat" + a counsellor secondary (Abhigna's flow).
 function CoursesCard({ name, courseId, slug, paid, flagship, price, trainer, audience, backend, frontend, syllabus1, syllabus2 }) {
   const { openEnroll, openModal } = useAuth();
+  const { founder } = useFounder();
   const batches = useBatches();
   const nextBatch = getNextBatchForCourse(name, batches);
   const modules = (
@@ -58,7 +60,7 @@ function CoursesCard({ name, courseId, slug, paid, flagship, price, trainer, aud
             </span>
           </div>
         )}
-        {flagship && (
+        {flagship && hasFounder(founder) && (
           <Link className="cc-founder-link" to="/about">Meet the founder →</Link>
         )}
       </div>

--- a/src/components/organism/courses/CoursesCard.jsx
+++ b/src/components/organism/courses/CoursesCard.jsx
@@ -58,6 +58,9 @@ function CoursesCard({ name, courseId, slug, paid, flagship, price, trainer, aud
             </span>
           </div>
         )}
+        {flagship && (
+          <Link className="cc-founder-link" to="/about">Meet the founder →</Link>
+        )}
       </div>
 
       <div className="cc-body">


### PR DESCRIPTION
Reworks /about to be **admin-managed** (same pattern as trainers) so Uday's team fills the founder story themselves — nobody's story is hardcoded. `founder` D1 table + `GET /api/founder` (returns {} → page hidden until a name is set) + `/admin/founder` Basic-Auth editor (linked from every admin nav). About.jsx renders only the filled fields and redirects home when empty, so the page doesn't exist until content is added; the flagship "Meet the founder" link is gated the same way. Not prerendered/in sitemap (dynamic + hidden until filled). Schema applied to D1. 64 tests pass. Closes #76.