### PR TITLE
feat(analytics): GA4 purchase + begin_checkout events (revenue tracking)

### DIFF
--- a/src/components/forms/EnrollForm/EnrollForm.jsx
+++ b/src/components/forms/EnrollForm/EnrollForm.jsx
@@ -1,9 +1,16 @@
 import { Box, CircularProgress } from "@mui/material";
-import React, { useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
+import PropTypes from "prop-types";
 import TypoGraphyComponent from "../../atoms/TypoGraphyComponent/TypoGraphyComponent";
 import ButtonComponent from "../../atoms/ButtonComponent/ButtonComponent";
 import { useAuth } from "../../../App";
-import { getReferral, loadRazorpay, createOrder, verifyPayment } from "./enrollApi";
+import {
+  getReferral,
+  loadRazorpay,
+  createOrder,
+  verifyPayment,
+} from "./enrollApi";
+import { trackBeginCheckout, trackPurchase } from "../../../lib/analytics";
 import "./EnrollForm.css";
 
 // No form. "Book your seat" opens Razorpay Checkout directly — Razorpay collects
@@ -44,16 +51,20 @@ function EnrollForm({ course }) {
     }
     if (order.status === 503) {
       return fail(
-        "Enrolment is opening soon — please use “Talk to a counsellor” or message us on WhatsApp to reserve your seat."
+        "Enrolment is opening soon — please use “Talk to a counsellor” or message us on WhatsApp to reserve your seat.",
       );
     }
     if (!order.ok || !order.body.orderId) {
-      return fail(order.body.error || "Could not start payment. Please try again.");
+      return fail(
+        order.body.error || "Could not start payment. Please try again.",
+      );
     }
 
     const loaded = await loadRazorpay();
     if (!loaded || !window.Razorpay) {
-      return fail("Could not load the payment window. Check your connection and try again.");
+      return fail(
+        "Could not load the payment window. Check your connection and try again.",
+      );
     }
 
     const rzp = new window.Razorpay({
@@ -78,16 +89,24 @@ function EnrollForm({ course }) {
           });
           if (v.ok && v.body.ok) {
             settled.current = true;
+            // GA4 revenue event — server has verified the payment. value uses
+            // course.price (same price map the server charges from).
+            trackPurchase({
+              transactionId: resp.razorpay_payment_id,
+              value: course.price,
+              courseId: course.courseId,
+              courseName: course.name,
+            });
             setPhase("done");
             notify && notify("Enrolment confirmed! 🎉");
           } else {
             fail(
-              "Your payment went through but we couldn't confirm it here. Keep your payment ID and message us — we'll sort it out."
+              "Your payment went through but we couldn't confirm it here. Keep your payment ID and message us — we'll sort it out.",
             );
           }
         } catch {
           fail(
-            "Your payment went through but we couldn't confirm it here. Keep your payment ID and message us — we'll sort it out."
+            "Your payment went through but we couldn't confirm it here. Keep your payment ID and message us — we'll sort it out.",
           );
         }
       },
@@ -99,14 +118,26 @@ function EnrollForm({ course }) {
         },
       },
     });
