### PR TITLE
feat(courses): make the enquiry course-aware from cards and course pages (#8)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -25,13 +25,21 @@ import { ToastContainer, toast } from 'react-toastify';
 function App() {
   const [modalIsOpen, setIsOpen] = useState(false);
   const [enrollCourse, setEnrollCourse] = useState(null);
+  // Which course the enquiry was opened from, so the form can say so and the
+  // lead arrives with the course attached. `null` when opened from the navbar
+  // or anywhere else that isn't about one course in particular.
+  const [enquiryCourse, setEnquiryCourse] = useState(null);
 
-  let openModal=()=> {
+  let openModal=(course)=> {
+    // Guards against a click handler being passed straight in as `onClick`,
+    // which would otherwise put a SyntheticEvent in here.
+    setEnquiryCourse(typeof course === "string" ? course : course?.name || null);
     setIsOpen(true);
   }
 
   let closeModal=()=> {
     setIsOpen(false);
+    setEnquiryCourse(null);
   }
 
   // Enrolment modal — opened per course (paid → checkout, else → register).
@@ -62,7 +70,7 @@ function App() {
   
 
   return (
-    <AuthContext.Provider className="app" value={{ openModal, closeModal, openEnroll, closeEnroll, notify }}>
+    <AuthContext.Provider className="app" value={{ openModal, closeModal, openEnroll, closeEnroll, notify, enquiryCourse }}>
       <Navbar />
       <ToastContainer className={"toast"} autoClose={2500}/>
       <Modal
@@ -72,7 +80,7 @@ function App() {
         style={customStyles}
 
       >
-        <EnquiryForm />
+        <EnquiryForm course={enquiryCourse} />
       </Modal>
       <Modal
         isOpen={!!enrollCourse}

--- a/src/components/Pages/CourseDetail.jsx
+++ b/src/components/Pages/CourseDetail.jsx
@@ -101,7 +101,7 @@ function CourseDetail() {
             <button className="cd-book" type="button" onClick={() => openEnroll({ courseId: course.courseId, name: course.name, paid: course.paid, price: course.price })}>
               Book your seat
             </button>
-            <button className="cd-talk" type="button" onClick={openModal}>Talk to a counsellor</button>
+            <button className="cd-talk" type="button" onClick={() => openModal(course.name)}>Talk to a counsellor</button>
           </div>
         </header>
 

--- a/src/components/forms/Enquiry Form/EnquiryForm.jsx
+++ b/src/components/forms/Enquiry Form/EnquiryForm.jsx
@@ -12,12 +12,26 @@ import { trackLead } from '../../../lib/analytics';
 import axios from 'axios';
 
 const WHATSAPP_FALLBACK_NUMBERS=["918073762257","919110424403"]
-const WHATSAPP_PREFILL=encodeURIComponent("Hi Rest Coder Academy, I'd like to enquire about a course.")
+const waPrefill=(course)=>encodeURIComponent(
+  course
+    ? `Hi Rest Coder Academy, I'd like to enquire about ${course}.`
+    : "Hi Rest Coder Academy, I'd like to enquire about a course.")
 const SUBMIT_TIMEOUT_MS=10000
 
-function EnquiryForm() {
+/**
+ * `course` is the course the enquiry was opened from — a course card or a
+ * /courses/<slug> page — and is null when it was opened from the navbar.
+ *
+ * It seeds the message rather than adding a field of its own. The enquiries
+ * table has no course column, and adding one would mean a migration against
+ * the live lead pipe for something the message can carry today (#8). Uday
+ * reads the message, so the course reaches him either way.
+ */
+function EnquiryForm({ course = null }) {
 
-  let [enquiryData,setenquiryData]=useState({fullname:"",mobile:"",email:"",experience:"",message:""})
+  const courseLine = course ? `I'd like to enquire about ${course}.` : ""
+
+  let [enquiryData,setenquiryData]=useState({fullname:"",mobile:"",email:"",experience:"",message:courseLine})
   // const { register, handleSubmit, watch, formState: { errors } , control, reset} = useForm();
   let [enquiryErrors,setenquiryErrors]=useState({})
   let [isSubmitting,setIsSubmitting]=useState(false)
@@ -149,8 +163,7 @@ const handleSubmit = async (e)=>
         <TypoGraphyComponent
           component="h6"
           variant="h6"
-            text="Enquire Now"
-        //   text="Login"
+          text={course ? `Enquire — ${course}` : "Enquire Now"}
         />
        <ButtonComponent
        paddingX={1}
@@ -228,7 +241,7 @@ const handleSubmit = async (e)=>
                 <a
                   key={num}
                   className="enquiry-whatsapp-fallback"
-                  href={`https://wa.me/${num}?text=${WHATSAPP_PREFILL}`}
+                  href={`https://wa.me/${num}?text=${waPrefill(course)}`}
                   target="_blank"
                   rel="noopener noreferrer"
                 >

--- a/src/components/organism/courses/CoursesCard.jsx
+++ b/src/components/organism/courses/CoursesCard.jsx
@@ -164,7 +164,7 @@ function CoursesCard({ name, courseId, slug, paid, flagship, price, trainer, aud
           <button className="cc-book" type="button" onClick={book}>
             Book your seat
           </button>
-          <button className="cc-counsellor" type="button" onClick={openModal}>
+          <button className="cc-counsellor" type="button" onClick={() => openModal(name)}>
             Or talk to a counsellor first
           </button>
           <Link className="cc-details" to={`/courses/${slug || courseId}`}>


### PR DESCRIPTION
Closes #8

## Most of #8 is already on `main`

Routing landed in earlier PRs. I verified the ticket's checklist against `main` in a browser rather than assuming:

| Ticket item | State |
|---|---|
| Wire `react-router-dom` | ✅ `App.jsx` renders `<Routes>` |
| `/` homepage as today | ✅ |
| `/courses/java-full-stack`, `/courses/python-full-stack`, `/courses/mern-stack` | ✅ all 200, driven off `courses.js` slugs |
| Course name + audience, next batch, duration, syllabus, trainer, placements | ✅ `CourseDetail.jsx` |
| Cards link through, secondary "view syllabus" | ✅ "Full syllabus & details →" |
| Shared Navbar + Footer, logo returns to `/` | ✅ both render outside `<Routes>` |
| Deep links, back/forward | ✅ `back -> /`, `forward -> /courses/java-full-stack` |
| Unknown slug | ✅ redirects to `/` |
| **Enquiry form with the course pre-filled** | ❌ — this PR |

The old `feat/per-course-pages-routing` branch is obsolete: `main` has moved ~4,800 lines past it, and merging it now would delete `analytics.js`, `sitemap.test.js` and the courses data tests. **It should be deleted, not merged.**

## What this PR adds

Every CTA opened the same anonymous modal, so a lead from the MERN page and a lead from the navbar arrived at Uday looking identical.

- `openModal(course)` now takes the course. It **guards the argument**, because most call sites pass the handler straight in as `onClick` and would otherwise hand it a SyntheticEvent — those keep the generic form.
- The modal heading names the course: *"Enquire — MERN Stack"*.
- The message seeds with *"I'd like to enquire about &lt;course&gt;."*, still editable.
- The WhatsApp fallback carries the course too — otherwise the context is lost at exactly the moment the form has already failed.

## Why the message, and not a new column

The course seeds the **message** rather than adding a field of its own. The `enquiries` table has no course column, and adding one means a schema migration against the live lead pipe for something the message carries today. That pipe silently dropped every lead once already (#2) — not worth reopening for a nicety. Uday reads the message, so the course reaches him either way.

If a real `course` column is wanted later, it is a migration plus one `INSERT` in `functions/api/enquiry.js`; the form already knows the value.

## Verified in the browser

```
course card   heading "Enquire — Forward Deployed Engineering"  message seeded
/courses/*    heading "Enquire — MERN Stack"                    message seeded
navbar        heading "Enquire Now"                             message empty   <- event guard holds
on failure    WhatsApp text "…I'd like to enquire about Java Full Stack."
```

## Checks

- `npm run test` — 75 passed
- `npm run build` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DjmEGczffCE2uiKAtdiXuE