### PR TITLE
fix(ci): bump Node from 20 → 22 (wrangler v4 requires ≥22)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
       - run: npm ci
       - run: npm test
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
       - run: npm ci
       - run: npx playwright install --with-deps chromium
@@ -46,7 +46,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
       - run: npm ci
       - run: npx playwright install --with-deps chromium


### PR DESCRIPTION
Follow-on to #132. Pinning wrangler as a devDep unblocked the immediate "webServer timed out" flake — but exposed the real error the timeout had been hiding:

\`\`\`
[WebServer] Wrangler requires at least Node.js v22.0.0.
You are using v20.20.2. Please update your version of Node.js.
Error: Process from config.webServer was not able to start. Exit code: 1
\`\`\`

Locally E2E passed because my machine runs newer Node. In CI setup-node@v4 was pinning us to 20, so wrangler exited immediately and Playwright dutifully failed the run.

Bump all three jobs (unit+integration, e2e, deploy) to \`node-version: 22\` — matches wrangler's own requirement and Node 20's deprecation warning that GitHub Actions has started emitting.

## What this unblocks

After merge → deploy job runs → main goes live with everything currently sitting on the branch but never shipped:
- #130 email fix (\`enquiry@restcoderacademy.com\` → \`restcoderacademy@gmail.com\`)
- #132 wrangler devDep pin

## Test plan
- [x] One-line workflow change; no code touched.
- [ ] After merge: E2E on main passes, Deploy job runs, live \`curl https://restcoderacademy.in/ | grep '"email"'\` returns the Gmail address.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014PnGG9Moyg9MTGr3j3vmHy