### PR TITLE
feat(contact): add /contact page with NAP + LocalBusiness schema (#81)

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -2,6 +2,7 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url><loc>https://restcoderacademy.in/</loc><changefreq>weekly</changefreq><priority>1.0</priority></url>
   <url><loc>https://restcoderacademy.in/for-parents</loc><changefreq>monthly</changefreq><priority>0.9</priority></url>
+  <url><loc>https://restcoderacademy.in/contact</loc><changefreq>monthly</changefreq><priority>0.7</priority></url>
   <url><loc>https://restcoderacademy.in/courses/forward-deployed-engineering</loc><changefreq>weekly</changefreq><priority>0.9</priority></url>
   <url><loc>https://restcoderacademy.in/courses/java-full-stack</loc><changefreq>weekly</changefreq><priority>0.8</priority></url>
   <url><loc>https://restcoderacademy.in/courses/python-full-stack</loc><changefreq>weekly</changefreq><priority>0.8</priority></url>

--- a/scripts/prerender.mjs
+++ b/scripts/prerender.mjs
@@ -19,6 +19,7 @@ const HOST = "127.0.0.1";
 const routes = [
   { path: "/", out: "index.html", waitFor: "#Courses" },
   { path: "/for-parents", out: "for-parents.html", waitFor: "main.fp" },
+  { path: "/contact", out: "contact.html", waitFor: "main.ct" },
   // /about is intentionally NOT prerendered: it's admin-managed (/api/founder)
   // and hides itself until content exists, so there's nothing static to snapshot.
   // It renders client-side (Googlebot executes JS) once a founder is set.

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -7,6 +7,7 @@ import Home from "./components/Pages/Home";
 import CourseDetail from "./components/Pages/CourseDetail";
 import ForParents from "./components/Pages/ForParents";
 import About from "./components/Pages/About";
+import Contact from "./components/Pages/Contact";
 import ScrollToTop from "./components/ScrollToTop";
 import Modal from 'react-modal';
 import EnquiryForm from './components/forms/Enquiry Form/EnquiryForm';
@@ -83,6 +84,7 @@ function App() {
         <Route path="/courses/:slug" element={<CourseDetail />} />
         <Route path="/for-parents" element={<ForParents />} />
         <Route path="/about" element={<About />} />
+        <Route path="/contact" element={<Contact />} />
         <Route path="*" element={<Navigate to="/" replace />} />
       </Routes>
       <FloatingIcons/>

--- a/src/components/Pages/Contact.css
+++ b/src/components/Pages/Contact.css
@@ -1,0 +1,80 @@
+/* Contact / location page. Shared design tokens; below the fixed navbar. */
+.ct {
+  max-width: 860px;
+  margin: 0 auto;
+  padding: 92px 20px 72px;
+  font-family: var(--rca-font, "Montserrat", "Segoe UI", system-ui, sans-serif);
+  color: #1b2230;
+}
+.ct h2 { font-size: clamp(21px, 3vw, 26px); font-weight: 800; letter-spacing: -0.01em; color: var(--rca-navy, #03084c); margin: 0 0 12px; }
+.ct p { font-size: 15.5px; line-height: 1.65; color: #37424f; }
+
+/* Hero */
+.ct-hero {
+  background: linear-gradient(155deg, var(--rca-navy, #03084c) 0%, #070d3a 100%);
+  color: #fff;
+  border-radius: var(--rca-radius-lg, 12px);
+  padding: 40px 34px 34px;
+  box-shadow: 0 14px 36px rgba(3, 8, 76, 0.14);
+}
+.ct-eyebrow {
+  display: inline-block;
+  background: rgba(255, 152, 0, 0.16);
+  color: #ffb74d;
+  font-size: 11px; font-weight: 700; letter-spacing: 0.11em; text-transform: uppercase;
+  padding: 5px 12px; border-radius: 999px; margin-bottom: 16px;
+}
+.ct-hero h1 {
+  margin: 0 0 14px;
+  font-size: clamp(27px, 4.6vw, 40px);
+  font-weight: 800; line-height: 1.12; letter-spacing: -0.02em; text-wrap: balance;
+}
+.ct-hero p { color: #c3caf0; font-size: 16px; margin: 0; max-width: 60ch; }
+.ct-cta { display: flex; flex-wrap: wrap; gap: 12px; margin-top: 26px; }
+.ct-btn {
+  font-family: inherit; font-size: 15.5px; font-weight: 600;
+  height: 48px; padding: 0 26px; border: none; border-radius: var(--rca-radius-md, 8px);
+  background: #fff; color: var(--rca-navy, #03084c); cursor: pointer;
+  text-decoration: none; display: inline-flex; align-items: center;
+  transition: transform 0.12s ease, box-shadow 0.12s ease;
+}
+.ct-btn:hover { transform: translateY(-1px); box-shadow: 0 6px 18px rgba(0, 0, 0, 0.18); }
+.ct-btn--ghost { background: transparent; color: #fff; border: 1px solid rgba(255, 255, 255, 0.4); }
+.ct-btn--ghost:hover { background: rgba(255, 255, 255, 0.08); box-shadow: none; transform: none; }
+
+/* Address + phone/email cards */
+.ct-details { margin-top: 40px; display: grid; grid-template-columns: 1fr; gap: 14px; }
+@media (min-width: 620px) { .ct-details { grid-template-columns: 1fr 1fr; } }
+.ct-card {
+  background: #f5f7fb; border: 1px solid #e6e9f2; border-left: 4px solid var(--rca-blue, #146389);
+  border-radius: var(--rca-radius-md, 8px); padding: 20px 22px;
+}
+.ct-card h2 { font-size: 16px; margin: 0 0 6px; }
+.ct-card h2 + h2 { margin-top: 18px; }
+.ct-card p { margin: 0 0 4px; font-size: 14.5px; color: #45545d; }
+.ct-link { color: var(--rca-navy, #03084c); font-weight: 700; text-decoration: none; }
+.ct-link:hover { text-decoration: underline; }
+.ct-map-link { display: inline-block; margin-top: 10px; font-size: 14px; font-weight: 700; color: var(--rca-blue, #146389); text-decoration: none; }
+.ct-map-link:hover { text-decoration: underline; }
+
+/* Map CTA strip */
+.ct-map { margin-top: 24px; text-align: center; }
+.ct-map-cta {
+  display: inline-block; font-size: 14.5px; font-weight: 700;
+  color: var(--rca-navy, #03084c); text-decoration: none;
+  border: 1px solid #d0d7e6; border-radius: var(--rca-radius-md, 8px);
+  padding: 12px 22px;
+}
+.ct-map-cta:hover { background: #f5f7fb; }
+
+/* Closing */
+.ct-foot {
+  margin-top: 44px; text-align: center;
+  background: #f5f7fb; border: 1px solid #e6e9f2; border-radius: var(--rca-radius-lg, 12px);
+  padding: 34px 24px;
+}
+.ct-foot h2 { margin-bottom: 8px; }
+.ct-foot p { margin: 0 auto 22px; max-width: 52ch; }
+.ct-foot .ct-cta { justify-content: center; }
+.ct-foot .ct-btn { background: var(--rca-navy, #03084c); color: #fff; }
+.ct-foot .ct-btn--ghost { background: transparent; color: var(--rca-navy, #03084c); border: 1px solid var(--line-2, #d0d7e6); }

--- a/src/components/Pages/Contact.jsx
+++ b/src/components/Pages/Contact.jsx
@@ -1,0 +1,116 @@
+import React from "react";
+import { Link } from "react-router-dom";
+import { useAuth } from "../../App";
+import "./Contact.css";
+
+const ORIGIN = "https://restcoderacademy.in";
+const MAP_URL = "https://maps.app.goo.gl/XdZWt3oDzGUCL5KWA?g_st=iw";
+
+// Same NAP as the footer (FooterAddress.jsx / FooterLocation.jsx) — kept in
+// sync by hand since there's no shared data source for it yet.
+const ADDRESS = {
+  street: "#364, 3rd Floor, 16th Main, 4th T Block East, Pattabhirama Nagar, Jayanagar",
+  locality: "Bengaluru",
+  region: "Karnataka",
+  postalCode: "560041",
+  country: "IN",
+};
+const PHONE_DISPLAY = "+91 80737 62257";
+const PHONE_TEL = "+918073762257";
+const EMAIL = "enquiry@restcoderacademy.com";
+
+function Contact() {
+  const { openModal } = useAuth();
+  const url = `${ORIGIN}/contact`;
+  const fullAddress = `${ADDRESS.street}, ${ADDRESS.locality}, ${ADDRESS.region} ${ADDRESS.postalCode}`;
+  const description =
+    `Visit or call Rest Coder Academy in Jayanagar, Bengaluru — ${fullAddress}. ` +
+    `Phone ${PHONE_DISPLAY}, or reach us at ${EMAIL}.`;
+
+  const jsonLd = {
+    "@context": "https://schema.org",
+    "@type": "LocalBusiness",
+    name: "Rest Coder Academy",
+    image: `${ORIGIN}/favicon.png`,
+    url: ORIGIN,
+    telephone: PHONE_TEL,
+    email: EMAIL,
+    address: {
+      "@type": "PostalAddress",
+      streetAddress: ADDRESS.street,
+      addressLocality: ADDRESS.locality,
+      addressRegion: ADDRESS.region,
+      postalCode: ADDRESS.postalCode,
+      addressCountry: ADDRESS.country,
+    },
+    hasMap: MAP_URL,
+  };
+
+  return (
+    <>
+      <title>Contact Us — Rest Coder Academy, Jayanagar, Bengaluru</title>
+      <meta name="description" content={description} />
+      <link rel="canonical" href={url} />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }} />
+
+      <main className="ct">
+        <header className="ct-hero">
+          <span className="ct-eyebrow">Contact &amp; location</span>
+          <h1>Visit us in Jayanagar, or just call.</h1>
+          <p>
+            Offline classes, one campus, no call centre in between. If you'd rather talk first,
+            a counsellor can walk you through courses, fees and the next batch.
+          </p>
+          <div className="ct-cta">
+            <button className="ct-btn" type="button" onClick={openModal}>Talk to a counsellor</button>
+            <Link className="ct-btn ct-btn--ghost" to="/">See our courses</Link>
+          </div>
+        </header>
+
+        <section className="ct-details">
+          <div className="ct-card">
+            <h2>Address</h2>
+            <p>
+              #364, 3rd Floor, 16th Main
+              <br />
+              4th T Block East, Pattabhirama Nagar
+              <br />
+              Jayanagar, Bengaluru, Karnataka 560041
+            </p>
+            <a className="ct-map-link" href={MAP_URL} target="_blank" rel="noreferrer">
+              Get directions →
+            </a>
+          </div>
+
+          <div className="ct-card">
+            <h2>Phone</h2>
+            <p>
+              <a className="ct-link" href={`tel:${PHONE_TEL}`}>{PHONE_DISPLAY}</a>
+            </p>
+            <h2>Email</h2>
+            <p>
+              <a className="ct-link" href={`mailto:${EMAIL}`}>{EMAIL}</a>
+            </p>
+          </div>
+        </section>
+
+        <section className="ct-map">
+          <a className="ct-map-cta" href={MAP_URL} target="_blank" rel="noreferrer">
+            Open our location in Google Maps →
+          </a>
+        </section>
+
+        <section className="ct-foot">
+          <h2>Have a question first?</h2>
+          <p>Fees, EMI, batch timings, prerequisites — a counsellor can answer it in one call.</p>
+          <div className="ct-cta">
+            <button className="ct-btn" type="button" onClick={openModal}>Talk to a counsellor</button>
+            <Link className="ct-btn ct-btn--ghost" to="/for-parents">For parents</Link>
+          </div>
+        </section>
+      </main>
+    </>
+  );
+}
+
+export default Contact;

--- a/src/components/Pages/Contact.jsx
+++ b/src/components/Pages/Contact.jsx
@@ -30,6 +30,10 @@ function Contact() {
   const jsonLd = {
     "@context": "https://schema.org",
     "@type": "LocalBusiness",
+    // Same @id as the EducationalOrganization node in index.html, so this is
+    // read as the same entity (with address/contact detail) rather than a
+    // second, competing business on the same domain.
+    "@id": `${ORIGIN}/#org`,
     name: "Rest Coder Academy",
     image: `${ORIGIN}/favicon.png`,
     url: ORIGIN,
@@ -71,11 +75,9 @@ function Contact() {
           <div className="ct-card">
             <h2>Address</h2>
             <p>
-              #364, 3rd Floor, 16th Main
+              {ADDRESS.street}
               <br />
-              4th T Block East, Pattabhirama Nagar
-              <br />
-              Jayanagar, Bengaluru, Karnataka 560041
+              {ADDRESS.locality}, {ADDRESS.region} {ADDRESS.postalCode}
             </p>
             <a className="ct-map-link" href={MAP_URL} target="_blank" rel="noreferrer">
               Get directions →

--- a/src/components/molecules/Footer Components/FooterLinks.jsx
+++ b/src/components/molecules/Footer Components/FooterLinks.jsx
@@ -2,6 +2,7 @@ import React from 'react'
 import TypoGraphyComponent from '../../atoms/TypoGraphyComponent/TypoGraphyComponent'
 import { Box,List,ListItem,ListItemText } from '@mui/material'
 import { Link, animateScroll as scroll } from 'react-scroll';
+import { Link as RouterLink } from 'react-router-dom';
 
 
 function FooterLinks() {
@@ -32,7 +33,11 @@ function FooterLinks() {
               </ListItem>
           
               })}
-               
+              <ListItem>
+                <RouterLink to="/contact">
+                  <ListItemText primary="Contact" />
+                </RouterLink>
+              </ListItem>
           </List>
     </>
   )


### PR DESCRIPTION
## Summary

No contact/location page existed — every course card and CTA led to the same enquiry modal, and the address/phone/email were only reachable by scrolling to the footer. "Coding classes near me" style searches and Google Maps had nowhere real to send someone.

## What's added

- **`/contact`** — hero, an address card with a Google Maps deep link, phone (`tel:`) and email (`mailto:`) links, and a closing CTA into the enquiry modal or through to `/for-parents`.
- **`LocalBusiness` JSON-LD** on the page, using the same NAP already published in the footer (`FooterAddress.jsx`/`FooterLocation.jsx`) and in `index.html`'s `EducationalOrganization` block.
- Registered in **`scripts/prerender.mjs`** (`waitFor: "main.ct"`, matching the `CourseDetail`/`ForParents` convention) and in **`sitemap.xml`**.
- Linked from the footer's "Who Are We" list (`FooterLinks.jsx`) so the page is actually discoverable, not just reachable by typing the URL.

Google Business Profile claim/optimization is called out in the ticket as an owner action — out of scope here.

## Verification

- `npm run build` — succeeds
- `npm run lint` — 377 problems before and after (identical baseline, zero new issues)
- `npm test` — 64/64 pass
- Manually verified against the dev server via a headless Playwright check: correct per-route title/meta/canonical/JSON-LD (mirrors the same static-vs-per-route duplicate pattern `CourseDetail.jsx` already has, which the prerender step's `keepLast` logic collapses), clean `h1`→`h2` heading order, working `tel:`/`mailto:` links, and the new footer "Contact" link navigates to `/contact` correctly.

Fixes #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013g5dMJbYotQx9iLbYcjZvS