### PR TITLE
feat(fde): page conversion bundle — shortlink + instructor CTA + FDE-aware WhatsApp

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -23,4 +23,11 @@
 /portal          /index.html    200
 /portal/*        /index.html    200
 
+# Shortlink for the FDE course page. Prospects reach the site with the short
+# URL from business cards, DMs and social posts — before this rule /courses/fde
+# 404'd, so every one of those clicks landed on the not-found page. The full
+# slug (forward-deployed-engineering) stays canonical for SEO; this redirect
+# just lets the short link work.
+/courses/fde     /courses/forward-deployed-engineering    301
+
 /*               /404.html      404

--- a/src/components/Pages/CourseDetail.jsx
+++ b/src/components/Pages/CourseDetail.jsx
@@ -132,7 +132,13 @@ function CourseDetail() {
             <button className="cd-book" type="button" onClick={() => openEnroll({ courseId: course.courseId, name: course.name, paid: course.paid, price: course.price })}>
               Book your seat
             </button>
-            <button className="cd-talk" type="button" onClick={() => openModal(course.name)}>Talk to a counsellor</button>
+            {/* FDE is a ₹50k senior-track program taught by a working
+                engineer — the prospect wants to talk to the instructor, not
+                a counsellor. The other courses (parent-buyer shaped) keep
+                the counsellor framing. */}
+            <button className="cd-talk" type="button" onClick={() => openModal(course.name)}>
+              {course.slug === 'forward-deployed-engineering' ? 'Talk to the instructor' : 'Talk to a counsellor'}
+            </button>
           </div>
         </header>
 

--- a/src/components/molecules/Floating Icons Components/FloatingIcons.jsx
+++ b/src/components/molecules/Floating Icons Components/FloatingIcons.jsx
@@ -1,5 +1,6 @@
 import { Box } from '@mui/material'
 import React, { useState, useEffect, useRef } from 'react';
+import { useLocation } from 'react-router-dom';
 import WhatsAppIcon from '@mui/icons-material/WhatsApp';
 import CallIcon from '@mui/icons-material/Call';
 import ArrowUpwardIcon from '@mui/icons-material/ArrowUpward';
@@ -8,11 +9,34 @@ import ScrollToHome from './ScrollToHome';
 import {animateScroll as scroll } from 'react-scroll';
 import { trackLead } from '../../../lib/analytics';
 
