### PR TITLE
fix(seo): repair sitemap.xml (merge-conflict markers) + guard test

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -2,12 +2,10 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url><loc>https://restcoderacademy.in/</loc><changefreq>weekly</changefreq><priority>1.0</priority></url>
   <url><loc>https://restcoderacademy.in/for-parents</loc><changefreq>monthly</changefreq><priority>0.9</priority></url>
-<<<<<<< HEAD
+  <url><loc>https://restcoderacademy.in/about</loc><changefreq>monthly</changefreq><priority>0.9</priority></url>
   <url><loc>https://restcoderacademy.in/placements</loc><changefreq>monthly</changefreq><priority>0.8</priority></url>
-=======
-  <url><loc>https://restcoderacademy.in/contact</loc><changefreq>monthly</changefreq><priority>0.7</priority></url>
   <url><loc>https://restcoderacademy.in/faq</loc><changefreq>monthly</changefreq><priority>0.8</priority></url>
->>>>>>> origin/main
+  <url><loc>https://restcoderacademy.in/contact</loc><changefreq>monthly</changefreq><priority>0.7</priority></url>
   <url><loc>https://restcoderacademy.in/courses/forward-deployed-engineering</loc><changefreq>weekly</changefreq><priority>0.9</priority></url>
   <url><loc>https://restcoderacademy.in/courses/java-full-stack</loc><changefreq>weekly</changefreq><priority>0.8</priority></url>
   <url><loc>https://restcoderacademy.in/courses/python-full-stack</loc><changefreq>weekly</changefreq><priority>0.8</priority></url>

--- a/tests/sitemap.test.js
+++ b/tests/sitemap.test.js
@@ -1,0 +1,39 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+// Guards public/sitemap.xml. A stray Git merge-conflict marker once shipped
+// here and made the whole sitemap unparseable in Search Console — these checks
+// catch that (and other malformed-XML slips) before they reach production.
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const sitemap = readFileSync(resolve(__dirname, "../public/sitemap.xml"), "utf8");
+
+describe("public/sitemap.xml", () => {
+  it("has no unresolved merge-conflict markers", () => {
+    expect(sitemap).not.toMatch(/^(<{7}|={7}|>{7})/m);
+  });
+
+  it("is a well-formed sitemap: xml declaration + urlset wrapper", () => {
+    expect(sitemap.trimStart()).toMatch(/^<\?xml/);
+    expect(sitemap).toContain("<urlset");
+    expect(sitemap).toContain("</urlset>");
+  });
+
+  it("has balanced <url> / <loc> tags", () => {
+    const urls = (sitemap.match(/<url>/g) || []).length;
+    const urlCloses = (sitemap.match(/<\/url>/g) || []).length;
+    const locs = (sitemap.match(/<loc>/g) || []).length;
+    expect(urls).toBeGreaterThan(0);
+    expect(urlCloses).toBe(urls);
+    expect(locs).toBe(urls);
+  });
+
+  it("every <loc> is an absolute https://restcoderacademy.in URL, with no duplicates", () => {
+    const locs = [...sitemap.matchAll(/<loc>([^<]+)<\/loc>/g)].map((m) => m[1]);
+    for (const loc of locs) {
+      expect(loc).toMatch(/^https:\/\/restcoderacademy\.in\//);
+    }
+    expect(new Set(locs).size).toBe(locs.length); // no duplicate URLs
+  });
+});


### PR DESCRIPTION
The live sitemap.xml had committed Git conflict markers (`<<<<<<< HEAD` etc.) from an earlier union-merge → invalid XML → Search Console rejected it. Removes the markers (keeps placements+contact+faq), adds the missing /about page, and adds tests/sitemap.test.js to guard against markers / malformed XML / duplicate URLs so this can't silently recur.