### PR TITLE
[#58] Re-align course card to Abhigna's design — remove bespoke flagship extras

### DIFF
--- a/src/components/organism/courses/CourseCard.css
+++ b/src/components/organism/courses/CourseCard.css
@@ -1,5 +1,5 @@
-/* Premium course card — the flagship look applied to every course, with
-   Abhigna's Book-your-seat flow. FDE adds .course-card--flagship extras. */
+/* Uniform course card — one design for every course (Abhigna §5).
+   Book-your-seat primary + counsellor secondary flow. */
 .course-card {
   width: 100%;
   max-width: 384px;
@@ -13,9 +13,6 @@
   font-family: var(--rca-font, "Montserrat", "Segoe UI", system-ui, sans-serif);
   text-align: left;
 }
-.course-card--flagship {
-  box-shadow: 0 14px 36px rgba(3, 8, 76, 0.16);
-}
 .course-card * { box-sizing: border-box; }
 
 /* --- Navy header --- */
@@ -23,20 +20,6 @@
   background: var(--rca-navy, #03084c);
   color: #fff;
   padding: 20px 24px 18px;
-}
-.cc-flagship {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  background: rgba(255, 152, 0, 0.16);
-  color: #ffb74d;
-  font-size: 10.5px;
-  font-weight: 700;
-  letter-spacing: 0.1em;
-  text-transform: uppercase;
-  padding: 5px 11px;
-  border-radius: var(--rca-radius-pill, 999px);
-  margin-bottom: 12px;
 }
 .cc-title {
   margin: 0;
@@ -176,21 +159,6 @@
   font-style: italic;
 }
 
-.cc-chips {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 7px;
-  margin-top: 14px;
-}
-.cc-chips span {
-  background: #f0f3f8;
-  color: #33415c;
-  font-size: 11.5px;
-  font-weight: 600;
-  padding: 5px 10px;
-  border-radius: var(--rca-radius-pill, 999px);
-}
-
 .cc-syllabus {
   margin-top: var(--rca-space-4);
   /* Push the foot to the bottom of the card so every CTA in the row sits on
@@ -215,7 +183,6 @@
 }
 .cc-syllabus li { display: flex; align-items: flex-start; gap: 10px; }
 .cc-syllabus li span { font-size: 13px; color: #333; line-height: 1.4; }
-.cc-syllabus li.cc-capstone span { color: var(--rca-navy, #03084c); font-weight: 600; }
 .cc-check { flex-shrink: 0; margin-top: 1px; }
 
 .cc-foot { margin-top: 20px; }

--- a/src/components/organism/courses/CoursesCard.jsx
+++ b/src/components/organism/courses/CoursesCard.jsx
@@ -25,10 +25,10 @@ function Check({ filled }) {
   );
 }
 
-// One premium card for every course. The paid flagship (FDE) adds a Flagship
-// pill, the trainer credibility line and highlight chips; every card shares the
-// navy header, check-icon syllabus, price slot ("Fee on request" until priced),
-// equal heights, and "Book your seat" + a counsellor secondary (Abhigna's flow).
+// Uniform card for every course (Abhigna §5). flagship prop is data-only:
+// selects the right syllabus arrays and trainer credibility line — no visual
+// difference. Navy header, price slot, equal heights, "Book your seat" primary
+// + counsellor secondary on every card.
 function CoursesCard({ name, courseId, slug, paid, flagship, price, trainer, audience, backend, frontend, syllabus1, syllabus2 }) {
   const { openEnroll, openModal } = useAuth();
   const { founder } = useFounder();

--- a/src/components/organism/courses/CoursesCard.jsx
+++ b/src/components/organism/courses/CoursesCard.jsx
@@ -76,8 +76,6 @@ function CoursesCard({ name, courseId, slug, paid, flagship, price, trainer, aud
   const modules = (
     flagship ? [...(syllabus1 || []), ...(syllabus2 || [])] : [...(backend || []), ...(frontend || [])]
   ).filter(Boolean);
-  const chips = flagship ? ["Project-based", "Live cohort", "Ship to production"] : [];
-
   const book = () => openEnroll({ courseId, name, paid, price });
 
   /* The syllabus was the only thing making the cards different heights: the
@@ -90,16 +88,8 @@ function CoursesCard({ name, courseId, slug, paid, flagship, price, trainer, aud
   const hiddenModules = Math.max(0, modules.length - VISIBLE_MODULES);
 
   return (
-    <div className={"course-card" + (flagship ? " course-card--flagship" : "")}>
+    <div className="course-card">
       <div className="cc-head">
-        {flagship && (
-          <span className="cc-flagship">
-            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" aria-hidden="true">
-              <path d="M12 2.5l2.85 6.05 6.65.7-4.95 4.5 1.35 6.55L12 17.6 6.1 20.8l1.35-6.55L2.5 9.25l6.65-.7L12 2.5z" fill="#FFB74D" />
-            </svg>
-            Flagship
-          </span>
-        )}
         <h3 className="cc-title">{name}</h3>
         <p className="cc-sub">{audience || "For Freshers & Working Professionals"}</p>
         {trainer && (
@@ -149,20 +139,12 @@ function CoursesCard({ name, courseId, slug, paid, flagship, price, trainer, aud
           )}
         </div>
 
-        {chips.length > 0 && (
-          <div className="cc-chips">
-            {chips.map((c, i) => (
-              <span key={i}>{c}</span>
-            ))}
-          </div>
-        )}
-
         <div className="cc-syllabus">
-          <div className="cc-syllabus-label">What you'll {flagship ? "master" : "learn"}</div>
+          <div className="cc-syllabus-label">What you'll learn</div>
           <ul>
             {shownModules.map((m, i) => (
-              <li key={i} className={flagship && i === modules.length - 1 ? "cc-capstone" : ""}>
-                <Check filled={flagship && i === modules.length - 1} />
+              <li key={i}>
+                <Check filled={false} />
                 <span>{m}</span>
               </li>
             ))}


### PR DESCRIPTION
## What

Removes the bespoke FDE flagship visual extras that made the card diverge from @Abhigna1975's `design/ui-template.html §5` spec. All courses now render one uniform card.

## Removed

| Element | Where |
|---------|-------|
| "Flagship" star pill badge | `CoursesCard.jsx`, `CourseCard.css` |
| Highlight chips (Project-based · Live cohort · Ship to production) | `CoursesCard.jsx`, `CourseCard.css` |
| "What you'll **master**" label split | `CoursesCard.jsx` |
| `cc-capstone` filled check on last module | `CoursesCard.jsx`, `CourseCard.css` |
| `course-card--flagship` elevated box-shadow | `CourseCard.css` |

## Kept

- `flagship` prop — still used for **data access only** (picks the right syllabus arrays, sets the FDE trainer credibility line). No visual effect remains.
- All existing uniform card features: navy header, reserved price slot, equal heights, "Book your seat" + counsellor secondary, schedule block, trainer block.

## Test plan

- [ ] All three course cards look identical in structure at desktop + mobile
- [ ] No "Flagship" badge or highlight chips visible on FDE card
- [ ] All syllabus items have the same unfilled check icon
- [ ] Card heights remain equal across the row
- [ ] "Book your seat" and "Or talk to a counsellor first" still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)