### PR TITLE
feat(portal): course + lesson schema and session-guarded course APIs (#136)

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,3 +259,19 @@ npx wrangler d1 execute restcoder-enquiries --file=./schema-users.sql
 | `GET /auth/:provider/callback` | exchange the code, **verify the ID token against the provider's JWKS**, upsert into `users`, issue the session cookie |
 | `GET /auth/me` | the current user, or 401. Also reports which providers are configured. |
 | `POST /auth/logout` | clear the session cookie |
+| `GET /api/portal/courses` | the signed-in student's enrolled courses, or 401 |
+| `GET /api/portal/courses/:slug` | one enrolled course with its published lessons. **404 when the student is not enrolled**, so slugs cannot be probed. |
+
+### Course content (Phase 2)
+
+Courses and lessons live in the same D1 database as `users`:
+
+```
+npx wrangler d1 execute restcoder-enquiries --file=./schema-courses.sql
+```
+
+`enrolments_users` is the resolved link between a portal account and a course.
+The older `enrollments` table cannot serve that role: it identifies a person by
+the email typed into the enquiry form and a course by free text, and its rows
+predate any sign-in. The backfill that maps one to the other is at the foot of
+`schema-courses.sql`.

--- a/functions/api/portal/courses.js
+++ b/functions/api/portal/courses.js
@@ -1,0 +1,29 @@
+// GET /api/portal/courses — the signed-in student's enrolled courses (#136).
+// Session-guarded: no cookie, no course data. Never cached, because the
+// response is specific to one student.
+import { getSession } from "../../../shared/auth.js";
+import { listEnrolledCourses } from "../../../shared/courses.js";
+
+const json = (body, status = 200) =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json", "cache-control": "no-store" },
+  });
+
+export async function onRequestGet(context) {
+  const { request, env } = context;
+
+  const session = await getSession(request, env);
+  if (!session) return json({ error: "unauthenticated" }, 401);
+
+  // No D1 binding is a server fault, not an empty course list. Returning []
+  // here would tell a student who has enrolments that they have none.
+  if (!env.DB) return json({ error: "unavailable" }, 503);
+
+  try {
+    const courses = await listEnrolledCourses(env.DB, session.uid);
+    return json({ courses });
+  } catch {
+    return json({ error: "unavailable" }, 503);
+  }
+}

--- a/functions/api/portal/courses/[slug].js
+++ b/functions/api/portal/courses/[slug].js
@@ -1,0 +1,32 @@
+// GET /api/portal/courses/:slug — one enrolled course with its lessons (#136).
+//
+// A student who is not enrolled gets the same 404 as a slug that does not
+// exist. A 403 would confirm the course is real, which is not something an
+// outsider should be able to learn by guessing slugs.
+import { getSession } from "../../../../shared/auth.js";
+import { getEnrolledCourse } from "../../../../shared/courses.js";
+
+const json = (body, status = 200) =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json", "cache-control": "no-store" },
+  });
+
+export async function onRequestGet(context) {
+  const { request, env, params } = context;
+
+  const session = await getSession(request, env);
+  if (!session) return json({ error: "unauthenticated" }, 401);
+  if (!env.DB) return json({ error: "unavailable" }, 503);
+
+  const slug = String(params.slug || "");
+  if (!slug) return json({ error: "not_found" }, 404);
+
+  try {
+    const course = await getEnrolledCourse(env.DB, session.uid, slug);
+    if (!course) return json({ error: "not_found" }, 404);
+    return json({ course });
+  } catch {
+    return json({ error: "unavailable" }, 503);
+  }
+}

