### PR TITLE
fix(perf): remove redundant slick-carousel CDN <link>s (#105)

### DIFF
--- a/index.html
+++ b/index.html
@@ -89,17 +89,10 @@
     }
     </script>
 
-    <link
-      rel="stylesheet"
-      type="text/css"
-      charset="UTF-8"
-      href="https://cdnjs.cloudflare.com/ajax/libs/slick-carousel/1.6.0/slick.min.css"
-    />
-    <link
-      rel="stylesheet"
-      type="text/css"
-      href="https://cdnjs.cloudflare.com/ajax/libs/slick-carousel/1.6.0/slick-theme.min.css"
-    />
+    <!-- slick-carousel CSS is bundled (imported in ClientsCard.jsx, PlacementCard.jsx,
+         ReviewsCard.jsx) — no external cdnjs <link> needed here. Same reasoning as the
+         self-hosted font below: an external stylesheet on the critical path can hang
+         and spike LCP. -->
     <!-- One typeface (#6). Montserrat is self-hosted via @fontsource/montserrat,
          imported in src/main.jsx — no font request leaves the site. -->
   </head>


### PR DESCRIPTION
## Summary

Cloudflare Web Analytics showed an LCP P99 outlier (~58s on one load), traced to an external resource on the critical path. `index.html` loaded slick-carousel's CSS from cdnjs on every page load:

\`\`\`html
<link ... href="https://cdnjs.cloudflare.com/ajax/libs/slick-carousel/1.6.0/slick.min.css" />
<link ... href="https://cdnjs.cloudflare.com/ajax/libs/slick-carousel/1.6.0/slick-theme.min.css" />
\`\`\`

But the same CSS is already bundled — \`ClientsCard.jsx\`, \`PlacementCard.jsx\` and \`ReviewsCard.jsx\` all \`import "slick-carousel/slick/slick.css"\` (+ \`slick-theme.css\`), and \`slick-carousel@^1.8.1\` is a direct dependency. The two \`<link>\` tags were pure dead weight — an external stylesheet on the critical path that can hang and spike LCP, same reasoning as why the fonts are already self-hosted.

## Fix

Removed both \`<link>\` tags, replaced with a short comment explaining why nothing's there (matching the existing font comment right below it).

## Verification

- \`npm run build\` — succeeds
- \`npm run lint\` — 322 problems before and after (identical baseline, zero new issues)
- \`npm test\` — 64/64 pass
- Checked the actual **production build** (\`vite preview\`, not just dev server) via a headless Playwright check: zero requests to \`cdnjs.cloudflare.com\`, all 3 carousels (Clients, Reviews, Placements) render, and the slick arrows/dots are correctly styled (position, dimensions, visibility all intact — confirming the bundled CSS fully covers what the CDN link provided).

Fixes #105

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013g5dMJbYotQx9iLbYcjZvS