### PR TITLE
feat(placements): Instagram embed layer — proof-of-concept for #145 (Kota Akshay)

### DIFF
--- a/src/components/Pages/PlacementsPage.jsx
+++ b/src/components/Pages/PlacementsPage.jsx
@@ -2,6 +2,7 @@ import React from "react";
 import { Link } from "react-router-dom";
 import { useAuth } from "../../App";
 import { placements } from "../organism/placements/placement";
+import InstagramEmbed from "../organism/placements/InstagramEmbed";
 import "./PlacementsPage.css";
 
 const ORIGIN = "https://restcoderacademy.in";
@@ -32,12 +33,18 @@ function PlacementsPage() {
   const jsonLd = {
     "@context": "https://schema.org",
     "@graph": [
-      ...placements.map((p) => ({
-        "@type": "Review",
-        itemReviewed: { "@id": ORG_ID },
-        author: { "@type": "Person", name: p.name },
-        reviewBody: p.description,
-      })),
+      // Review entries need an actual reviewBody — a Person who was placed
+      // but hasn't shared a written testimonial (yet) contributes to
+      // ItemList + Person nodes only. Google flags Review with an empty
+      // reviewBody as incomplete structured data.
+      ...placements
+        .filter((p) => p.description)
+        .map((p) => ({
+          "@type": "Review",
+          itemReviewed: { "@id": ORG_ID },
+          author: { "@type": "Person", name: p.name },
+          reviewBody: p.description,
+        })),
       ...placements.map((p) => ({
         "@type": "Person",
         name: p.name,
@@ -86,30 +93,49 @@ function PlacementsPage() {
         </header>
 
         <section className="pl-list">
-          {placements.map((p) => (
-            <article className="pl-card" key={p.name}>
-              <img className="pl-photo" src={p.image} alt={p.name} />
-              <div className="pl-body">
-                <h2>{p.name}</h2>
-                <p className="pl-role">{p.designation} · {p.company?.name}</p>
-                {p.company?.logo && (
-                  <img className="pl-logo" src={p.company.logo} alt={`${p.company.name} logo`} />
-                )}
-                {p.background && (
-                  <p className="pl-background"><b>Background:</b> {p.background}</p>
-                )}
-                {p.journey && (
-                  <p className="pl-journey"><b>Journey:</b> {p.journey}</p>
-                )}
-                <p className="pl-quote">&ldquo;{p.description}&rdquo;</p>
-                {p.linkedin && (
-                  <a className="pl-verify" href={p.linkedin} target="_blank" rel="noopener noreferrer">
-                    Verify on LinkedIn &rarr;
-                  </a>
-                )}
-              </div>
-            </article>
-          ))}
+          {placements.map((p) => {
+            // IG-embed-only variant: no photo / role / testimonial in
+            // `placement.js` — the embed IS the case study. Render the
+            // embed inside the same pl-card shell so it fits the section's
+            // layout without a bespoke wrapper.
+            if (p.instagram_url) {
+              return (
+                <article className="pl-card pl-card--instagram" key={p.name}>
+                  <div className="pl-body pl-body--instagram">
+                    <h2>{p.name}</h2>
+                    {p.background && (
+                      <p className="pl-background"><b>Background:</b> {p.background}</p>
+                    )}
+                    <InstagramEmbed url={p.instagram_url} alumnusName={p.name} />
+                  </div>
+                </article>
+              );
+            }
+            return (
+              <article className="pl-card" key={p.name}>
+                <img className="pl-photo" src={p.image} alt={p.name} />
+                <div className="pl-body">
+                  <h2>{p.name}</h2>
+                  <p className="pl-role">{p.designation} · {p.company?.name}</p>
+                  {p.company?.logo && (
+                    <img className="pl-logo" src={p.company.logo} alt={`${p.company.name} logo`} />
+                  )}
+                  {p.background && (
+                    <p className="pl-background"><b>Background:</b> {p.background}</p>
+                  )}
+                  {p.journey && (
+                    <p className="pl-journey"><b>Journey:</b> {p.journey}</p>
+                  )}
+                  <p className="pl-quote">&ldquo;{p.description}&rdquo;</p>
+                  {p.linkedin && (
+                    <a className="pl-verify" href={p.linkedin} target="_blank" rel="noopener noreferrer">
+                      Verify on LinkedIn &rarr;
+                    </a>
+                  )}
+                </div>
+              </article>
+            );
+          })}
         </section>
 
         <section className="pl-foot">

--- a/src/components/organism/placements/InstagramEmbed.jsx
+++ b/src/components/organism/placements/InstagramEmbed.jsx
@@ -1,0 +1,148 @@
+import { useEffect, useRef } from "react";
+
+/**
+ * Proof-of-concept for the placement Instagram embed layer described in
+ * issue #145 (canonical scope in the 2026-09-07 comment). When a placement
+ * record on the site has an `instagram_url` — the URL of a specific post or
+ * Reel on @restcoderacademy — this component renders IG's official embed
+ * inline in place of the photo+name+company card.
+ *
+ * Why an embed and not a screenshot: RCA's biggest social-proof moat is the
+ * verifiability of each named placement. An embed carries the real caption,
+ * the real like count, the real IG branding — a prospect can click through
+ * to the actual post and verify. A screenshot could be faked; an embed can't.
+ *
+ * IG's `embed.js` is ~250KB and initialises the DOM by scanning for
+ * `.instagram-media` blockquotes. It is loaded here lazily via an
+ * IntersectionObserver so it never touches page load — only when this
+ * component enters (or nearly enters) the viewport does the script get
+ * inserted. Once loaded, subsequent embeds on the same page reuse the same
+ * global (`window.instgrm.Embeds.process()` re-scans the DOM).
+ *
+ * Failure modes handled explicitly (per the ticket comment):
+ *   - Script fails to load (network error, IG down)  → the blockquote's
+ *     fallback anchor stays visible, taking the viewer to the post on IG.
+ *   - Post has been deleted from IG (404)            → IG renders its own
+ *     "Post unavailable" placeholder inside the iframe. Ugly but never a
+ *     broken tile.
+ *   - `prefers-reduced-motion` set                   → we don't autoplay
+ *     anything; IG's embed itself does not autoplay Reels either.
+ *
+ * The component never removes the script tag or the global — treating them
+ * as page-lifecycle singletons is intentional. Re-mounting the component
+ * just re-observes the viewport intersection and calls process() again.
+ */
+
+// Module-level singletons so the script loads exactly once per page even if
+// multiple embed components mount (four placement cards in the carousel, for
+// example). A boolean flag alone is not enough — two components mounting
+// simultaneously would both try to insert the script tag. The promise makes
+// the second caller await the first.
+let scriptPromise = null;
+
+function loadInstagramEmbedScript() {
+  if (scriptPromise) return scriptPromise;
+  scriptPromise = new Promise((resolve) => {
+    // If the script tag is somehow already in the DOM (a plugin, or a hot
+    // reload) reuse it rather than double-loading.
+    const existing = document.querySelector('script[src*="instagram.com/embed.js"]');
+    if (existing) {
+      resolve();
+      return;
+    }
+    const s = document.createElement("script");
+    s.async = true;
+    s.src = "https://www.instagram.com/embed.js";
+    s.onload = () => resolve();
+    // Silent resolve on error — the blockquote's anchor fallback covers the
+    // viewer either way. Logging would just add noise for a class of failure
+    // (adblockers, network hiccups) that isn't actionable.
+    s.onerror = () => resolve();
+    document.body.appendChild(s);
+  });
+  return scriptPromise;
+}
+
+export default function InstagramEmbed({ url, alumnusName }) {
+  const containerRef = useRef(null);
+
+  useEffect(() => {
+    if (!url || !containerRef.current) return;
+
+    let cancelled = false;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        const entry = entries[0];
+        if (!entry.isIntersecting) return;
+        observer.disconnect();
+        loadInstagramEmbedScript().then(() => {
+          if (cancelled) return;
+          // process() is idempotent per blockquote — safe to call on
+          // remount, safe to call before the script has replaced other
+          // instances on the same page.
+          if (window.instgrm && window.instgrm.Embeds && window.instgrm.Embeds.process) {
+            window.instgrm.Embeds.process();
+          }
+        });
+      },
+      // Start loading slightly before the element scrolls into view so the
+      // viewer sees the embed already partially rendered by the time they
+      // reach the carousel. 200px matches the pattern used in FloatingIcons.
+      { rootMargin: "200px" },
+    );
+
+    observer.observe(containerRef.current);
+
+    return () => {
+      cancelled = true;
+      observer.disconnect();
+    };
+  }, [url]);
+
+  if (!url) return null;
+
+  return (
+    <blockquote
+      ref={containerRef}
+      className="instagram-media"
+      data-instgrm-permalink={url}
+      data-instgrm-version="14"
+      // The min-width matches IG's own recommended minimum. Without it the
+      // slick carousel item can collapse the embed to zero width during the
+      // brief moment before the script processes it.
+      style={{
+        background: "#FFF",
+        border: 0,
+        borderRadius: "3px",
+        boxShadow: "0 0 1px 0 rgba(0,0,0,0.5), 0 1px 10px 0 rgba(0,0,0,0.15)",
+        margin: "0 auto",
+        maxWidth: "540px",
+        minWidth: "280px",
+        padding: 0,
+        width: "100%",
+      }}
+    >
+      {/* Fallback content, visible while the script is loading or if it
+          fails to load entirely. The link is the whole point — a viewer who
+          can't see the embed can still click through and verify the post
+          themselves. */}
+      <a
+        href={url}
+        target="_blank"
+        rel="noopener noreferrer"
+        style={{
+          background: "#FFFFFF",
+          lineHeight: "0",
+          padding: "0 0",
+          textAlign: "center",
+          textDecoration: "none",
+          width: "100%",
+          display: "block",
+        }}
+      >
+        See {alumnusName ? `${alumnusName}'s placement` : "this placement"} on Instagram
+      </a>
+    </blockquote>
+  );
+}

--- a/src/components/organism/placements/PlacementCard.jsx
+++ b/src/components/organism/placements/PlacementCard.jsx
@@ -18,6 +18,7 @@ import "slick-carousel/slick/slick.css";
 import "slick-carousel/slick/slick-theme.css";
 import ClientIcon from "../reviews/ReviewIcon";
 import PlacementIcon from "./PlacementIcon";
+import InstagramEmbed from "./InstagramEmbed";
 
 function PlacementCard() {
   const sliderRef = useRef(null);
@@ -73,8 +74,22 @@ function PlacementCard() {
     <>
       <section className="slider-container">
       <Slider ref={sliderRef} {...settings} className="ss">
-      {placements.map(({ name, designation, image, company }, id) => {
-        return ( 
+      {placements.map(({ name, designation, image, company, instagram_url }, id) => {
+        // If this placement has an IG post URL, the embed is the whole card —
+        // it carries the photo, the salary, the caption and the IG branding
+        // that a screenshot could never match. Photo, designation and company
+        // become optional; the wrapper card still holds the layout so heights
+        // stay consistent across the carousel row.
+        if (instagram_url) {
+          return (
+            <Card sx={{}} className="card card--instagram" key={id}>
+              <CardContent className="card-content">
+                <InstagramEmbed url={instagram_url} alumnusName={name} />
+              </CardContent>
+            </Card>
+          );
+        }
+        return (
           // <CardGridItem xs={12} sm={12} md={6} lg={4}>
           <Card sx={{}} className="card" key={id}>
             <CardContent className="card-content">
@@ -95,9 +110,9 @@ function PlacementCard() {
                 sx={{fontWeight: "bold",color:"var(--rca-navy)"}}
               />
           </Box>
-             
+
              {/* <Box className="card-text">
-            
+
               <PlacementIcon value={ratings}/>
               <TypoGraphyComponent
                 variant="p"
@@ -124,8 +139,8 @@ function PlacementCard() {
               </CardContent>
           </Card>
           // </CardGridItem>
-  
-        
+
+
         );
       })}
        </Slider>

--- a/src/components/organism/placements/placement.js
+++ b/src/components/organism/placements/placement.js
@@ -23,19 +23,33 @@ import qsg from "../../../assets/clients/qsg.jpg"
 // visitor will call us on.
 //
 // Fields:
-//   name         (required) student name as shown publicly
-//   designation  (required) role at the company
-//   image        (required) bundled photo import
-//   company      (required) { name, logo }
-//   description  (required) student's own words / testimonial
-//   background   (optional) one-line context ("BCA from Karnataka College…")
-//   courseSlug   (optional) slug from courses.js — renders "Course" chip and
-//                links alumniOf to that specific course
-//   journey      (optional) 1–3 sentences: where they started → what they did
-//                at RCA → what they do now. Used as `worksFor.description` in
-//                schema and rendered as a case-study paragraph in the card.
-//   linkedin     (optional) full LinkedIn URL — surfaced as `sameAs` in schema
-//                and rendered as a "Verify on LinkedIn" link.
+//   name          (required) student name as shown publicly
+//   designation   (optional) role at the company — required for the traditional
+//                 photo+name+company card; omitted for IG-embed-only records
+//                 whose visual comes entirely from the embed
+//   image         (optional) bundled photo import — same optionality reasoning
+//                 as designation
+//   company       (optional) { name, logo } — same again
+//   description   (optional) student's own words / testimonial
+//   background    (optional) one-line context ("BCA from Karnataka College…")
+//   courseSlug    (optional) slug from courses.js — renders "Course" chip and
+//                 links alumniOf to that specific course
+//   journey       (optional) 1–3 sentences: where they started → what they did
+//                 at RCA → what they do now. Used as `worksFor.description` in
+//                 schema and rendered as a case-study paragraph in the card.
+//   linkedin      (optional) full LinkedIn URL — surfaced as `sameAs` in schema
+//                 and rendered as a "Verify on LinkedIn" link.
+//   instagram_url (optional) direct URL to the placement post or Reel on
+//                 @restcoderacademy. When set, `PlacementCard` renders IG's
+//                 official embed as the primary content of the card in place
+//                 of the photo+name+company layout — the embed carries the
+//                 real caption, real like count and real IG branding, which
+//                 is stronger social proof than a screenshot could ever be.
+//                 Photo, designation and company become optional when this
+//                 field is set (see Kota Akshay Rathna Kumar below). Fallback
+//                 rendering when the embed fails to load is documented in
+//                 `InstagramEmbed.jsx`. Wider scope (YouTube + LinkedIn URLs,
+//                 admin CRUD) is queued as portal work in #145.
 export let placements=[
     {
         name:"Ashish Jadhav",
@@ -67,6 +81,17 @@ export let placements=[
         company:{name:"Quality Service Group", logo:qsg},
          description:`Uday sir is a fantastic Java trainer who breaks down complex topics into simple, easy-to-grasp concepts. He creates a supportive learning environment that encourages students to ask questions and grow. What sets him apart is his ability to adapt to different learning styles and pace.I'm grateful for his mentorship, which helped me achieve my goals. Finally thanks to all the team members of rest coder academy.`
 
+    },
+    // First IG-embed-only placement — proof-of-concept for the pattern
+    // described in #145. Kota Akshay's placement was announced on
+    // @restcoderacademy on 2026-09-06 (post ID Dc5o-Uatcxz). Photo, company
+    // and testimonial aren't in `placement.js` yet — the embed carries all
+    // of that visually. When the D1 + admin CRUD lands, this record migrates
+    // as-is (the instagram_url field becomes an instagram_url column).
+    {
+        name: "Kota Akshay Rathna Kumar",
+        background: "B.Tech CSE, 2026 graduate",
+        instagram_url: "https://www.instagram.com/p/Dc5o-Uatcxz/",
     },
 
 ]


### PR DESCRIPTION
Ships the IG-embed rendering pattern from the expanded #145 scope, applied to a single new placement (Kota Akshay Rathna Kumar). Establishes the pattern that @Abhigna1975's D1 + admin CRUD work will migrate into once it ships — same \`instagram_url\` field, same component, no data-model churn.

## What ships

**Four files, one new component.**

- \`src/components/organism/placements/InstagramEmbed.jsx\` — new. The reusable embed component. Lazy-loads IG's \`embed.js\` via IntersectionObserver (200px rootMargin, singleton script tag). Failure modes handled by the blockquote's own anchor fallback — never a broken tile.
- \`src/components/organism/placements/placement.js\` — schema comment expanded to document \`instagram_url\` as an optional field; \`designation\`, \`image\`, \`company\` re-marked as optional (they were already render-safe). Kota Akshay Rathna Kumar added with just \`name\`, \`background\` and \`instagram_url\`.
- \`src/components/organism/placements/PlacementCard.jsx\` — early return when \`instagram_url\` is set: renders the embed inside the existing carousel-item card shell. Traditional card path stays byte-identical for the existing 4 placements.
- \`src/components/Pages/PlacementsPage.jsx\` — same conditional-render on the /placements list section, plus a schema fix: \`Review\` entries are filtered by \`p.description\` presence (an empty \`reviewBody\` is incomplete structured data; Google flags it).

## Why one placement, not the ~13 the IG audit found

Ashish Jadhav, Sakshi, Sujith and Prajwala R don't have findable IG posts in the last ~200 posts we searched. The audit fork saw ~13 other alumni on IG with recent placement announcements not currently in \`placement.js\` at all (Shuchismita Sahu, Vinaykumar, Mohammad Kaif, Uday Srinivas, Chennakesava, Harika Kadiri, others). Batch-adding them is a natural follow-up — either as a manual sweep after this pattern proves out on prod, or once @Abhigna1975's admin CRUD lands and the team adds them through the portal form.

## Why an embed and not a screenshot

RCA's biggest social-proof moat is verifiability. An embed carries the real caption, real like count, real IG branding — the viewer can click through and check. A screenshot could be faked; an embed can't. Every competitor makes aggregate claims ("1000+ hires"); RCA makes specific ones. This is the visual extension of that.

## Deliberately not in this PR

- **YouTube video / LinkedIn URL fields** — in #145's canonical scope but their code lives in the D1 + admin CRUD work. Shipping alongside this PoC would collide with @Abhigna1975's spec.
- **A test for \`InstagramEmbed\`** — the IntersectionObserver + external-script interplay is difficult to test meaningfully without a jsdom polyfill for IO and a real network. Manual verification after deploy is enough for the pattern to prove out.
- **The migration to D1** — \`placement.js\` stays hardcoded. When #145 ships, the \`instagram_url\` field maps cleanly onto an \`instagram_url\` column; no data loss, no schema conflict.

## Verification

- \`npm run build\` — clean (3.17s)
- \`npm test\` — 75/75 passing
- Post-deploy checks:
  - Homepage placements carousel scrolls to Kota's card → IG embed loads a Reel-shaped block
  - Kota's card falls back to "See Kota Akshay Rathna Kumar's placement on Instagram" link if \`embed.js\` is blocked (adblocker test)
  - Existing 4 placements render photo+name+company unchanged
  - /placements page shows Kota with embed + background line; other 4 unchanged
  - Rich Results Test on /placements — Review + Person + ItemList schema still valid

## Related

- Closes: the IG-embed portion of #145 (as PoC — full portal-managed version remains @Abhigna1975's work)
- Depends on: nothing new; CSP is deferred per PR #140, so IG's script from \`www.instagram.com\` is unblocked

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014PnGG9Moyg9MTGr3j3vmHy