-    rzp.on("payment.failed", () => fail("Payment failed or was cancelled. You can try again."));
+    rzp.on("payment.failed", () =>
+      fail("Payment failed or was cancelled. You can try again."),
+    );
+    // GA4 funnel start — checkout is opening (measures intent vs. completed purchase).
+    trackBeginCheckout({
+      value: course.price,
+      courseId: course.courseId,
+      courseName: course.name,
+    });
     rzp.open();
   }
 
   if (phase === "done") {
     return (
       <Box className="enroll-form enroll-done">
-        <TypoGraphyComponent component="h6" variant="h6" text="Your seat is booked 🎉" />
+        <TypoGraphyComponent
+          component="h6"
+          variant="h6"
+          text="Your seat is booked 🎉"
+        />
         <TypoGraphyComponent
           component="p"
           variant="body2"
@@ -122,8 +153,16 @@ function EnrollForm({ course }) {
       <Box className="enroll-form">
         <Box className="form-heading">
           <Box>
-            <TypoGraphyComponent component="h6" variant="h6" text="Couldn't complete checkout" />
-            <TypoGraphyComponent component="p" variant="body2" text={course.name} />
+            <TypoGraphyComponent
+              component="h6"
+              variant="h6"
+              text="Couldn't complete checkout"
+            />
+            <TypoGraphyComponent
+              component="p"
+              variant="body2"
+              text={course.name}
+            />
           </Box>
           <ButtonComponent paddingX={1} paddingY={1} onBtnClick={closeEnroll}>
             ×
@@ -132,7 +171,11 @@ function EnrollForm({ course }) {
         <Box className="enroll-error" role="alert">
           <TypoGraphyComponent component="p" variant="body2" text={failed} />
         </Box>
-        <ButtonComponent label="Try again" fullWidth onBtnClick={startCheckout} />
+        <ButtonComponent
+          label="Try again"
+          fullWidth
+          onBtnClick={startCheckout}
+        />
       </Box>
     );
   }
@@ -140,7 +183,11 @@ function EnrollForm({ course }) {
   // launching
   return (
     <Box className="enroll-form enroll-launching">
-      <TypoGraphyComponent component="h6" variant="h6" text="Opening secure checkout…" />
+      <TypoGraphyComponent
+        component="h6"
+        variant="h6"
+        text="Opening secure checkout…"
+      />
       <TypoGraphyComponent
         component="p"
         variant="body2"
@@ -157,5 +204,14 @@ function EnrollForm({ course }) {
     </Box>
   );
 }
+
+EnrollForm.propTypes = {
+  course: PropTypes.shape({
+    courseId: PropTypes.string.isRequired,
+    name: PropTypes.string.isRequired,
+    price: PropTypes.number,
+    paid: PropTypes.bool,
+  }).isRequired,
+};
 
 export default EnrollForm;

--- a/src/lib/analytics.js
+++ b/src/lib/analytics.js
@@ -1,0 +1,50 @@
+// Thin, defensive wrappers around GA4 (gtag.js, loaded in index.html).
+//
+// gtag loads async and can be absent entirely (ad-blockers, offline, the tag
+// not yet parsed). Every call here is guarded and wrapped so analytics can
+// NEVER break the enrolment flow — a missing/throwing gtag is a no-op.
+
+function emit(eventName, params) {
+  try {
+    if (typeof window === "undefined" || typeof window.gtag !== "function")
+      return false;
+    window.gtag("event", eventName, params);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// Funnel start: the student opened Razorpay Checkout for a course.
+export function trackBeginCheckout({ value, courseId, courseName }) {
+  return emit("begin_checkout", {
+    currency: "INR",
+    value: Number(value) || 0,
+    items: [
+      {
+        item_id: courseId,
+        item_name: courseName,
+        price: Number(value) || 0,
+        quantity: 1,
+      },
+    ],
+  });
+}
+
+// Revenue: a payment was verified/confirmed by the server. transactionId is the
+// Razorpay payment id (the natural unique key for de-duping conversions).
+export function trackPurchase({ transactionId, value, courseId, courseName }) {
+  return emit("purchase", {
+    transaction_id: transactionId,
+    currency: "INR",
+    value: Number(value) || 0,
+    items: [
+      {
+        item_id: courseId,
+        item_name: courseName,
+        price: Number(value) || 0,
+        quantity: 1,
+      },
+    ],
+  });
+}

--- a/src/lib/analytics.test.js
+++ b/src/lib/analytics.test.js
@@ -1,0 +1,120 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { trackPurchase, trackBeginCheckout } from "./analytics";
+
+// vitest runs in the "node" environment (no global window), so stub it per-test.
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("analytics (GA4 events)", () => {
+  describe("trackPurchase", () => {
+    it("fires a GA4 purchase event with the right payload", () => {
+      const gtag = vi.fn();
+      vi.stubGlobal("window", { gtag });
+      const ok = trackPurchase({
+        transactionId: "pay_ABC123",
+        value: 35000,
+        courseId: "java-fs",
+        courseName: "Java Full Stack",
+      });
+      expect(ok).toBe(true);
+      expect(gtag).toHaveBeenCalledWith("event", "purchase", {
+        transaction_id: "pay_ABC123",
+        currency: "INR",
+        value: 35000,
+        items: [
+          {
+            item_id: "java-fs",
+            item_name: "Java Full Stack",
+            price: 35000,
+            quantity: 1,
+          },
+        ],
+      });
+    });
+
+    it("coerces a non-numeric value to 0 rather than sending NaN", () => {
+      const gtag = vi.fn();
+      vi.stubGlobal("window", { gtag });
+      trackPurchase({
+        transactionId: "pay_1",
+        value: undefined,
+        courseId: "x",
+        courseName: "X",
+      });
+      const [, , params] = gtag.mock.calls[0];
+      expect(params.value).toBe(0);
+      expect(params.items[0].price).toBe(0);
+    });
+  });
+
+  describe("trackBeginCheckout", () => {
+    it("fires a GA4 begin_checkout event", () => {
+      const gtag = vi.fn();
+      vi.stubGlobal("window", { gtag });
+      const ok = trackBeginCheckout({
+        value: 50000,
+        courseId: "fde",
+        courseName: "FDE",
+      });
+      expect(ok).toBe(true);
+      expect(gtag).toHaveBeenCalledWith("event", "begin_checkout", {
+        currency: "INR",
+        value: 50000,
+        items: [
+          { item_id: "fde", item_name: "FDE", price: 50000, quantity: 1 },
+        ],
+      });
+    });
+  });
+
+  describe("when gtag is unavailable (blocked / not yet loaded)", () => {
+    it("is a safe no-op and never throws when window has no gtag", () => {
+      vi.stubGlobal("window", {});
+      expect(() =>
+        trackPurchase({
+          transactionId: "p",
+          value: 1,
+          courseId: "c",
+          courseName: "C",
+        }),
+      ).not.toThrow();
+      expect(
+        trackPurchase({
+          transactionId: "p",
+          value: 1,
+          courseId: "c",
+          courseName: "C",
+        }),
+      ).toBe(false);
+      expect(
+        trackBeginCheckout({ value: 1, courseId: "c", courseName: "C" }),
+      ).toBe(false);
+    });
+
+    it("swallows a throwing gtag instead of breaking the caller", () => {
+      vi.stubGlobal("window", {
+        gtag: () => {
+          throw new Error("gtag boom");
+        },
+      });
+      expect(() =>
+        trackPurchase({
+          transactionId: "p",
+          value: 1,
+          courseId: "c",
+          courseName: "C",
+        }),
+      ).not.toThrow();
+      expect(
+        trackPurchase({
+          transactionId: "p",
+          value: 1,
+          courseId: "c",
+          courseName: "C",
+        }),
+      ).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
Fires GA4 ecommerce events so course revenue shows in Monetisation reports (#120). `begin_checkout` when Razorpay opens; `purchase` on server-verified payment (transaction_id = razorpay_payment_id, value = course.price, INR). New src/lib/analytics.js guards gtag defensively (missing/blocked/throwing = safe no-op, never breaks checkout) + 5 unit tests. Adds EnrollForm PropTypes. After merge: mark `purchase` as a key event in GA4 Admin. Closes #120.