### PR TITLE
fix(nav): footer/navbar links to new pages + founder-link placement

### DIFF
--- a/src/components/molecules/Footer Components/FooterLinks.jsx
+++ b/src/components/molecules/Footer Components/FooterLinks.jsx
@@ -1,59 +1,53 @@
 import React from 'react'
 import TypoGraphyComponent from '../../atoms/TypoGraphyComponent/TypoGraphyComponent'
-import { Box,List,ListItem,ListItemText } from '@mui/material'
-import { Link, animateScroll as scroll } from 'react-scroll';
-import { Link as RouterLink } from 'react-router-dom';
+import { List, ListItem, ListItemText } from '@mui/material'
+import { Link as RouterLink, useNavigate, useLocation } from 'react-router-dom';
+import { scroller } from 'react-scroll';
 
+// Real pages (added over the SEO push) get router links; the two homepage
+// sections (Courses, Reviews) route home first, then scroll — so they work
+// from any page, not just "/".
+const pageLinks = [
+  { label: 'About Us', to: '/about' },
+  { label: 'For Parents', to: '/for-parents' },
+  { label: 'Success Stories', to: '/placements' },
+  { label: 'FAQs', to: '/faq' },
+  { label: 'Blog', to: '/blog' },
+  { label: 'Contact', to: '/contact' },
+];
+const sectionLinks = ['Courses', 'Reviews'];
 
 function FooterLinks() {
-  let links=['Placements', 'Reviews','Batches'];
+  const navigate = useNavigate();
+  const location = useLocation();
 
-  let scrollToTop=()=>
-  {
-    scroll.scrollToTop()
-  }
+  // On the homepage scroll to the section; from any other route go home and
+  // let Home scroll to it (via location state) — mirrors the navbar.
+  const goToSection = (id) => {
+    if (location.pathname === '/') {
+      scroller.scrollTo(id, { smooth: true, offset: -62, duration: 400 });
+    } else {
+      navigate('/', { state: { scrollTo: id } });
+    }
+  };
+
   return (
     <>
-        <TypoGraphyComponent variant='h5' component='h2' text='Who Are We'/>
-        <List className='links'>
-        <ListItem onClick={scrollToTop}>
-                
-                    <ListItemText
-                      primary={"About Us"}
-                    />
-            </ListItem>
-              {links.map((link,id)=>
-              {
-               return <ListItem  key={id}>
-                  <Link to={link} smooth={true} offset={-62}>
-                    <ListItemText
-                      primary={link}
-                    />
-                  </Link>
-              </ListItem>
-          
-              })}
-              <ListItem>
-                <RouterLink to="/placements">
-                  <ListItemText primary="Success Stories" />
-                </RouterLink>
-              </ListItem>
-              <ListItem>
-                <RouterLink to="/contact">
-                  <ListItemText primary="Contact" />
-                </RouterLink>
-              </ListItem>
-              <ListItem>
-                <RouterLink to="/faq">
-                  <ListItemText primary="FAQs" />
-                </RouterLink>
-              </ListItem>
-              <ListItem>
-                <RouterLink to="/blog">
-                  <ListItemText primary="Blog" />
-                </RouterLink>
-              </ListItem>
-          </List>
+      <TypoGraphyComponent variant='h5' component='h2' text='Who Are We' />
+      <List className='links'>
+        {pageLinks.map((l) => (
+          <ListItem key={l.to}>
+            <RouterLink to={l.to}>
+              <ListItemText primary={l.label} />
+            </RouterLink>
+          </ListItem>
+        ))}
+        {sectionLinks.map((id) => (
+          <ListItem key={id} onClick={() => goToSection(id)} style={{ cursor: 'pointer' }}>
+            <ListItemText primary={id} />
+          </ListItem>
+        ))}
+      </List>
     </>
   )
 }

--- a/src/components/molecules/Navbar/Navbar.jsx
+++ b/src/components/molecules/Navbar/Navbar.jsx
@@ -23,6 +23,8 @@ import { useNavigate, useLocation, Link as RouterLink } from 'react-router-dom';
 const drawerWidth = 240;
 // const navItems = ['Home', 'Fish', 'Stones','Plants','Food','Lights','Air Pumps','Tanks & Bowls'];
 const navItems = ['Courses',  'Reviews','Clients','Placements'];
+// Real pages added over the SEO push — router links, not homepage-section scrolls.
+const pageItems = [{ label: 'For Parents', to: '/for-parents' }, { label: 'About', to: '/about' }];
 
 
 function Navbar(props) {
@@ -60,6 +62,15 @@ function Navbar(props) {
             </ListItemButton>
           </ListItem>
         ))}
+        {pageItems.map((p) => (
+          <ListItem key={p.to} disablePadding>
+            <ListItemButton sx={{ textAlign: 'center' }} onClick={handleDrawerToggle}>
+              <RouterLink to={p.to} style={{ width: '100%' }}>
+                <ListItemText primary={p.label} />
+              </RouterLink>
+            </ListItemButton>
+          </ListItem>
+        ))}
       </List>
     </Box>
   );
@@ -90,7 +101,14 @@ function Navbar(props) {
               <ButtonComponent key={item} textColor="color-dark-black" variant='text' onBtnClick={() => goToSection(item)}>
                   {item}
                 </ButtonComponent>
-                
+
+            ))}
+            {pageItems.map((p) => (
+              <RouterLink key={p.to} to={p.to}>
+                <ButtonComponent textColor="color-dark-black" variant='text'>
+                  {p.label}
+                </ButtonComponent>
+              </RouterLink>
             ))}
              <ButtonComponent variant='contained' bgColor='bg-btn-blue' borderRadius='0px' paddingX={1.5} paddingY={.7} onBtnClick={openModal}>
                     Apply Now

--- a/src/components/organism/courses/CourseCard.css
+++ b/src/components/organism/courses/CourseCard.css
@@ -79,15 +79,20 @@
 .cc-trainer--link { cursor: pointer; }
 .cc-trainer--link:hover .cc-trainer-text b { text-decoration: underline; }
 .cc-trainer--link:focus-visible { outline: 2px solid #ffb74d; outline-offset: 3px; border-radius: 6px; }
+/* Sits directly under the trainer name (indented past the 36px avatar + 11px
+   gap) so it reads as a sub-action of "Taught by …", not a stray amber line. */
 .cc-founder-link {
-  display: inline-block;
-  margin-top: 12px;
-  font-size: 12.5px;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  margin: 5px 0 0 47px;
+  font-size: 12px;
   font-weight: 600;
   color: #ffb74d;
   text-decoration: none;
+  opacity: 0.92;
 }
-.cc-founder-link:hover { text-decoration: underline; }
+.cc-founder-link:hover { opacity: 1; text-decoration: underline; }
 
 /* --- Body --- */
 .cc-body {


### PR DESCRIPTION
Yesterday's SEO push added 6 new pages but navbar/footer never linked them. Footer "About Us" was a scrollToTop no-op → now routes to /about; footer + navbar now surface the new pages (For Parents, About in nav; full set in footer). Also tucked the "Meet the founder" link under the trainer name so it stops floating orphaned in the card header. 64 tests pass, build green.