--- a/schema-courses.sql
+++ b/schema-courses.sql
@@ -1,0 +1,63 @@
+-- Phase 2: course + lesson content for the student portal (#136).
+-- Lives in the same D1 database as the Phase 1 `users` table so a student's
+-- enrolments join to their account without a second datastore.
+
+CREATE TABLE IF NOT EXISTS courses (
+  id         INTEGER PRIMARY KEY AUTOINCREMENT,
+  slug       TEXT NOT NULL,                          -- URL id, e.g. 'fde'
+  title      TEXT NOT NULL,
+  summary    TEXT,
+  cover_url  TEXT,
+  published  INTEGER NOT NULL DEFAULT 0,             -- 0 until it is ready to show
+  created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_courses_slug ON courses (slug);
+
+CREATE TABLE IF NOT EXISTS lessons (
+  id               INTEGER PRIMARY KEY AUTOINCREMENT,
+  course_id        INTEGER NOT NULL REFERENCES courses(id) ON DELETE CASCADE,
+  position         INTEGER NOT NULL,                 -- order within the course, 1-based
+  title            TEXT NOT NULL,
+  notes            TEXT,                             -- markdown, the data-light half of a lesson
+  video_url        TEXT,                             -- filled in by the Phase 2 upload ticket
+  duration_seconds INTEGER,
+  published        INTEGER NOT NULL DEFAULT 0,
+  created_at       TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+-- The course page reads lessons for one course in order; this is that query.
+CREATE INDEX IF NOT EXISTS idx_lessons_course_position ON lessons (course_id, position);
+
+-- The resolved link between a portal account and a course.
+--
+-- The existing `enrollments` table cannot serve this. It predates the portal:
+-- it identifies a person by the email typed into the enquiry form and a course
+-- by a free-text string, and a row is written before the student has ever
+-- signed in. Joining portal reads to it directly would mean matching on email
+-- on every request and trusting a string to name a course. So enrolment is
+-- resolved once, into this table, keyed by the ids that actually exist.
+CREATE TABLE IF NOT EXISTS enrolments_users (
+  id            INTEGER PRIMARY KEY AUTOINCREMENT,
+  user_id       INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  course_id     INTEGER NOT NULL REFERENCES courses(id) ON DELETE CASCADE,
+  -- Which `enrollments` row this came from, when it came from one. Null for a
+  -- link an admin created by hand.
+  enrollment_id INTEGER,
+  created_at    TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+-- A student is enrolled in a course once, not once per sign-in.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_enrolments_users_pair
+  ON enrolments_users (user_id, course_id);
+
+-- Backfill, run after a student first signs in. Matches the enquiry-form email
+-- to the account email and the enrolment's course string to a course slug.
+-- Case-insensitive on email because the two came from different keyboards.
+--
+--   INSERT OR IGNORE INTO enrolments_users (user_id, course_id, enrollment_id)
+--   SELECT u.id, c.id, e.id
+--     FROM enrollments e
+--     JOIN users   u ON lower(u.email) = lower(e.email)
+--     JOIN courses c ON c.slug = e.course
+--    WHERE e.email IS NOT NULL;

--- a/shared/courses.js
+++ b/shared/courses.js
@@ -1,0 +1,51 @@
+// Course + lesson reads for the student portal (#136).
+//
+// These take the D1 binding rather than reaching for it, so the API routes stay
+// thin and the query shapes are unit-testable against a fake database.
+
+// The courses a student is actually enrolled in. Unpublished courses are
+// withheld even from an enrolled student: `published` is the academy's switch
+// for "this is ready to be seen", and an enrolment does not override it.
+export async function listEnrolledCourses(db, userId) {
+  const { results } = await db
+    .prepare(
+      "SELECT c.id, c.slug, c.title, c.summary, c.cover_url, " +
+        "(SELECT COUNT(*) FROM lessons l WHERE l.course_id = c.id AND l.published = 1) AS lesson_count " +
+        "FROM enrolments_users eu " +
+        "JOIN courses c ON c.id = eu.course_id " +
+        "WHERE eu.user_id = ?1 AND c.published = 1 " +
+        "ORDER BY c.title ASC"
+    )
+    .bind(userId)
+    .all();
+  return results || [];
+}
+
+// One course with its lessons, but only if this student is enrolled in it.
+//
+// Returns null both for "no such course" and for "not enrolled", deliberately.
+// The caller turns that into a 404 either way, so an outsider probing slugs
+// cannot tell a real course they lack access to from one that does not exist.
+export async function getEnrolledCourse(db, userId, slug) {
+  const course = await db
+    .prepare(
+      "SELECT c.id, c.slug, c.title, c.summary, c.cover_url " +
+        "FROM enrolments_users eu " +
+        "JOIN courses c ON c.id = eu.course_id " +
+        "WHERE eu.user_id = ?1 AND c.slug = ?2 AND c.published = 1"
+    )
+    .bind(userId, slug)
+    .first();
+  if (!course) return null;
+
+  const { results } = await db
+    .prepare(
+      "SELECT id, position, title, notes, video_url, duration_seconds " +
+        "FROM lessons WHERE course_id = ?1 AND published = 1 " +
+        "ORDER BY position ASC"
+    )
+    .bind(course.id)
+    .all();
+
+  return { ...course, lessons: results || [] };
+}

--- a/tests/portal.courses.test.js
+++ b/tests/portal.courses.test.js
@@ -1,0 +1,161 @@
+import { describe, it, expect } from "vitest";
+import { onRequestGet as listGet } from "../functions/api/portal/courses.js";
+import { onRequestGet as detailGet } from "../functions/api/portal/courses/[slug].js";
+import { listEnrolledCourses, getEnrolledCourse } from "../shared/courses.js";
+import { signSession } from "../shared/auth.js";
+
+const SECRET = "test-secret-value";
+
+// A fake D1 that records the SQL it was handed and replays canned rows. The
+// point is to assert the query shape and the route's behaviour around it, not
+// to reimplement SQLite: `plan` maps a matcher to the rows that query returns.
+function fakeDB(plan, log = []) {
+  return {
+    log,
+    prepare(sql) {
+      const stmt = {
+        sql,
+        args: [],
+        bind(...args) {
+          stmt.args = args;
+          return stmt;
+        },
+        async all() {
+          log.push({ sql, args: stmt.args });
+          return { results: resolve(plan, sql, stmt.args) ?? [] };
+        },
+        async first() {
+          log.push({ sql, args: stmt.args });
+          const rows = resolve(plan, sql, stmt.args);
+          return rows && rows.length ? rows[0] : null;
+        },
+      };
+      return stmt;
+    },
+  };
+}
+function resolve(plan, sql, args) {
+  for (const [needle, rows] of plan) {
+    if (sql.includes(needle)) return typeof rows === "function" ? rows(args) : rows;
+  }
+  return [];
+}
+const throwingDB = () => ({
+  prepare() {
+    return { bind: () => ({ all: async () => { throw new Error("d1 down"); }, first: async () => { throw new Error("d1 down"); } }) };
+  },
+});
+
+const session = (uid = 7) => signSession({ uid, email: "s@example.com", name: "S", role: "student" }, SECRET);
+const req = (url, token) =>
+  new Request(url, { headers: token ? { cookie: `rca_session=${token}` } : {} });
+
+describe("GET /api/portal/courses", () => {
+  it("401s without a session, and reads no course data", async () => {
+    const log = [];
+    const res = await listGet({ request: req("https://x/api/portal/courses"), env: { SESSION_SECRET: SECRET, DB: fakeDB([], log) } });
+    expect(res.status).toBe(401);
+    expect(log).toHaveLength(0);
+  });
+
+  it("401s on a tampered cookie", async () => {
+    const token = (await session()) + "x";
+    const res = await listGet({ request: req("https://x/api/portal/courses", token), env: { SESSION_SECRET: SECRET, DB: fakeDB([]) } });
+    expect(res.status).toBe(401);
+  });
+
+  it("returns the student's enrolled courses", async () => {
+    const db = fakeDB([["FROM enrolments_users", [{ id: 1, slug: "fde", title: "Full Dev", lesson_count: 3 }]]]);
+    const res = await listGet({ request: req("https://x/api/portal/courses", await session()), env: { SESSION_SECRET: SECRET, DB: db } });
+    expect(res.status).toBe(200);
+    expect((await res.json()).courses).toEqual([{ id: 1, slug: "fde", title: "Full Dev", lesson_count: 3 }]);
+  });
+
+  it("scopes the query to the caller's own user id", async () => {
+    const log = [];
+    const db = fakeDB([["FROM enrolments_users", []]], log);
+    await listGet({ request: req("https://x/api/portal/courses", await session(42)), env: { SESSION_SECRET: SECRET, DB: db } });
+    expect(log[0].args).toEqual([42]);
+    expect(log[0].sql).toContain("eu.user_id = ?1");
+  });
+
+  it("never caches a per-student response", async () => {
+    const res = await listGet({ request: req("https://x/api/portal/courses", await session()), env: { SESSION_SECRET: SECRET, DB: fakeDB([]) } });
+    expect(res.headers.get("cache-control")).toBe("no-store");
+  });
+
+  it("503s rather than reporting an empty course list when D1 is missing", async () => {
+    const res = await listGet({ request: req("https://x/api/portal/courses", await session()), env: { SESSION_SECRET: SECRET } });
+    expect(res.status).toBe(503);
+  });
+
+  it("503s when the query throws", async () => {
+    const res = await listGet({ request: req("https://x/api/portal/courses", await session()), env: { SESSION_SECRET: SECRET, DB: throwingDB() } });
+    expect(res.status).toBe(503);
+  });
+});
+
+describe("GET /api/portal/courses/:slug", () => {
+  const enrolled = [
+    ["FROM enrolments_users", [{ id: 5, slug: "fde", title: "Full Dev" }]],
+    ["FROM lessons", [{ id: 1, position: 1, title: "Intro", notes: "# hi" }]],
+  ];
+
+  it("401s without a session", async () => {
+    const res = await detailGet({ request: req("https://x/api/portal/courses/fde"), env: { SESSION_SECRET: SECRET, DB: fakeDB(enrolled) }, params: { slug: "fde" } });
+    expect(res.status).toBe(401);
+  });
+
+  it("returns the course with its lessons in order", async () => {
+    const res = await detailGet({ request: req("https://x/api/portal/courses/fde", await session()), env: { SESSION_SECRET: SECRET, DB: fakeDB(enrolled) }, params: { slug: "fde" } });
+    expect(res.status).toBe(200);
+    const { course } = await res.json();
+    expect(course.slug).toBe("fde");
+    expect(course.lessons).toHaveLength(1);
+  });
+
+  it("404s for a course the student is not enrolled in, and reads no lessons", async () => {
+    const log = [];
+    const db = fakeDB([["FROM enrolments_users", []], ["FROM lessons", [{ id: 1 }]]], log);
+    const res = await detailGet({ request: req("https://x/api/portal/courses/secret", await session()), env: { SESSION_SECRET: SECRET, DB: db }, params: { slug: "secret" } });
+    expect(res.status).toBe(404);
+    expect(log.some((q) => q.sql.includes("FROM lessons"))).toBe(false);
+  });
+
+  it("gives an unenrolled student the same 404 as a nonexistent slug", async () => {
+    const db = fakeDB([["FROM enrolments_users", []]]);
+    const a = await detailGet({ request: req("https://x/a", await session()), env: { SESSION_SECRET: SECRET, DB: db }, params: { slug: "real-but-not-mine" } });
+    const b = await detailGet({ request: req("https://x/b", await session()), env: { SESSION_SECRET: SECRET, DB: db }, params: { slug: "no-such-course" } });
+    expect(a.status).toBe(b.status);
+    expect(await a.json()).toEqual(await b.json());
+  });
+
+  it("404s on an empty slug", async () => {
+    const res = await detailGet({ request: req("https://x/api/portal/courses/", await session()), env: { SESSION_SECRET: SECRET, DB: fakeDB(enrolled) }, params: {} });
+    expect(res.status).toBe(404);
+  });
+});
+
+describe("course queries", () => {
+  it("withholds an unpublished course even from an enrolled student", async () => {
+    const log = [];
+    await listEnrolledCourses(fakeDB([], log), 1);
+    expect(log[0].sql).toContain("c.published = 1");
+  });
+
+  it("counts only published lessons", async () => {
+    const log = [];
+    await listEnrolledCourses(fakeDB([], log), 1);
+    expect(log[0].sql).toContain("l.published = 1");
+  });
+
+  it("returns null for a course the student is not enrolled in", async () => {
+    expect(await getEnrolledCourse(fakeDB([["FROM enrolments_users", []]]), 1, "fde")).toBeNull();
+  });
+
+  it("orders lessons by position", async () => {
+    const log = [];
+    await getEnrolledCourse(fakeDB([["FROM enrolments_users", [{ id: 5, slug: "fde" }]], ["FROM lessons", []]], log), 1, "fde");
+    expect(log[1].sql).toContain("ORDER BY position ASC");
+  });
+});


### PR DESCRIPTION
Part of #43. Closes #136.

Phase 2's data foundation, stacked on #127 (the session guard it depends on).
**Base is `feat/portal-login-home`, so review #127 first.**

### Schema (`schema-courses.sql`)

- `courses` (slug unique, `published` gate) and `lessons` (ordered by `position`, indexed on `(course_id, position)`).
- `enrolments_users`, the resolved link between a portal account and a course.

The older `enrollments` table cannot serve that role. It identifies a person by
the email typed into the enquiry form and a course by a free-text string, and a
row is written before the student has ever signed in. Joining portal reads to it
would mean matching on email on every request and trusting a string to name a
course. So enrolment is resolved once into its own table; the backfill query is
documented at the foot of the schema file.

### Endpoints

| Route | Behaviour |
|---|---|
| `GET /api/portal/courses` | the caller's enrolled courses, scoped to their own user id, or 401 |
| `GET /api/portal/courses/:slug` | one enrolled course with its published lessons, or 404 |

Two decisions worth a look in review:

- **404, not 403, for a course the student is not enrolled in.** A 403 would
  confirm the course exists, so slugs could be probed. An unenrolled student and
  a nonexistent slug get a byte-identical response; there is a test asserting that.
- **503, not `[]`, when D1 is missing or the query throws.** Returning an empty
  list would tell a student who has enrolments that they have none.

Unpublished courses stay hidden even from an enrolled student, and the lesson
count only counts published lessons.

### Tests

16 new tests, 123 passing overall. Covers the 401 paths (no cookie, tampered
cookie), user-id scoping, the identical-404 property, `no-store` on per-student
responses, both 503 paths, and that a 404 reads no lesson rows.

### Not in this PR

The student-facing UI is #137. The video player and instructor upload are
unticketed, both waiting on the storage decision, see the note below.

> **Open question for @nikshepkulli:** #43 says lesson video goes to Supabase
> storage, but Phase 1 and this PR are all-Cloudflare D1 with no Supabase. R2
> would keep it on one stack. Worth settling before the upload ticket is written.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UC2usWsvEYnGXQkZGeaA6b
