### PR TITLE
feat(analytics): add GA4 tracking (G-2MEMYQ1Z2Q)

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,6 +2,17 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
+
+    <!-- Google tag (gtag.js) — GA4 property "restcoderacademy.in" (G-2MEMYQ1Z2Q).
+         Baked into index.html so every prerendered page carries it in <head>. -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-2MEMYQ1Z2Q"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-2MEMYQ1Z2Q');
+    </script>
+
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link rel="icon" type="image/png" href="/favicon.png" />
     <link rel="apple-touch-icon" href="/favicon.png" />


### PR DESCRIPTION
Wires GA4 into the site (the measurement gap in #16/#72). gtag in index.html head → carried into every prerendered page (verified locally on for-parents/faq/placements/blog/course pages). Property: GA4 restcoderacademy.in (India/IST/INR), Enhanced Measurement on. Follow-up PR will fire a `purchase` event on Razorpay success for revenue tracking. Closes #16.