### PR TITLE
feat(analytics): GA4 lead tracking (enquiry form, WhatsApp, call)

### DIFF
--- a/src/components/forms/Enquiry Form/EnquiryForm.jsx
+++ b/src/components/forms/Enquiry Form/EnquiryForm.jsx
@@ -8,6 +8,7 @@ import TypoGraphyComponent from '../../atoms/TypoGraphyComponent/TypoGraphyCompo
 import ButtonComponent from '../../atoms/ButtonComponent/ButtonComponent';
 import { useAuth } from '../../../App';
 import { regex } from '../../../regex/regex';
+import { trackLead } from '../../../lib/analytics';
 import axios from 'axios';
 
 const WHATSAPP_FALLBACK_NUMBERS=["918073762257","919110424403"]
@@ -72,6 +73,9 @@ const handleSubmit = async (e)=>
       // axios only resolves for 2xx responses by default; anything else (and network
       // errors/timeouts) rejects and is handled in the catch block below.
       await axios.post('/api/enquiry',enquiryData,{timeout:SUBMIT_TIMEOUT_MS})
+
+      // GA4 lead — the enquiry saved, so we have their contact details.
+      trackLead("enquiry_form")
 
       notify(`Enquiry received. We'll call you on ${enquiryData.mobile} within one working day.`)
       closeModal()

--- a/src/components/molecules/Floating Icons Components/FloatingIcons.jsx
+++ b/src/components/molecules/Floating Icons Components/FloatingIcons.jsx
@@ -6,6 +6,7 @@ import ArrowUpwardIcon from '@mui/icons-material/ArrowUpward';
 import "./FloatingIcons.css"
 import ScrollToHome from './ScrollToHome';
 import {animateScroll as scroll } from 'react-scroll';
+import { trackLead } from '../../../lib/analytics';
 
 
 
@@ -62,10 +63,10 @@ function FloatingIcons() {
 
   return (
     <Box className="floating-icons">
-       <a href="https://wa.me/918073762257?text=Hello!%20Can%20I%20get%20more%20info%20on%20courses%20and%20placements." target='_blank'>
+       <a href="https://wa.me/918073762257?text=Hello!%20Can%20I%20get%20more%20info%20on%20courses%20and%20placements." target='_blank' onClick={() => trackLead("whatsapp_float")}>
        <WhatsAppIcon fontSize='large' className='whatsapp'  style={whatsappStyle}/>
        </a>
-       <a href="tel:+918073762257">
+       <a href="tel:+918073762257" onClick={() => trackLead("call_float")}>
             <CallIcon fontSize='large' className='call'  style={callStyle}/>
        </a>
         <ArrowUpwardIcon fontSize='large' className='arrow'  style={arrowStyle} onClick={scrollToTop}/>

--- a/src/lib/analytics.js
+++ b/src/lib/analytics.js
@@ -31,6 +31,13 @@ export function trackBeginCheckout({ value, courseId, courseName }) {
   });
 }
 
+// Lead: someone gave us a way to reach them (enquiry form) or reached out
+// (WhatsApp / call). `method` distinguishes the source so GA4 can show which
+// channel produces leads. Fires GA4's recommended `generate_lead` event.
+export function trackLead(method) {
+  return emit("generate_lead", { method });
+}
+
 // Revenue: a payment was verified/confirmed by the server. transactionId is the
 // Razorpay payment id (the natural unique key for de-duping conversions).
 export function trackPurchase({ transactionId, value, courseId, courseName }) {

--- a/src/lib/analytics.test.js
+++ b/src/lib/analytics.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, afterEach, vi } from "vitest";
-import { trackPurchase, trackBeginCheckout } from "./analytics";
+import { trackPurchase, trackBeginCheckout, trackLead } from "./analytics";
 
 // vitest runs in the "node" environment (no global window), so stub it per-test.
 afterEach(() => {
@@ -46,6 +46,23 @@ describe("analytics (GA4 events)", () => {
       const [, , params] = gtag.mock.calls[0];
       expect(params.value).toBe(0);
       expect(params.items[0].price).toBe(0);
+    });
+  });
+
+  describe("trackLead", () => {
+    it("fires a GA4 generate_lead event tagged with the source method", () => {
+      const gtag = vi.fn();
+      vi.stubGlobal("window", { gtag });
+      const ok = trackLead("enquiry_form");
+      expect(ok).toBe(true);
+      expect(gtag).toHaveBeenCalledWith("event", "generate_lead", {
+        method: "enquiry_form",
+      });
+    });
+
+    it("is a safe no-op when gtag is unavailable", () => {
+      vi.stubGlobal("window", {});
+      expect(trackLead("whatsapp_float")).toBe(false);
     });
   });
 


### PR DESCRIPTION
Fires GA4 `generate_lead` at the lead-capture points so leads are measured by channel — the funnel step between traffic and purchase. Enquiry form (on successful submit), floating WhatsApp click, floating Call click, each tagged with a `method`. Same defensive gtag helper as purchase (safe no-op if gtag absent) + 2 unit tests. After merge: mark `generate_lead` as a key event in GA4.