### PR TITLE
feat(courses): "Taught by" block with photo on every course card

### DIFF
--- a/src/components/organism/courses/CourseCard.css
+++ b/src/components/organism/courses/CourseCard.css
@@ -63,6 +63,7 @@
   height: 36px;
   flex-shrink: 0;
   border-radius: 999px;
+  overflow: hidden;
   background: var(--rca-blue, #146389);
   color: #fff;
   display: flex;
@@ -71,6 +72,7 @@
   font-size: 13px;
   font-weight: 700;
 }
+.cc-avatar img { width: 100%; height: 100%; object-fit: cover; display: block; }
 .cc-trainer-text { display: flex; flex-direction: column; line-height: 1.35; }
 .cc-trainer-text b { font-size: 13px; font-weight: 600; }
 .cc-trainer-text span { font-size: 11.5px; color: #8e96c8; }

--- a/src/components/organism/courses/CoursesCard.jsx
+++ b/src/components/organism/courses/CoursesCard.jsx
@@ -2,13 +2,16 @@ import React from "react";
 import { Link } from "react-router-dom";
 import { useAuth } from "../../../App";
 import { useFounder, hasFounder } from "../../Pages/useFounder";
+import { useTrainers } from "../mentors/useTrainers";
 import { useBatches } from "../Batches/useBatches";
 import { getNextBatchForCourse, formatBatchDateShort } from "../Batches/batchDateUtils";
 import "./CourseCard.css";
 
-// FDE-only credibility line under the trainer name.
+// Credibility line under the flagship trainer's name (Nikshep). Other courses
+// use the trainer's own profile title.
 const FDE_TRAINER_TITLE = "ex-Head of Engineering, Organic Mandya";
 
+const norm = (s) => String(s || "").trim().toLowerCase();
 function initials(name = "") {
   return name.split(/\s+/).filter(Boolean).slice(0, 2).map((w) => w[0]).join("").toUpperCase();
 }
@@ -29,8 +32,14 @@ function Check({ filled }) {
 function CoursesCard({ name, courseId, slug, paid, flagship, price, trainer, audience, backend, frontend, syllabus1, syllabus2 }) {
   const { openEnroll, openModal } = useAuth();
   const { founder } = useFounder();
+  const trainers = useTrainers();
   const batches = useBatches();
   const nextBatch = getNextBatchForCourse(name, batches);
+
+  // Match the course's trainer to a full profile (photo + title) so every card
+  // shows a "Taught by …" credibility block, not just the flagship.
+  const trainerProfile = trainer ? (trainers || []).find((t) => norm(t.name) === norm(trainer)) : null;
+  const trainerTitle = flagship ? FDE_TRAINER_TITLE : (trainerProfile && trainerProfile.title) || "";
   const modules = (
     flagship ? [...(syllabus1 || []), ...(syllabus2 || [])] : [...(backend || []), ...(frontend || [])]
   ).filter(Boolean);
@@ -51,12 +60,18 @@ function CoursesCard({ name, courseId, slug, paid, flagship, price, trainer, aud
         )}
         <h3 className="cc-title">{name}</h3>
         <p className="cc-sub">{audience || "For Freshers & Working Professionals"}</p>
-        {flagship && trainer && (
+        {trainer && (
           <div className="cc-trainer">
-            <span className="cc-avatar">{initials(trainer)}</span>
+            <span className="cc-avatar">
+              {trainerProfile && trainerProfile.photo_url ? (
+                <img src={trainerProfile.photo_url} alt={trainer} />
+              ) : (
+                initials(trainer)
+              )}
+            </span>
             <span className="cc-trainer-text">
               <b>Taught by {trainer}</b>
-              <span>{FDE_TRAINER_TITLE}</span>
+              {trainerTitle && <span>{trainerTitle}</span>}
             </span>
           </div>
         )}
@@ -84,7 +99,7 @@ function CoursesCard({ name, courseId, slug, paid, flagship, price, trainer, aud
                 {[nextBatch.day, formatBatchDateShort(nextBatch.date), nextBatch.time].filter(Boolean).join(" · ")}
               </span>
               <span className="cc-sched-meta">
-                {[nextBatch.mode, nextBatch.duration, nextBatch.trainer && `Trainer: ${nextBatch.trainer}`].filter(Boolean).join(" · ")}
+                {[nextBatch.mode, nextBatch.duration].filter(Boolean).join(" · ")}
               </span>
             </>
           ) : (


### PR DESCRIPTION
Every homepage course card now shows a 'Taught by <trainer>' block with the trainer's photo + title (from /admin/trainers), not just the flagship. Removed the redundant 'Trainer:' from the schedule line. 64 tests pass. Closes #95.