### PR TITLE
fix(contact): switch to restcoderacademy@gmail.com — old address bounces

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,7 +55,7 @@
       "logo": "https://restcoderacademy.in/favicon.png",
       "image": "https://restcoderacademy.in/favicon.png",
       "description": "Live, project-based full-stack coding courses (Java, Python, MERN) and a Forward Deployed Engineering program in Bengaluru, with placement support, EMI, and weekly progress reports visible to guardians.",
-      "email": "enquiry@restcoderacademy.com",
+      "email": "restcoderacademy@gmail.com",
       "telephone": "+91-80737-62257",
       "hasMap": "https://maps.app.goo.gl/XdZWt3oDzGUCL5KWA",
       "areaServed": "Bengaluru",

--- a/src/components/Pages/Contact.jsx
+++ b/src/components/Pages/Contact.jsx
@@ -17,7 +17,11 @@ const ADDRESS = {
 };
 const PHONE_DISPLAY = "+91 80737 62257";
 const PHONE_TEL = "+918073762257";
-const EMAIL = "enquiry@restcoderacademy.com";
+// The old enquiry@restcoderacademy.com address hard-bounces (.com is expired
+// at GoDaddy per README; the .in domain has no MX). Until we set up mail on
+// restcoderacademy.in, use the working Gmail address. Everyone who copies
+// this from the site actually reaches an inbox we check.
+const EMAIL = "restcoderacademy@gmail.com";
 
 function Contact() {
   const { openModal } = useAuth();

--- a/src/components/molecules/Footer Components/FooterAddress.jsx
+++ b/src/components/molecules/Footer Components/FooterAddress.jsx
@@ -8,7 +8,7 @@ import TypoGraphyComponent from '../../atoms/TypoGraphyComponent/TypoGraphyCompo
 function FooterAddress() {
   let address=`#364, 3rd Floor, 16th Main, 4th T Block East, Pattabhirama Nagar, Jayanagar, Bengaluru, Karnataka 560041`
 let contact=`Mobile: 8073762257`;
-let email=`Email: enquiry@restcoderacademy.com`;
+let email=`Email: restcoderacademy@gmail.com`;
 
 
   return (


### PR DESCRIPTION
## Summary

Every place we published `enquiry@restcoderacademy.com` — the Contact page (`mailto:` link), the footer, and the `EducationalOrganization` JSON-LD in `index.html` — **hard-bounces silently**.

The README already flags the cause: `restcoderacademy.com` lapsed at GoDaddy, and `restcoderacademy.in` has no MX record. Anyone who copies the address from the site (or from a Google/AI SERP that reads our schema) sends into the void and never hears back. The enquiry FORM works fine because it writes to D1, not email — so this only affects people who prefer to email.

Swap to `restcoderacademy@gmail.com` everywhere it's shown to users:

- `src/components/Pages/Contact.jsx`
- `src/components/molecules/Footer Components/FooterAddress.jsx`
- `index.html` (JSON-LD schema `email`)

Not touched: README's warning that the `.com` domain itself is expired — still accurate.

Once we set up mail on `restcoderacademy.in` (Cloudflare Email Routing is the plan) we can swap back to a branded address in a follow-up.

## Test plan

- [x] `npm test` — 75 tests passing
- [x] `npm run build` — clean
- [x] `npm run lint` — no new errors introduced on either file (baseline is pre-existing unused MUI imports + one irregular-whitespace warning in `FooterAddress.jsx`)
- [ ] After merge + deploy: verify `curl https://restcoderacademy.in/contact` shows `restcoderacademy@gmail.com` in the `mailto:` link
- [ ] After deploy: verify `curl https://restcoderacademy.in/ | grep '"email"'` shows the Gmail address in JSON-LD

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014PnGG9Moyg9MTGr3j3vmHy