### PR TITLE
[P1] ButtonComponent — add hover, pressed, focus & loading states (closes #7)

### DIFF
--- a/src/components/atoms/ButtonComponent/ButtonComponent.jsx
+++ b/src/components/atoms/ButtonComponent/ButtonComponent.jsx
@@ -1,85 +1,99 @@
-import { Button } from "@mui/material";
-import { makeStyles } from "@mui/styles";
-import DeleteIcon from "@mui/icons-material/Delete";
-
-const useStyles = makeStyles({
-  root: {
-    " &:disabled": {
-      backgroundColor: "var(--rca-disabled-ink)",
-      color: "white",
-    },
-
-  },
-});
+import { Button, CircularProgress } from "@mui/material";
 
 const ButtonComponent = ({
   label = "",
   variant = "contained",
   onBtnClick = () => {},
-  size = "small",
-  borderRadius = "4px",
-  textColor = "color-white",
-  bgColor = "bg-btn-blue",
   fullWidth = false,
   disabled = false,
+  loading = false,
   children,
-  paddingX= 3,
-  paddingY=1,
-  // component = "",
-  // iconPosition = "start",
-  // icon = <DeleteIcon />,
-  // showIcon = false,
   sx = {},
   onMouseLeave = () => {},
   onMouseEnter = () => {},
-  type="button"
+  type = "button",
+  // backward-compat props — no longer applied
+  size: _size,
+  borderRadius: _borderRadius,
+  bgColor: _bgColor,
+  textColor: _textColor,
+  paddingX: _paddingX,
+  paddingY: _paddingY,
 }) => {
-  const classes = useStyles();
-
-  // let IconProp = showIcon
-  //   ? iconPosition === "start"
-  //     ? {
-  //         startIcon: icon,
-  //       }
-  //     : { endIcon: icon }
-  //   : {};
-
   return (
     <Button
       variant={variant}
       onClick={onBtnClick}
       onMouseEnter={onMouseEnter}
       onMouseLeave={onMouseLeave}
-      size={size}
-      className={`${
-        disabled === true
-          ? classes.root
-          : // eslint-disable-next-line no-nested-ternary
-          variant === "contained"
-          ? `${bgColor} ${textColor}`
-          : variant === "outlined"
-          ? `${textColor}`
-          : variant === "text"
-          ? `${textColor}`
-          : ""
-      } `}
+      aria-busy={loading || undefined}
       sx={{
+        // text variant: min touch target only, no forced height
+        ...(variant === "text"
+          ? { minHeight: 44 }
+          : { height: "var(--rca-control-h)" }),
+        borderRadius: "var(--rca-radius-md)",
         textTransform: "capitalize",
-        borderRadius: { borderRadius },
-        paddingX: paddingX,
-        paddingY: paddingY,
+        transition: "background-color var(--rca-transition), border-color var(--rca-transition)",
+        position: "relative",
+        ...(variant === "contained" && {
+          backgroundColor: loading ? "var(--rca-navy-pressed)" : "var(--rca-navy)",
+          color: "var(--rca-ink-invert)",
+          boxShadow: "none",
+          "&:hover": { backgroundColor: "var(--rca-navy-hover)", boxShadow: "none" },
+          "&:active": { backgroundColor: "var(--rca-navy-pressed)", boxShadow: "none" },
+          "&:focus-visible, &.Mui-focusVisible": { boxShadow: "var(--rca-focus-ring)", outline: "none" },
+          "&.Mui-disabled": {
+            backgroundColor: loading ? "var(--rca-navy-pressed)" : "var(--rca-disabled-bg)",
+            color: loading ? "var(--rca-ink-invert)" : "var(--rca-disabled-ink)",
+          },
+        }),
+        ...(variant === "outlined" && {
+          borderColor: "var(--rca-navy)",
+          color: "var(--rca-navy)",
+          "&:hover": { backgroundColor: "rgba(3, 8, 76, 0.06)", borderColor: "var(--rca-navy)" },
+          "&:active": { backgroundColor: "rgba(3, 8, 76, 0.10)", borderColor: "var(--rca-navy)" },
+          "&:focus-visible, &.Mui-focusVisible": { boxShadow: "var(--rca-focus-ring)", outline: "none" },
+          "&.Mui-disabled": { borderColor: "var(--rca-disabled-bg)", color: "var(--rca-disabled-ink)" },
+        }),
+        ...(variant === "text" && {
+          color: "var(--rca-ink)",
+          "&:focus-visible, &.Mui-focusVisible": { boxShadow: "var(--rca-focus-ring)", outline: "none" },
+        }),
         ...sx,
       }}
       fullWidth={fullWidth}
-      disabled={disabled}
+      disabled={disabled || loading}
       disableRipple
-      disableFocusRipple
       disableElevation
       type={type}
-      
     >
-      {label}
-      {children}
+      {loading ? (
+        <>
+          {/* hidden original content keeps button width stable */}
+          <span aria-hidden="true" style={{ visibility: "hidden", display: "inline-flex", alignItems: "center" }}>
+            {label}{children}
+          </span>
+          <span
+            style={{
+              position: "absolute",
+              inset: 0,
+              display: "inline-flex",
+              alignItems: "center",
+              justifyContent: "center",
+              gap: 6,
+            }}
+          >
+            <CircularProgress size={16} color="inherit" />
+            Sending…
+          </span>
+        </>
+      ) : (
+        <>
+          {label}
+          {children}
+        </>
+      )}
     </Button>
   );
 };

--- a/src/components/forms/Enquiry Form/EnquiryForm.jsx
+++ b/src/components/forms/Enquiry Form/EnquiryForm.jsx
@@ -1,4 +1,4 @@
-import { Box, CircularProgress } from '@mui/material';
+import { Box } from '@mui/material';
 import React, { useState } from 'react'
 import InputBoxComponent from '../../atoms/InputBoxComponent/InputBoxComponent';
 import TextAreaComponent from '../../atoms/TextAreaComponent/TextAreaComponent';
@@ -241,16 +241,10 @@ const handleSubmit = async (e)=>
         <Box className="enquiry-field-button">
           <ButtonComponent
             variant="contained"
-            bgColor="bg-btn-blue"
-            borderRadius="0px"
-            paddingX={1.5}
-            paddingY={0.7}
             type="submit"
-            disabled={isSubmitting}
+            loading={isSubmitting}
           >
-            {isSubmitting
-              ? <><CircularProgress size={16} color="inherit" className="enquiry-submit-spinner" /> Sending…</>
-              : "Submit"}
+            Submit
           </ButtonComponent>
         </Box>
       </Box>

--- a/src/components/molecules/Navbar/Navbar.jsx
+++ b/src/components/molecules/Navbar/Navbar.jsx
@@ -110,7 +110,7 @@ function Navbar(props) {
                 </ButtonComponent>
               </RouterLink>
             ))}
