### PR TITLE
feat(footer): link institutional IG + LinkedIn + sameAs

### DIFF
--- a/index.html
+++ b/index.html
@@ -79,7 +79,11 @@
         "@type": "GeoCoordinates",
         "latitude": 12.9246221,
         "longitude": 77.5883017
-      }
+      },
+      "sameAs": [
+        "https://www.instagram.com/restcoderacademy/",
+        "https://www.linkedin.com/company/rest-coder-academy/"
+      ]
     }
     </script>
 

--- a/src/components/molecules/Footer Components/FooterAddress.jsx
+++ b/src/components/molecules/Footer Components/FooterAddress.jsx
@@ -1,4 +1,6 @@
-import { Box ,TextField,InputAdornment} from '@mui/material'
+import { Box } from '@mui/material'
+import InstagramIcon from '@mui/icons-material/Instagram'
+import LinkedInIcon from '@mui/icons-material/LinkedIn'
 import React from 'react'
 import TypoGraphyComponent from '../../atoms/TypoGraphyComponent/TypoGraphyComponent'
 
@@ -6,7 +8,7 @@ import TypoGraphyComponent from '../../atoms/TypoGraphyComponent/TypoGraphyCompo
 
 
 function FooterAddress() {
-  let address=`#364, 3rd Floor, 16th Main, 4th T Block East, Pattabhirama Nagar, Jayanagar, Bengaluru, Karnataka 560041`
+  let address=`#364, 3rd Floor, 16th Main, 4th T Block East, Pattabhirama Nagar, Jayanagar, Bengaluru, Karnataka 560041`
 let contact=`Mobile: 8073762257`;
 let email=`Email: restcoderacademy@gmail.com`;
 
@@ -17,11 +19,25 @@ let email=`Email: restcoderacademy@gmail.com`;
         <TypoGraphyComponent variant='body2' component='p' text={address}/>
         <TypoGraphyComponent variant='body2' component='p' text={contact}/>
         <TypoGraphyComponent variant='body2' component='p' text={email}/>
-       
 
-        
-
-
+        <Box className="footer-socials" sx={{mt:"0.75rem", display:"flex", gap:"0.75rem"}}>
+          <a
+            href="https://www.instagram.com/restcoderacademy/"
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label="Rest Coder Academy on Instagram"
+          >
+            <InstagramIcon />
+          </a>
+          <a
+            href="https://www.linkedin.com/company/rest-coder-academy/"
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label="Rest Coder Academy on LinkedIn"
+          >
+            <LinkedInIcon />
+          </a>
+        </Box>
     </>
   )
 }

--- a/src/components/organism/Footer/FooterComponent.css
+++ b/src/components/organism/Footer/FooterComponent.css
@@ -206,3 +206,22 @@ hr
     min-width: var(--rca-control-h-mobile);
     min-height: var(--rca-control-h-mobile);
 }
+
+.footer .footer-socials a
+{
+    color: var(--rca-surface);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: var(--rca-control-h-mobile);
+    min-height: var(--rca-control-h-mobile);
+    transition: opacity 120ms ease;
+}
+.footer .footer-socials a:hover
+{
+    opacity: 0.75;
+}
+.footer .footer-socials .MuiSvgIcon-root
+{
+    font-size: 1.6rem;
+}


### PR DESCRIPTION
Close the loop between the SEO engine we just fixed and the socials engine that was disconnected from it.

## The gap

Live audit today (2026-09-06) surfaced two disconnects:

- **Instagram** @restcoderacademy — 1,215 followers, 540 posts, daily cadence — but the bio link points to a Google Maps URL, not the site. Every click IG has earned this year has been bypassing the funnel, the schema, and the analytics.
- **LinkedIn Company Page** rest-coder-academy — 263 followers, 66.5% Bengaluru — dormant since 2026-03-19, and even active posts linked the dead \`.com\` domain.

The site's footer had no institutional social links at all, so a visitor arriving from search couldn't discover either account either. The two channels were running in parallel with the SEO work, contributing nothing to each other.

## What this PR does

**1. Footer social block** (FooterAddress.jsx)

Two \`<a>\` tags with MUI's Instagram and LinkedIn icons, appended under the existing address/mobile/email block. Placement inside \`FooterAddress\` (not a new footer column) keeps the 4-column grid intact and groups the socials with the other reach-us fields, which is where a visitor scans for them.

- \`target="_blank" rel="noopener noreferrer"\` — standard for external links, plus the noopener defense against reverse tabnabbing.
- Explicit \`aria-label\` on each anchor — the icon is the whole affordance, so the label is what a screen reader announces.
- 44×44 tap target inheriting the same \`min-width\` / \`min-height\` treatment the footer already applies to icon anchors (established in the earlier tap-target audit; see the existing \`.footer .grid-content-box > a\` rule).

**2. \`sameAs\` on the org JSON-LD** (index.html)

The two profile URLs added to the \`sameAs\` array on the \`EducationalOrganization\`+\`LocalBusiness\` entity node. This is the search-engine half of the same fix — without \`sameAs\`, the \`#org\` entity is orphaned from the social accounts even after the footer links exist. Google and LLMs use \`sameAs\` to bind a canonical entity to its verified social presence.

## Rationale note (won't ship)

The founder-personal accounts (\`nikshepkulli\`, \`_udaypawar_\`, etc.) referenced elsewhere in the codebase are intentionally NOT added here. Those belong on the About page team section, not the site footer — the footer is the site's institutional identity, and mixing personals there both dilutes the brand association and creates a maintenance drag when someone leaves.

## Verification

- \`npm run build\` — clean (2.94s)
- \`npm test\` — 75/75 passing
- No route or prerender pipeline changes; the sameAs is inside the existing baked-into-\`<head>\` JSON-LD block so it prerenders on every route
- Visual check post-deploy: the two icons appear under email at desktop; below the address stack on mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014PnGG9Moyg9MTGr3j3vmHy