+// The WhatsApp pre-fill needs to change per page so Uday knows what the
+// prospect was looking at when they clicked. Before this map, every WhatsApp
+// click landed as generic "info on courses and placements" — Uday had to
+// phone-and-ask, and a ₹50k FDE prospect looked identical to a ₹35k Java
+// enquiry until then. Course-slug pages are the ones worth being specific
+// about; the rest fall back to the generic pre-fill.
+const WHATSAPP_MESSAGE_BY_PATH = {
+  '/courses/forward-deployed-engineering':
+    "Hi Rest Coder Academy, I'm interested in the Forward Deployed Engineering program — can we schedule a call?",
+  '/courses/full-stack-java':
+    "Hi Rest Coder Academy, I'd like to enquire about the Full Stack Java course.",
+  '/courses/full-stack-python':
+    "Hi Rest Coder Academy, I'd like to enquire about the Full Stack Python course.",
+  '/courses/mern-stack':
+    "Hi Rest Coder Academy, I'd like to enquire about the MERN Stack course.",
+};
+const WHATSAPP_MESSAGE_DEFAULT =
+  "Hello! Can I get more info on courses and placements.";
+
 
 
 
 function FloatingIcons() {
     const [isScrolled, setIsScrolled] = useState(false);
+    const location = useLocation();
+    const whatsappHref = `https://wa.me/918073762257?text=${encodeURIComponent(
+      WHATSAPP_MESSAGE_BY_PATH[location.pathname] || WHATSAPP_MESSAGE_DEFAULT
+    )}`;
 
     //! for four cards in batches and courses use below value
   // const threshold = 3200; // Adjust this value as needed
@@ -63,7 +87,7 @@ function FloatingIcons() {
 
   return (
     <Box className="floating-icons">
-       <a href="https://wa.me/918073762257?text=Hello!%20Can%20I%20get%20more%20info%20on%20courses%20and%20placements." target='_blank' onClick={() => trackLead("whatsapp_float")}>
+       <a href={whatsappHref} target='_blank' rel='noopener noreferrer' onClick={() => trackLead("whatsapp_float")}>
        <WhatsAppIcon fontSize='large' className='whatsapp'  style={whatsappStyle}/>
        </a>
        <a href="tel:+918073762257" onClick={() => trackLead("call_float")}>

--- a/src/components/organism/courses/CoursesCard.jsx
+++ b/src/components/organism/courses/CoursesCard.jsx
@@ -187,7 +187,7 @@ function CoursesCard({ name, courseId, slug, paid, flagship, price, trainer, aud
             Book your seat
           </button>
           <button className="cc-counsellor" type="button" onClick={() => openModal(name)}>
-            Or talk to a counsellor first
+            {slug === 'forward-deployed-engineering' ? 'Or talk to the instructor first' : 'Or talk to a counsellor first'}
           </button>
           <Link className="cc-details" to={`/courses/${slug || courseId}`}>
             Full syllabus &amp; details →


### PR DESCRIPTION
Prep for the FDE demand campaign — before we drive traffic to \`/courses/forward-deployed-engineering\`, the on-site conversion mechanics need to actually convert.

## Findings from a live browser audit (2026-09-06)

- **\`/courses/fde\` returns 404.** The short URL had never existed as a redirect. Every prospect reaching the site with the short link — business cards, DMs, social posts — was hitting the not-found page.
- **Both CTAs on the FDE page read "Talk to a counsellor".** For a ₹50k senior-track program targeted at working developers, "counsellor" is the wrong signal. FDE buyers want to talk to the person teaching, not to a sales-adjacent role.
- **Floating WhatsApp button pre-fill was hardcoded and generic.** Every WhatsApp click site-wide, whether from the FDE page or the Java course page or the homepage, sent Uday "Hello! Can I get more info on courses and placements." He couldn't triage a ₹50k FDE prospect from a ₹35k Java enquiry without asking.

## Changes

**1. `public/_redirects`** — add `/courses/fde` → `/courses/forward-deployed-engineering` as a 301. Full slug stays canonical for SEO; the short link now works. One line.

**2. `src/components/Pages/CourseDetail.jsx`** — conditional CTA label on the course detail page. If `course.slug === 'forward-deployed-engineering'` render "Talk to the instructor"; else keep "Talk to a counsellor". Comment inline explaining the split.

**3. `src/components/organism/courses/CoursesCard.jsx`** — same conditional on the homepage course card grid.

**4. `src/components/molecules/Floating Icons Components/FloatingIcons.jsx`** — path-aware WhatsApp pre-fill. `WHATSAPP_MESSAGE_BY_PATH` maps the four course slugs to specific messages; every other path falls through to the generic default. Also added `rel="noopener noreferrer"` that was missing from the anchor.

## Explicitly NOT in this PR

**A `course` column on the `enquiries` table.** \`EnquiryForm.jsx\` carries a code comment on its \`course\` prop explaining a prior decision to keep course context in the message body rather than migrate the live D1 lead pipe:

> "The enquiries table has no course column, and adding one would mean a migration against the live lead pipe for something the message can carry today. Uday reads the message, so the course reaches him either way."

The form already pre-fills the message with "I'd like to enquire about {course}." so Uday sees which course every enquiry is for. Respecting the earlier call. Structured course context becomes more valuable when we add the enquiry notification webhook (filed as a separate ticket) — will revisit at that point.

## Verification

- `npm run build` — clean (3.86s)
- `npm test` — 75/75 passing
- Post-deploy checks: `curl -I /courses/fde` should 301 → the full slug URL; page-load on `/courses/forward-deployed-engineering` should show "Talk to the instructor" not "Talk to a counsellor"; hovering the floating WhatsApp icon on the FDE page should show the FDE-specific pre-filled URL

## Follow-up ticket

Filing separately: enquiry notification webhook — hot FDE leads decay fast, and Uday currently has to log into the admin panel to see them. Needs a WhatsApp/SMS/email trigger the moment a lead lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014PnGG9Moyg9MTGr3j3vmHy