### PR TITLE
fix(seo): real 404 for unmatched routes + baseline security headers

### DIFF
--- a/public/404.html
+++ b/public/404.html
@@ -1,0 +1,84 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Page not found — Rest Coder Academy</title>
+    <meta name="robots" content="noindex, follow" />
+    <link rel="canonical" href="https://restcoderacademy.in/" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link rel="icon" type="image/png" href="/favicon.png" />
+    <style>
+      body {
+        margin: 0;
+        min-height: 100vh;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+        color: #37424f;
+        background: #f5f7fb;
+      }
+      main {
+        max-width: 520px;
+        padding: 40px 24px;
+        text-align: center;
+      }
+      .eyebrow {
+        font-size: 12px;
+        letter-spacing: 0.16em;
+        text-transform: uppercase;
+        color: #6b7280;
+        margin: 0 0 12px;
+      }
+      h1 {
+        font-size: 40px;
+        margin: 0 0 12px;
+        color: #03084c;
+        line-height: 1.15;
+      }
+      p {
+        font-size: 16px;
+        line-height: 1.6;
+        margin: 0 0 28px;
+      }
+      .cta {
+        display: inline-flex;
+        align-items: center;
+        gap: 8px;
+        padding: 12px 22px;
+        background: #03084c;
+        color: #fff;
+        text-decoration: none;
+        border-radius: 8px;
+        font-weight: 600;
+        min-height: 48px;
+      }
+      .cta:hover { background: #146389; }
+      .links {
+        margin-top: 24px;
+        font-size: 14px;
+      }
+      .links a {
+        color: #146389;
+        margin: 0 10px;
+        text-decoration: none;
+      }
+      .links a:hover { text-decoration: underline; }
+    </style>
+  </head>
+  <body>
+    <main>
+      <p class="eyebrow">404</p>
+      <h1>We couldn't find that page.</h1>
+      <p>The link may be broken, or the page may have moved. Head back to the site — the courses, batches and placements are all still where they were.</p>
+      <a class="cta" href="/">Back to Rest Coder Academy</a>
+      <p class="links">
+        <a href="/">Home</a>
+        <a href="/blog">Blog</a>
+        <a href="/placements">Placements</a>
+        <a href="/contact">Contact</a>
+      </p>
+    </main>
+  </body>
+</html>

--- a/public/_headers
+++ b/public/_headers
@@ -1,0 +1,31 @@
+# HTTP headers Cloudflare Pages injects on every response.
+# Applied top-to-bottom; more-specific rules override less-specific ones.
+#
+# What's here: three security headers that are safe on any request shape and
+# add real protection.
+#   Strict-Transport-Security  — belt-and-suspenders on top of the HTTP→HTTPS
+#     301 CF already does. Tells any browser that has visited once to refuse
+#     plain HTTP for this host and every subdomain for two years, and marks the
+#     header eligible for the HSTS preload list (add the domain at
+#     hstspreload.org when we're confident www→apex is stable).
+#   X-Frame-Options DENY       — no other origin may frame our pages, killing
+#     clickjacking of the enrolment flow. Modern browsers prefer CSP
+#     frame-ancestors, but this header is respected by older ones and costs
+#     nothing to keep alongside.
+#   Permissions-Policy          — every powerful browser API defaults to off.
+#     None of the pages here ask for camera / mic / geolocation / usb /
+#     payment / xr, so denying by default has zero UX cost and shrinks the
+#     drive-by surface. Extend if a page later needs one.
+#
+# What's deliberately NOT here:
+#   Content-Security-Policy — inline JSON-LD (organisation + per-course +
+#     placements) plus GTM plus the Cloudflare email-decode script plus
+#     Razorpay checkout all sit inside one page, so a real CSP needs
+#     'unsafe-inline' or a per-request nonce and a curated allowlist for six
+#     hosts. Landing that as one big change on production without a report-only
+#     staging pass would silently break payments. It gets its own ticket.
+
+/*
+  Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
+  X-Frame-Options: DENY
+  Permissions-Policy: camera=(), microphone=(), geolocation=(), usb=(), payment=(), xr-spatial-tracking=()

--- a/public/_redirects
+++ b/public/_redirects
@@ -1,1 +1,26 @@
-/*    /index.html   200
+# Cloudflare Pages routing.
+#
+# Before this file said `/*  /index.html  200` — a wildcard that swallowed
+# every unmatched URL and served the homepage HTML with a 200 status. A
+# mistyped path like /some-typo indexed as a canonical duplicate of the
+# homepage, and any junk URL a crawler tried came back "found." Same class
+# of bug that hid /about behind the homepage before it got its own
+# prerender.
+#
+# CF Pages' precedence resolves this cleanly. It matches in order:
+#   1. an exact static file (dist/about.html, dist/courses/mern-stack.html…)
+#   2. a Pages Function (functions/api/*, functions/admin/*, functions/auth/*)
+#   3. these _redirects rules
+# So every real route ships as its own prerendered HTML (see scripts/prerender.mjs)
+# and never hits this file. Only truly unmatched paths do — and they now get a
+# real 404 with a noindex page (public/404.html).
+#
+# The one exception is /portal — a client-side SPA route the future student
+# portal (#127) will register but which is not yet prerendered. Serving 404 for
+# it would break the preview; serving the SPA shell keeps it functional. Once
+# #127 lands and prerenders /portal/*, delete these two exceptions.
+
+/portal          /index.html    200
+/portal/*        /index.html    200
+
+/*               /404.html      404


### PR DESCRIPTION
Two issues surfaced by the SEO audit run today. Both are one config change away, and the first is severe enough to fix same day.

## Soft-404 catch-all (task #17)

`public/_redirects` was \`/*  /index.html  200\` — a wildcard that swallowed every unmatched URL and served the homepage HTML with a 200 status. A mistyped path like \`/some-typo\` indexed as a canonical duplicate of the homepage, and any junk URL a crawler tried came back "found." Same class of bug that hid \`/about\` behind the homepage before it got its own prerender.

CF Pages' file precedence resolves this cleanly. It matches in order:

1. an exact static file (\`dist/about.html\`, \`dist/courses/mern-stack.html\`…)
2. a Pages Function (\`functions/api/*\`, \`functions/admin/*\`, \`functions/auth/*\`)
3. the \`_redirects\` rules

So every real route already ships as its own prerendered HTML via \`scripts/prerender.mjs\` and never hits \`_redirects\`. Only truly unmatched paths do — and they now get a real 404 with a noindex page (\`public/404.html\`), rather than a homepage clone.

**One exception:** \`/portal\` and \`/portal/*\`, the client-side SPA route the future student portal (#127) will register but which is not yet prerendered. Serving 404 for it would break the in-progress preview, so those paths still fall through to \`/index.html 200\`. **Once #127 lands and prerenders \`/portal/*\`, delete these two exception lines** (documented at the top of the file).

Reproduce before/after:

\`\`\`
curl -so /dev/null -w "%{http_code}\n" https://restcoderacademy.in/some-typo-xyz
# before: 200
# after:  404
\`\`\`

## Baseline security headers (task #18)

New \`public/_headers\` with three headers that are safe on any request shape and add real protection without risking anything on production:

- **\`Strict-Transport-Security: max-age=63072000; includeSubDomains; preload\`** — belt-and-suspenders on top of CF's HTTP→HTTPS 301. Browsers refuse plain HTTP for this host + subdomains for 2 years. Preload-eligible (submit at hstspreload.org once www→apex is confirmed stable).
- **\`X-Frame-Options: DENY\`** — no other origin can frame our pages, killing clickjacking of the enrolment flow. Older browsers respect this even where CSP \`frame-ancestors\` isn't recognised.
- **\`Permissions-Policy: camera=(), microphone=(), geolocation=(), usb=(), payment=(), xr-spatial-tracking=()\`** — every powerful browser API defaults to off. None of our pages ask for these, so denying is zero UX cost.

**\`Content-Security-Policy\` deliberately deferred to its own ticket** — inline JSON-LD, GTM, Cloudflare email-decode, and Razorpay checkout all sit on the same page, so a real CSP needs \`'unsafe-inline'\` (or nonces) and a curated 6-host allowlist. Landing that as one big change without a report-only staging pass could silently break payments. Rationale documented in the file.

## Test plan

- [x] \`npm run build\` — clean; \`dist/404.html\`, \`dist/_redirects\`, \`dist/_headers\` all present.
- [x] \`npm test\` — 75 tests still passing.
- [x] Local wrangler dev returns 404 for typo URLs.
- [ ] After deploy: \`curl -so /dev/null -w "%{http_code}\n" https://restcoderacademy.in/some-typo-xyz\` returns \`404\`.
- [ ] After deploy: \`curl -sI https://restcoderacademy.in/ | grep -iE '^(strict-transport|x-frame|permissions-policy):'\` returns all three headers.
- [ ] After deploy: \`/portal\` still 200s with the SPA shell (not 404).
- [ ] After deploy: real routes (\`/about\`, \`/faq\`, \`/courses/java-full-stack\`) still 200 (unaffected by _redirects fallback).

## Related

- Task #16 was investigated and closed as a false alarm (seo-geo agent misidentified \`aria-hidden\` "Sending…" button-loading text as broken prerender; verified all placement names + client logos are in the raw HTML).
- Task #18 landed here alongside #17 since both are single-file config changes in \`public/\`.
- Tasks #19 (FDE positioning), #20 (homepage H1 + LocalBusiness schema), #21 (blog depth) still pending — they need either a founder decision or larger content work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014PnGG9Moyg9MTGr3j3vmHy