### PR TITLE
feat(seo): multi-type org as EducationalOrganization + LocalBusiness; FDE naming note

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,14 +41,21 @@
     <meta name="twitter:description" content="Live, project-based full-stack courses with placement support and EMI — and progress reports parents can actually see." />
     <meta name="twitter:image" content="https://restcoderacademy.in/favicon.png" />
 
-    <!-- Site-wide organisation node. Course entries were removed and moved to
-         the homepage component (Home.jsx) so Course + Offer schema only appears
-         on / and /courses/<slug> — Google flags Course schema on non-course
-         pages (FAQ, contact, blog, placements) as misplaced structured data. -->
+    <!-- Site-wide organisation node. Multi-typed as EducationalOrganization +
+         LocalBusiness because both are true and Google uses each differently:
+         EducationalOrganization surfaces Course + FAQPage rich results and
+         alumniOf relationships (used on /placements); LocalBusiness feeds the
+         local pack on Maps queries like "coding classes Jayanagar" and lets
+         Google associate this @id with our verified Google Business Profile.
+         geo + priceRange are the additions LocalBusiness expects but
+         EducationalOrganization does not carry. Course entries stay on the
+         homepage component (Home.jsx) — Course/Offer only appears on / and
+         /courses/<slug> because Google flags Course schema on unrelated pages
+         (FAQ, contact, blog, placements) as misplaced structured data. -->
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",
-      "@type": "EducationalOrganization",
+      "@type": ["EducationalOrganization", "LocalBusiness"],
       "@id": "https://restcoderacademy.in/#org",
       "name": "Rest Coder Academy",
       "url": "https://restcoderacademy.in/",
@@ -57,6 +64,7 @@
       "description": "Live, project-based full-stack coding courses (Java, Python, MERN) and a Forward Deployed Engineering program in Bengaluru, with placement support, EMI, and weekly progress reports visible to guardians.",
       "email": "restcoderacademy@gmail.com",
       "telephone": "+91-80737-62257",
+      "priceRange": "₹35000–₹50000",
       "hasMap": "https://maps.app.goo.gl/XdZWt3oDzGUCL5KWA",
       "areaServed": "Bengaluru",
       "address": {
@@ -66,6 +74,11 @@
         "addressRegion": "Karnataka",
         "postalCode": "560041",
         "addressCountry": "IN"
+      },
+      "geo": {
+        "@type": "GeoCoordinates",
+        "latitude": 12.9246221,
+        "longitude": 77.5883017
       }
     }
     </script>

--- a/src/components/organism/courses/courseContent.js
+++ b/src/components/organism/courses/courseContent.js
@@ -6,7 +6,7 @@
 export const courseContent = {
   "forward-deployed-engineering": {
     intro:
-      "Forward Deployed Engineering (FDE) is the program a former Head of Engineering built to train the kind of hire he was tired of not being able to find: someone who can walk into a real codebase, ship a feature end-to-end, own its production behaviour, and talk to the customer about it. It is intentionally different from a bootcamp — you spend most of your time in a real repo, not a slide deck.",
+      "Forward Deployed Engineering (FDE) is the program a former Head of Engineering built to train the kind of hire he was tired of not being able to find: someone who can walk into a real codebase, ship a feature end-to-end, own its production behaviour, and talk to the customer about it. It is intentionally different from a bootcamp — you spend most of your time in a real repo, not a slide deck. A note on the name: we teach the original discipline the term comes from — production engineering under senior mentorship, in the sense Palantir used it. AI companies have recently reused “Forward Deployed Engineer” for LLM/RAG/agent-deployment roles; that is a different job and we do not teach it here.",
     whoFor: [
       "Recent CS/IT graduates who can write basic code but have never shipped anything a stranger uses.",
       "Working engineers 0–3 years in who feel they got hired but never actually got trained.",


### PR DESCRIPTION
Two changes from the SEO audit that don't need a decision to ship.

## Multi-typed root node (task #20)

The site is both — a training school (EducationalOrganization) and a real physical location on a specific Bengaluru street (LocalBusiness). Google surfaces them differently:

- **EducationalOrganization** drives Course + FAQPage rich results and the alumniOf/Person entries we already emit on /placements.
- **LocalBusiness** feeds the local pack on queries like "coding classes Jayanagar" and lets Google associate this \`@id\` with our verified Google Business Profile.

The seo-sxo audit flagged "coding bootcamp Jayanagar" as a query with **no dedicated local competitor** — LocalBusiness is the schema half of capturing it (the on-page half is task #20's second part: H1 wording, deferred until the founder picks the phrasing).

Two properties LocalBusiness expects that EducationalOrganization doesn't carry:
- \`priceRange: "₹35000–₹50000"\` — sourced from courses.js
- \`geo: {GeoCoordinates}\` — 12.9246221, 77.5883017 (the coordinates Google has already geocoded for our GBP)

Multi-typed nodes are legal Schema.org and Google's structured-data validator accepts them. Both parent types share \`@id\`, so this remains **one entity**, not two — the alumniOf references on /placements still resolve.

## FDE naming disambiguation (task #19, monitor-only)

seo-sxo flagged that the current SERP for "Forward Deployed Engineering" is dominated by AI-deployment programs (IIT Roorkee, Scaler, Futurense in Bengaluru, ADaSci) — RCA's page teaches the original Palantir-era discipline.

Decided against renaming (task #19 downgraded to "monitor"):
- RCA isn't competing for that keyword organically — the audience arrives via homepage/blog links, not from an "FDE" Google search.
- A slug change would break internal links.
- The term is historically correct (Palantir usage predates the AI reuse).

Instead: **one honest line in the FDE course intro** acknowledging the overlap. Turns the naming collision into a differentiator rather than pretending it doesn't exist, and doesn't force a curriculum pivot.

## Deliberately NOT added

- \`openingHours\` — GBP showed varying close times (4pm vs 8pm) in different session screenshots. Confirm authoritative weekday hours with Uday before shipping — a wrong \`openingHours\` in schema is worse than none.
- \`sameAs\` links to LinkedIn / Instagram — \`SOCIAL_PROFILES\` in \`src/data/contact.js\` is still empty pending the URLs, per the note there.

## Test plan

- [x] \`npm run build\` — clean.
- [x] \`npm test\` — 75 passing.
- [x] JSON-LD parses; \`@type\` is the array \`["EducationalOrganization", "LocalBusiness"]\`; \`priceRange\` + \`geo\` present.
- [ ] After merge + deploy: paste the homepage into Google's Rich Results Test — verify both types are detected and no errors.
- [ ] After deploy: check the FDE page renders the new disambiguation line as the second sentence of the intro.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014PnGG9Moyg9MTGr3j3vmHy