-             <ButtonComponent variant='contained' bgColor='bg-btn-blue' borderRadius='0px' paddingX={1.5} paddingY={.7} onBtnClick={openModal}>
+             <ButtonComponent variant='contained' onBtnClick={openModal}>
                     Apply Now
                 </ButtonComponent>
           </Box>

--- a/src/components/organism/Banner/Banner.css
+++ b/src/components/organism/Banner/Banner.css
@@ -49,10 +49,6 @@
 
 
 
-.banner-content-btns button:hover
-{
-  background-color: var(--rca-blue)!important;
-}
 
 
 /* .banner-content-btns button:active
@@ -93,11 +89,6 @@
             .banner .banner-image
             {
                 margin-top: 2rem;
-            }
-            .banner .banner-content-btns button
-            {
-                border-radius: 30px!important
-
             }
 
         }

--- a/src/components/organism/Banner/BannerContent.jsx
+++ b/src/components/organism/Banner/BannerContent.jsx
@@ -30,7 +30,7 @@ function BannerContent() {
         At <span className="color-dark-blue">REST CODER ACADEMY</span>{quote}
         </TypoGraphyComponent>
       <Box className="banner-content-btns">
-              <ButtonComponent  sx={{px:"2rem"}} variant='contained' size="large" color="" borderRadius="0" onBtnClick={openModal}>
+              <ButtonComponent sx={{px:"2rem"}} variant='contained' onBtnClick={openModal}>
                     Register Now
                 </ButtonComponent>
       </Box>

--- a/src/components/organism/Batches/BatchesCard.jsx
+++ b/src/components/organism/Batches/BatchesCard.jsx
@@ -66,7 +66,6 @@ import { courses } from '../courses/courses';
           size="large"
           variant={canEnroll && course.paid ? "contained" : "outlined"}
           label={ctaLabel}
-          borderRadius="0"
           sx={{}}
           onBtnClick={onCta}
         />


### PR DESCRIPTION
## What

Implements all button states specified in `design/ui-template.html §3` and the issue checklist.

## Changes

**`ButtonComponent.jsx`** — full rewrite
- 6 states via MUI `sx`: default · hover `#0A1270` · pressed `#01062F` · focus-visible 3px ring · disabled · loading
- `loading` prop: spinner + "Sending…" overlaid absolutely; original content hidden (`visibility:hidden`) to keep button width stable; `aria-busy` + `aria-hidden` for screen readers
- Height `var(--rca-control-h)` (48px desktop / 44px mobile via token) on `contained`/`outlined`; `minHeight: 44px` on `text` variant to keep navbar toolbar layout intact
- `border-radius: var(--rca-radius-md)` (8px) — removes all per-call-site `borderRadius="0"/"0px"` overrides
- Transition on `background-color` + `border-color`, `180ms cubic-bezier(0.2,0,0,1)`
- Dropped `disableFocusRipple`; kept `disableRipple` (no lift/scale per spec)
- Both `contained` and `outlined` variants get full 6-state treatment
- Focus selector: `&:focus-visible, &.Mui-focusVisible` for cross-browser + MUI compat
- Dead props (`bgColor`, `textColor`, `borderRadius`, `paddingX`, `paddingY`, `size`) kept in signature for backward compat, no longer applied

**`Banner.css`** — two `!important` overrides removed
- `.banner-content-btns button:hover { background-color: var(--rca-blue)!important }` was overriding our hover state with the wrong colour
- Mobile `border-radius: 30px!important` was overriding `var(--rca-radius-md)`

**Call sites cleaned** (`borderRadius` / `bgColor` props removed):
- `EnquiryForm.jsx` — manual `CircularProgress` + `disabled={isSubmitting}` replaced with `loading={isSubmitting}`
- `Navbar.jsx`, `BannerContent.jsx`, `BatchesCard.jsx`

## Test plan

- [ ] Navbar "Apply Now" — hover shifts lighter, click darkens, tab shows focus ring
- [ ] Hero "Register Now" — same states, `px: 2rem` still applies
- [ ] Batches outlined variant — hover subtle fill, focus ring
- [ ] Enquiry form submit — throttle network to Slow 3G, submit → spinner + "Sending…" appears, button width stable, double-submit blocked
- [ ] Tab through entire page — every button reachable and shows focus ring
- [ ] No console errors about unknown props

🤖 Generated with [Claude Code](https://claude.com/claude-code)