### PR TITLE
feat(courses): reserved price slot, equal card heights, format on the detail page (#12)

### DIFF
--- a/src/components/Pages/CourseDetail.css
+++ b/src/components/Pages/CourseDetail.css
@@ -57,7 +57,7 @@
 }
 .cd-price { font-size: 30px; font-weight: 800; letter-spacing: -0.5px; }
 .cd-price small { font-size: 13px; font-weight: 400; color: #aeb6e0; }
-.cd-batch, .cd-trainer { font-size: 14px; color: #dfe3f7; }
+.cd-batch, .cd-trainer, .cd-format { font-size: 14px; color: #dfe3f7; }
 .cd-batch b, .cd-trainer b {
   display: block;
   font-size: 10px;

--- a/src/components/Pages/CourseDetail.jsx
+++ b/src/components/Pages/CourseDetail.jsx
@@ -42,6 +42,9 @@ function CourseDetail() {
 
   const url = `${ORIGIN}/courses/${course.slug || course.courseId}`;
   const priceLabel = `₹${Number(course.price).toLocaleString("en-IN")}`;
+  const formatLabel = next
+    ? [next.duration, next.mode].filter(Boolean).join(" · ")
+    : "";
   const nextLabel = next
     ? [next.day, formatBatchDateShort(next.date), next.time].filter(Boolean).join(" · ")
     : "New dates coming soon";
@@ -93,6 +96,14 @@ function CourseDetail() {
           <div className="cd-meta">
             <span className="cd-price">{priceLabel}<small> · EMI available</small></span>
             <span className="cd-batch"><b>Next batch</b> {nextLabel}</span>
+            {/* Duration and mode (#12). They were on the card but not here, so
+                the page a Java Full Stack ad lands on said less about the
+                course than the card the visitor had already scrolled past.
+                Both come off the batch, and the row is only rendered when
+                there is a batch to read them from. */}
+            {formatLabel && (
+              <span className="cd-format"><b>Format</b> {formatLabel}</span>
+            )}
             {course.flagship && course.trainer && (
               <span className="cd-trainer"><b>Trainer</b> {course.trainer}</span>
             )}

--- a/src/components/organism/courses/CourseCard.css
+++ b/src/components/organism/courses/CourseCard.css
@@ -104,7 +104,14 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 12px;
+  gap: var(--rca-space-3);
+  /* A reserved slot, not conditional markup (#12). "₹35,000 · EMI available"
+     is set at 27px and "Fee on request" at 18px, so without a floor the row
+     collapsed by ~14px and a course whose price is not public produced a
+     shorter card than the one beside it. The row holds either answer at the
+     same height, so pricing can be turned on per course without the grid
+     moving. */
+  min-height: 41px;
 }
 .cc-price {
   font-size: 27px;
@@ -112,12 +119,12 @@
   color: var(--rca-navy, #03084c);
   letter-spacing: -0.5px;
 }
-.cc-price small { font-size: 12px; font-weight: 400; color: #45545d; }
+.cc-price small { font-size: var(--rca-fs-caption); font-weight: 400; color: var(--rca-ink-soft); }
 .cc-price--request {
   font-size: var(--rca-fs-lead, 18px);
   font-weight: 500;
   letter-spacing: 0;
-  color: #45545d;
+  color: var(--rca-ink-soft);
 }
 .cc-tag {
   flex-shrink: 0;
@@ -182,7 +189,12 @@
   border-radius: var(--rca-radius-pill, 999px);
 }
 
-.cc-syllabus { margin-top: 18px; }
+.cc-syllabus {
+  margin-top: var(--rca-space-4);
+  /* Push the foot to the bottom of the card so every CTA in the row sits on
+     the same line, whatever the syllabus above it came to. */
+  flex: 1 1 auto;
+}
 .cc-syllabus-label {
   font-size: 10.5px;
   font-weight: 700;
@@ -244,3 +256,31 @@
   text-decoration: none;
 }
 .cc-details:hover { text-decoration: underline; }
+
+/* The reserved "+N more" row (#12). It is always rendered — as a link when
+   modules are hidden, as an empty box of the same height when they are not —
+   so the card height does not depend on how long a syllabus happens to be. */
+.cc-syllabus-more {
+  display: flex;
+  align-items: center;
+  min-height: var(--rca-control-h-mobile);
+  margin-top: var(--rca-space-2);
+}
+
+.cc-syllabus-more a {
+  font-size: var(--rca-fs-small);
+  font-weight: var(--rca-fw-semibold);
+  color: var(--rca-blue);
+  text-decoration: none;
+}
+
+.cc-syllabus-more a:hover {
+  text-decoration: underline;
+  text-underline-offset: 3px;
+}
+
+.cc-syllabus-more a:focus-visible {
+  outline: none;
+  box-shadow: var(--rca-focus-ring);
+  border-radius: var(--rca-radius-sm);
+}

--- a/src/components/organism/courses/CoursesCard.jsx
+++ b/src/components/organism/courses/CoursesCard.jsx
@@ -80,6 +80,15 @@ function CoursesCard({ name, courseId, slug, paid, flagship, price, trainer, aud
 
   const book = () => openEnroll({ courseId, name, paid, price });
 
+  /* The syllabus was the only thing making the cards different heights: the
+     three standard courses list 10, 9 and 12 modules, which came out as 753,
+     727 and 805px cards in a row that is meant to read as a set. Capping the
+     list is what makes them match, and the full list is one tap away on the
+     course page — which is where #8 wants the traffic anyway. */
+  const VISIBLE_MODULES = 8;
+  const shownModules = modules.slice(0, VISIBLE_MODULES);
+  const hiddenModules = Math.max(0, modules.length - VISIBLE_MODULES);
+
   return (
     <div className={"course-card" + (flagship ? " course-card--flagship" : "")}>
       <div className="cc-head">
@@ -151,13 +160,26 @@ function CoursesCard({ name, courseId, slug, paid, flagship, price, trainer, aud
         <div className="cc-syllabus">
           <div className="cc-syllabus-label">What you'll {flagship ? "master" : "learn"}</div>
           <ul>
-            {modules.map((m, i) => (
+            {shownModules.map((m, i) => (
               <li key={i} className={flagship && i === modules.length - 1 ? "cc-capstone" : ""}>
                 <Check filled={flagship && i === modules.length - 1} />
                 <span>{m}</span>
               </li>
             ))}
           </ul>
+          {/* A reserved row, not conditional markup. With extra modules it is a
+              link to the full syllabus; without, it is an empty spacer of the
+              same height — so a course with nine modules and one with twelve
+              produce a card of exactly the same height. */}
+          <div className="cc-syllabus-more">
+            {hiddenModules > 0 ? (
+              <Link to={`/courses/${slug || courseId}`}>
+                +{hiddenModules} more {hiddenModules === 1 ? "module" : "modules"}
+              </Link>
+            ) : (
+              <span aria-hidden="true" />
+            )}
+          </div>
         </div>
 
         <div className="cc-foot">


### PR DESCRIPTION
Closes #12

Nik unblocked this — prices public, full fee online — and left the FDE card direction to me.

## My call: Direction A, adapted within the tokens

The flagship keeps its premium weight (navy header, "Flagship" pill, trainer credibility line, chips, capstone) because a ₹50,000 course earns it. What changes is that the **three standard cards become a genuine set** rather than three cards that happen to sit in a row.

I did not resurrect PR #59 — it is closed and conflicting, and the uniform-vs-flagship question it was answering is settled by this.

## The price row is a reserved slot, not conditional markup

Both variants already existed, but nothing held the height. `₹35,000 · EMI available` is set at 27px and `Fee on request` at 18px, so **a course whose price is not public produced a card ~14px shorter than the one beside it**.

Verified by swapping one card to the request variant in the live DOM:

```
priceRowH: 41        cardUnchanged: true
before [981, 751, 751, 751]
after  [981, 751, 751, 751]
```

That is what lets pricing be turned on per course — the FDE track was enquiry-only until its price landed — without the grid moving.

## The cards were never actually uniform

The syllabus was the only thing making them differ. 10, 9 and 12 modules came out as **753, 727 and 805px** in a row that is meant to read as a set.

The list is capped at 8, with a reserved **"+N more modules"** row underneath — always rendered, as a link when there are extras and as an empty box of the same height when there are not. The full list is one tap away on the course page, which is where #8 wants the traffic anyway.

| | before | after |
|---|---|---|
| Flagship (FDE) | 930 | 981 |
| Java Full Stack | 753 | **751** |
| Python Full Stack | 727 | **751** |
| MERN Stack | 805 | **751** |

## Duration and mode on the course detail page

They were on the card but not on the page — so a Java Full Stack ad landed somewhere that said *less* about the course than the card the visitor had already scrolled past. Both come off the batch, and the row only renders when there is a batch to read them from.

```
/courses/java-full-stack   ₹35,000 · EMI available   ·   4 months · offline
/courses/mern-stack        ₹35,000 · EMI available   ·   4 months · offline
```

## Already delivered, checked not rebuilt

The rest of #12's checklist is on `main` already: the enrolment flow (`EnrollForm` → Razorpay → verify → D1), the referral code field, and "Book your seat" as primary with the counsellor as secondary. I verified rather than duplicated.

## Note

At 375 the standard cards come out 747 / 767 / 767 — a 20px spread from a syllabus line wrapping differently. The cards are stacked in one column at that width, so it is not visible as a mismatch; I left it rather than truncate real module names.

## Checks

- `npm run test` — 75 passed
- `npx playwright test` — 12 passed
- `npm run build` — clean
- `npm run lint` — 19 errors in the touched files vs **20 on `main`**; all pre-existing, none added

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DjmEGczffCE2uiKAtdiXuE