### PR TITLE
feat(seo): blog + first two posts (content engine, #82)

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -12,4 +12,7 @@
   <url><loc>https://restcoderacademy.in/courses/java-full-stack</loc><changefreq>weekly</changefreq><priority>0.8</priority></url>
   <url><loc>https://restcoderacademy.in/courses/python-full-stack</loc><changefreq>weekly</changefreq><priority>0.8</priority></url>
   <url><loc>https://restcoderacademy.in/courses/mern-stack</loc><changefreq>weekly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://restcoderacademy.in/blog</loc><changefreq>weekly</changefreq><priority>0.7</priority></url>
+  <url><loc>https://restcoderacademy.in/blog/java-vs-python-full-stack</loc><changefreq>monthly</changefreq><priority>0.6</priority></url>
+  <url><loc>https://restcoderacademy.in/blog/is-a-coding-course-worth-it-2026</loc><changefreq>monthly</changefreq><priority>0.6</priority></url>
 </urlset>

--- a/scripts/prerender.mjs
+++ b/scripts/prerender.mjs
@@ -12,6 +12,7 @@ import { readFile, writeFile, mkdir } from "node:fs/promises";
 import { existsSync } from "node:fs";
 import { extname, join, dirname, resolve } from "node:path";
 import { courses } from "../src/components/organism/courses/courses.js";
+import { posts } from "../src/components/Pages/blog/posts.js";
 
 const DIST = resolve(process.cwd(), "dist");
 const HOST = "127.0.0.1";
@@ -22,6 +23,8 @@ const routes = [
   { path: "/placements", out: "placements.html", waitFor: "main.pl" },
   { path: "/contact", out: "contact.html", waitFor: "main.ct" },
   { path: "/faq", out: "faq.html", waitFor: "main.faq" },
+  { path: "/blog", out: "blog.html", waitFor: "main.bl" },
+  ...posts.map((p) => ({ path: `/blog/${p.slug}`, out: `blog/${p.slug}.html`, waitFor: "article.bl-post" })),
   // /about is intentionally NOT prerendered: it's admin-managed (/api/founder)
   // and hides itself until content exists, so there's nothing static to snapshot.
   // It renders client-side (Googlebot executes JS) once a founder is set.

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -10,6 +10,8 @@ import About from "./components/Pages/About";
 import PlacementsPage from "./components/Pages/PlacementsPage";
 import Contact from "./components/Pages/Contact";
 import FAQ from "./components/Pages/FAQ";
+import Blog from "./components/Pages/Blog";
+import BlogPost from "./components/Pages/BlogPost";
 import ScrollToTop from "./components/ScrollToTop";
 import Modal from 'react-modal';
 import EnquiryForm from './components/forms/Enquiry Form/EnquiryForm';
@@ -89,6 +91,8 @@ function App() {
         <Route path="/placements" element={<PlacementsPage />} />
         <Route path="/contact" element={<Contact />} />
         <Route path="/faq" element={<FAQ />} />
+        <Route path="/blog" element={<Blog />} />
+        <Route path="/blog/:slug" element={<BlogPost />} />
         <Route path="*" element={<Navigate to="/" replace />} />
       </Routes>
       <FloatingIcons/>

--- a/src/components/Pages/Blog.css
+++ b/src/components/Pages/Blog.css
@@ -1,0 +1,79 @@
+/* Blog index + post pages. Shared tokens; below the fixed navbar. */
+.bl {
+  max-width: 760px;
+  margin: 0 auto;
+  padding: 92px 20px 72px;
+  font-family: var(--rca-font, "Montserrat", "Segoe UI", system-ui, sans-serif);
+  color: #1b2230;
+}
+
+/* Index hero */
+.bl-hero { margin-bottom: 8px; }
+.bl-eyebrow {
+  display: inline-block;
+  background: var(--rca-accent-soft, rgba(255,152,0,0.12)); color: #8a5200;
+  font-size: 11px; font-weight: 700; letter-spacing: 0.11em; text-transform: uppercase;
+  padding: 5px 12px; border-radius: 999px; margin-bottom: 14px;
+}
+.bl-hero h1 {
+  margin: 0 0 12px; font-size: clamp(26px, 4.4vw, 38px);
+  font-weight: 800; line-height: 1.14; letter-spacing: -0.02em; color: var(--rca-navy, #03084c);
+}
+.bl-hero p { margin: 0; font-size: 16px; color: #45545d; }
+
+/* Index list */
+.bl-list { margin-top: 30px; display: flex; flex-direction: column; }
+.bl-item { padding: 24px 0; border-bottom: 1px solid #e6e9f2; }
+.bl-item:first-child { border-top: 1px solid #e6e9f2; }
+.bl-meta { display: flex; gap: 8px; align-items: center; font-size: 12.5px; color: #7a83a6; }
+.bl-item h2 { margin: 8px 0 8px; font-size: 21px; line-height: 1.25; }
+.bl-item h2 a { color: var(--rca-navy, #03084c); text-decoration: none; }
+.bl-item h2 a:hover { color: var(--rca-blue, #146389); }
+.bl-item p { margin: 0 0 12px; font-size: 15px; line-height: 1.6; color: #45545d; }
+.bl-read { font-size: 14px; font-weight: 600; color: var(--rca-blue, #146389); text-decoration: none; }
+.bl-read:hover { text-decoration: underline; }
+
+/* Post */
+.bl-crumb { display: flex; gap: 8px; font-size: 13px; color: #6b7280; margin-bottom: 22px; }
+.bl-crumb a { color: var(--rca-blue, #146389); text-decoration: none; }
+.bl-crumb a:hover { text-decoration: underline; }
+.bl-post header { margin-bottom: 22px; }
+.bl-post h1 {
+  margin: 10px 0 0; font-size: clamp(26px, 4.6vw, 38px);
+  font-weight: 800; line-height: 1.15; letter-spacing: -0.02em; color: var(--rca-navy, #03084c);
+  text-wrap: balance;
+}
+.bl-body { font-size: 17px; line-height: 1.75; color: #2b3444; }
+.bl-body h2 {
+  margin: 32px 0 12px; font-size: 22px; font-weight: 700; letter-spacing: -0.01em;
+  color: var(--rca-navy, #03084c); line-height: 1.3;
+}
+.bl-body p { margin: 0 0 18px; }
+.bl-body ul { margin: 0 0 18px; padding-left: 0; list-style: none; }
+.bl-body li {
+  position: relative; padding: 6px 0 6px 26px; line-height: 1.6;
+}
+.bl-body li::before {
+  content: ""; position: absolute; left: 4px; top: 15px; width: 8px; height: 8px;
+  border-radius: 2px; background: var(--rca-accent, #ff9800);
+}
+
+/* Post CTA */
+.bl-cta {
+  margin-top: 44px; padding: 30px 24px; text-align: center;
+  background: #f5f7fb; border: 1px solid #e6e9f2; border-radius: var(--rca-radius-lg, 12px);
+}
+.bl-cta h2 { margin: 0 0 8px; font-size: 21px; color: var(--rca-navy, #03084c); }
+.bl-cta p { margin: 0 auto 20px; max-width: 50ch; color: #45545d; font-size: 14.5px; }
+.bl-cta-row { display: flex; flex-wrap: wrap; gap: 12px; justify-content: center; align-items: center; }
+.bl-btn {
+  font-family: inherit; font-size: 15px; font-weight: 600;
+  height: 46px; padding: 0 24px; border: none; border-radius: var(--rca-radius-md, 8px);
+  background: var(--rca-navy, #03084c); color: #fff; cursor: pointer;
+  text-decoration: none; display: inline-flex; align-items: center;
+}
+.bl-btn:hover { background: var(--rca-navy-hover, #0a1270); }
+.bl-btn--ghost { background: transparent; color: var(--rca-navy, #03084c); border: 1px solid var(--line-2, #d0d7e6); }
+.bl-btn--ghost:hover { background: #eef2f9; }
+.bl-back { font-size: 14px; font-weight: 600; color: var(--rca-blue, #146389); text-decoration: none; padding: 0 6px; }
+.bl-back:hover { text-decoration: underline; }

--- a/src/components/Pages/Blog.jsx
+++ b/src/components/Pages/Blog.jsx
@@ -1,0 +1,70 @@
+import React from "react";
+import { Link } from "react-router-dom";
+import { posts } from "./blog/posts";
+import "./Blog.css";
+
+const ORIGIN = "https://restcoderacademy.in";
+
+function formatDate(d) {
+  try {
+    return new Date(d).toLocaleDateString("en-IN", { day: "numeric", month: "short", year: "numeric" });
+  } catch {
+    return d;
+  }
+}
+
+// Blog index — lists posts (newest first from posts.js).
+function Blog() {
+  const url = `${ORIGIN}/blog`;
+  const description =
+    "Guides and honest advice on learning to code, getting hired, and full-stack development — from the team at Rest Coder Academy, Bengaluru.";
+
+  const jsonLd = {
+    "@context": "https://schema.org",
+    "@type": "Blog",
+    name: "Rest Coder Academy Blog",
+    url,
+    publisher: { "@type": "EducationalOrganization", name: "Rest Coder Academy", "@id": `${ORIGIN}/#org` },
+    blogPost: posts.map((p) => ({
+      "@type": "BlogPosting",
+      headline: p.title,
+      description: p.description,
+      datePublished: p.date,
+      url: `${ORIGIN}/blog/${p.slug}`,
+    })),
+  };
+
+  return (
+    <>
+      <title>Blog — Learning to Code &amp; Getting Hired | Rest Coder Academy</title>
+      <meta name="description" content={description} />
+      <link rel="canonical" href={url} />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }} />
+
+      <main className="bl">
+        <header className="bl-hero">
+          <span className="bl-eyebrow">Blog</span>
+          <h1>Learning to code, getting hired — straight talk.</h1>
+          <p>Guides and honest advice on full-stack development, choosing a path, and what actually gets you a job.</p>
+        </header>
+
+        <section className="bl-list">
+          {posts.map((p) => (
+            <article className="bl-item" key={p.slug}>
+              <div className="bl-meta">
+                <time dateTime={p.date}>{formatDate(p.date)}</time>
+                <span>·</span>
+                <span>{p.readMinutes} min read</span>
+              </div>
+              <h2><Link to={`/blog/${p.slug}`}>{p.title}</Link></h2>
+              <p>{p.description}</p>
+              <Link className="bl-read" to={`/blog/${p.slug}`}>Read →</Link>
+            </article>
+          ))}
+        </section>
+      </main>
+    </>
+  );
+}
+
+export default Blog;

--- a/src/components/Pages/BlogPost.jsx
+++ b/src/components/Pages/BlogPost.jsx
@@ -1,0 +1,95 @@
+import React from "react";
+import { useParams, Navigate, Link } from "react-router-dom";
+import { useAuth } from "../../App";
+import { getPost } from "./blog/posts";
+import "./Blog.css";
+
+const ORIGIN = "https://restcoderacademy.in";
+
+function formatDate(d) {
+  try {
+    return new Date(d).toLocaleDateString("en-IN", { day: "numeric", month: "short", year: "numeric" });
+  } catch {
+    return d;
+  }
+}
+
+function Block({ block }) {
+  if (block.t === "h2") return <h2>{block.c}</h2>;
+  if (block.t === "ul") {
+    return (
+      <ul>
+        {block.c.map((li, i) => (
+          <li key={i}>{li}</li>
+        ))}
+      </ul>
+    );
+  }
+  return <p>{block.c}</p>;
+}
+
+function BlogPost() {
+  const { slug } = useParams();
+  const { openModal } = useAuth();
+  const post = getPost(slug);
+  if (!post) return <Navigate to="/blog" replace />;
+
+  const url = `${ORIGIN}/blog/${post.slug}`;
+  const jsonLd = {
+    "@context": "https://schema.org",
+    "@type": "BlogPosting",
+    headline: post.title,
+    description: post.description,
+    datePublished: post.date,
+    dateModified: post.date,
+    author: { "@type": "Organization", name: post.author || "Rest Coder Academy" },
+    publisher: { "@type": "EducationalOrganization", name: "Rest Coder Academy", "@id": `${ORIGIN}/#org` },
+    mainEntityOfPage: url,
+    url,
+  };
+
+  return (
+    <>
+      <title>{`${post.title} | Rest Coder Academy`}</title>
+      <meta name="description" content={post.description} />
+      <link rel="canonical" href={url} />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }} />
+
+      <main className="bl">
+        <nav className="bl-crumb" aria-label="Breadcrumb">
+          <Link to="/">Home</Link>
+          <span>/</span>
+          <Link to="/blog">Blog</Link>
+        </nav>
+
+        <article className="bl-post">
+          <header>
+            <div className="bl-meta">
+              <time dateTime={post.date}>{formatDate(post.date)}</time>
+              <span>·</span>
+              <span>{post.readMinutes} min read</span>
+            </div>
+            <h1>{post.title}</h1>
+          </header>
+          <div className="bl-body">
+            {post.body.map((block, i) => (
+              <Block key={i} block={block} />
+            ))}
+          </div>
+        </article>
+
+        <section className="bl-cta">
+          <h2>Thinking about a course?</h2>
+          <p>Our Java, Python and MERN full-stack courses are live, project-based, and built around real placements.</p>
+          <div className="bl-cta-row">
+            <button className="bl-btn" type="button" onClick={openModal}>Talk to a counsellor</button>
+            <Link className="bl-btn bl-btn--ghost" to="/">See our courses</Link>
+            <Link className="bl-back" to="/blog">← More posts</Link>
+          </div>
+        </section>
+      </main>
+    </>
+  );
+}
+
+export default BlogPost;

--- a/src/components/Pages/blog/posts.js
+++ b/src/components/Pages/blog/posts.js
@@ -1,0 +1,68 @@
+// Blog posts. Dependency-free: each post's `body` is an array of blocks
+// ({ t: "p" | "h2" | "ul", c }) rendered by BlogPost.jsx — no markdown lib,
+// prerender-safe. Add a new post by adding an object here (newest first).
+export const posts = [
+  {
+    slug: "java-vs-python-full-stack",
+    title: "Java vs Python for full-stack: which should you learn first?",
+    description:
+      "A straight answer for beginners choosing between a Java and a Python full-stack path — what each is good at, who hires for it, and how to decide.",
+    date: "2026-09-02",
+    author: "Rest Coder Academy",
+    readMinutes: 5,
+    body: [
+      { t: "p", c: "If you're starting out, \"Java or Python?\" is usually the first wall you hit. The honest answer: both lead to jobs, and the language matters less than whether you can actually build and ship something. But they do pull toward different work, so here's how to choose without overthinking it." },
+      { t: "h2", c: "What each is actually good at" },
+      { t: "p", c: "Java is the workhorse of large, long-lived enterprise systems — banking, insurance, big product companies. It's strict, verbose, and that strictness is exactly why big teams like it: the compiler catches a lot before code ever runs. A Java full-stack path typically means Core & Advanced Java, Spring/Spring Boot, Hibernate, REST APIs, and a front end." },
+      { t: "p", c: "Python is faster to write and reads almost like English, which is why it dominates data, scripting, automation, and AI, and is very strong for web too via Django. A Python full-stack path means Python, Django, REST APIs, and a modern front end. If you think you might drift toward data or AI later, Python gives you a head start." },
+      { t: "h2", c: "Who's hiring for each" },
+      { t: "p", c: "In most Indian cities, Java has the larger raw volume of openings — services companies and product teams run enormous Java codebases. Python roles are growing fast and skew toward startups, data, and AI-heavy teams. Neither is a dead end; both have healthy demand in 2026." },
+      { t: "h2", c: "So how do you actually decide?" },
+      { t: "ul", c: [
+        "Want the widest set of openings and don't mind strictness? Start with Java.",
+        "Prefer to move fast, or curious about data/AI down the line? Start with Python.",
+        "Genuinely torn? Pick either. The concepts — APIs, databases, HTTP, a front end, deploying to production — carry across. Learning your second language later is a matter of weeks, not months.",
+      ] },
+      { t: "h2", c: "The thing that actually gets you hired" },
+      { t: "p", c: "Whichever you pick, employers don't hire a language — they hire someone who has built and shipped real things. That's why our Java and Python full-stack courses are project-based and live: you build working software, not slides, and ship it. If you'd like help choosing based on your background and goals, talk to a counsellor — it's a five-minute conversation that saves months." },
+    ],
+  },
+  {
+    slug: "is-a-coding-course-worth-it-2026",
+    title: "Is a coding course worth it in 2026? An honest look",
+    description:
+      "Coding courses get a bad rap for good reasons. Here's when one is genuinely worth it, when it isn't, and the questions to ask before you pay.",
+    date: "2026-09-01",
+    author: "Rest Coder Academy",
+    readMinutes: 6,
+    body: [
+      { t: "p", c: "Plenty of people have paid for a coding course and gotten nothing out of it. So it's a fair question: in 2026, with free tutorials everywhere and AI that writes code, is a paid course still worth it? The honest answer is \"sometimes\" — and it depends far more on the course than on you." },
+      { t: "h2", c: "When a course is NOT worth it" },
+      { t: "ul", c: [
+        "It's all recorded videos and theory. You can get that free on YouTube.",
+        "You never build anything real — just follow along and copy exercises.",
+        "There's no accountability: nobody checks whether you're attending, learning, or progressing.",
+        "\"Placement\" is a vague promise with no named students or companies behind it.",
+      ] },
+      { t: "p", c: "If a course looks like this, save your money. Self-study plus a few real projects will beat it." },
+      { t: "h2", c: "When a course IS worth it" },
+      { t: "p", c: "A good course buys you three things free tutorials can't: structure, feedback, and momentum. A live cohort with a real trainer means you're building actual software, getting your work reviewed, and being kept accountable so you don't quietly drift off in week three — which is where most self-learners stall." },
+      { t: "p", c: "The best ones also close the loop to a job: real placement support, and honesty about outcomes. Ask to see named graduates and where they actually work." },
+      { t: "h2", c: "Does AI change the answer?" },
+      { t: "p", c: "AI writes code, but it doesn't yet decide what to build, debug a broken production system, or take responsibility for shipping. Those judgment skills are exactly what get you hired — and they come from building real things with feedback, not from watching videos. If anything, AI raises the bar on \"can you actually ship?\", which is what a good, project-based course trains." },
+      { t: "h2", c: "Questions to ask before you pay" },
+      { t: "ul", c: [
+        "Will I build and ship real projects, or just do exercises?",
+        "Is it live, with a real trainer I can verify?",
+        "How do you keep students accountable and on track?",
+        "Can you show me named graduates and the companies they joined?",
+        "What exactly does \"placement support\" mean?",
+      ] },
+      { t: "p", c: "That last set is how we'd want you to judge us too. Our courses are live and project-based, guardians can see a student's progress every week, and our placements page lists real graduates by name and company. If that's the kind of course you're after, come talk to us." },
+    ],
+  },
+];
+
+export function getPost(slug) {
+  return posts.find((p) => p.slug === slug) || null;
+}

--- a/src/components/molecules/Footer Components/FooterLinks.jsx
+++ b/src/components/molecules/Footer Components/FooterLinks.jsx
@@ -48,6 +48,11 @@ function FooterLinks() {
                   <ListItemText primary="FAQs" />
                 </RouterLink>
               </ListItem>
+              <ListItem>
+                <RouterLink to="/blog">
+                  <ListItemText primary="Blog" />
+                </RouterLink>
+              </ListItem>
           </List>
     </>
   )


### PR DESCRIPTION
Stands up /blog + /blog/:slug — dependency-free (posts as structured blocks in blog/posts.js, no markdown lib), each post with its own title/meta/canonical + BlogPosting JSON-LD, index with Blog schema, prerendered + in sitemap + footer link. Two starter posts written to real search intent. Adding a post = adding an object to posts.js. 64 tests pass. Closes #82.