### PR TITLE
feat(courses): link "Taught by <trainer>" to the Our Trainers section

### DIFF
--- a/src/components/organism/courses/CourseCard.css
+++ b/src/components/organism/courses/CourseCard.css
@@ -76,6 +76,9 @@
 .cc-trainer-text { display: flex; flex-direction: column; line-height: 1.35; }
 .cc-trainer-text b { font-size: 13px; font-weight: 600; }
 .cc-trainer-text span { font-size: 11.5px; color: #8e96c8; }
+.cc-trainer--link { cursor: pointer; }
+.cc-trainer--link:hover .cc-trainer-text b { text-decoration: underline; }
+.cc-trainer--link:focus-visible { outline: 2px solid #ffb74d; outline-offset: 3px; border-radius: 6px; }
 .cc-founder-link {
   display: inline-block;
   margin-top: 12px;

--- a/src/components/organism/courses/CoursesCard.jsx
+++ b/src/components/organism/courses/CoursesCard.jsx
@@ -3,6 +3,7 @@ import { Link } from "react-router-dom";
 import { useAuth } from "../../../App";
 import { useFounder, hasFounder } from "../../Pages/useFounder";
 import { useTrainers } from "../mentors/useTrainers";
+import { scroller } from "react-scroll";
 import { useBatches } from "../Batches/useBatches";
 import { getNextBatchForCourse, formatBatchDateShort } from "../Batches/batchDateUtils";
 import "./CourseCard.css";
@@ -40,6 +41,25 @@ function CoursesCard({ name, courseId, slug, paid, flagship, price, trainer, aud
   // shows a "Taught by …" credibility block, not just the flagship.
   const trainerProfile = trainer ? (trainers || []).find((t) => norm(t.name) === norm(trainer)) : null;
   const trainerTitle = flagship ? FDE_TRAINER_TITLE : (trainerProfile && trainerProfile.title) || "";
+
+  // Clicking a trainer with a profile jumps to the "Our Trainers" section
+  // (their full card — photo, bio, expertise, socials). The card only ever
+  // renders on the homepage, so a direct scroll is enough.
+  const goToTrainers = () => scroller.scrollTo("Trainers", { smooth: true, offset: -62, duration: 400 });
+  const trainerLinkProps = trainerProfile
+    ? {
+        role: "link",
+        tabIndex: 0,
+        title: `See ${trainer}'s profile`,
+        onClick: goToTrainers,
+        onKeyDown: (e) => {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            goToTrainers();
+          }
+        },
+      }
+    : {};
   const modules = (
     flagship ? [...(syllabus1 || []), ...(syllabus2 || [])] : [...(backend || []), ...(frontend || [])]
   ).filter(Boolean);
@@ -61,7 +81,7 @@ function CoursesCard({ name, courseId, slug, paid, flagship, price, trainer, aud
         <h3 className="cc-title">{name}</h3>
         <p className="cc-sub">{audience || "For Freshers & Working Professionals"}</p>
         {trainer && (
-          <div className="cc-trainer">
+          <div className={"cc-trainer" + (trainerProfile ? " cc-trainer--link" : "")} {...trainerLinkProps}>
             <span className="cc-avatar">
               {trainerProfile && trainerProfile.photo_url ? (
                 <img src={trainerProfile.photo_url} alt={trainer} />


### PR DESCRIPTION
Clicking the 'Taught by <trainer>' block on a course card scrolls to that trainer's full profile in the Our Trainers section — only when a profile exists (never a dead link), keyboard-accessible. 64 tests pass. Closes #99.