### PR TITLE
fix(floating-icons): correct Java & Python slug keys in WhatsApp path map (closes #150)

### DIFF
--- a/src/components/molecules/Floating Icons Components/FloatingIcons.jsx
+++ b/src/components/molecules/Floating Icons Components/FloatingIcons.jsx
@@ -18,9 +18,9 @@ import { trackLead } from '../../../lib/analytics';
 const WHATSAPP_MESSAGE_BY_PATH = {
   '/courses/forward-deployed-engineering':
     "Hi Rest Coder Academy, I'm interested in the Forward Deployed Engineering program — can we schedule a call?",
-  '/courses/full-stack-java':
+  '/courses/java-full-stack':
     "Hi Rest Coder Academy, I'd like to enquire about the Full Stack Java course.",
-  '/courses/full-stack-python':
+  '/courses/python-full-stack':
     "Hi Rest Coder Academy, I'd like to enquire about the Full Stack Python course.",
   '/courses/mern-stack':
     "Hi Rest Coder Academy, I'd like to enquire about the MERN Stack course.",


### PR DESCRIPTION
## Root cause investigation

Issue #150 reported Java and Python course pages returning 2.3KB SPA shell. Full investigation below.

### What the CI logs actually show

Checked the latest CI run (34105167843) prerender output:
```
prerendered /courses/java-full-stack   → courses/java-full-stack.html   [Java Full Stack Course in Bengaluru — Rest Coder Academy]
prerendered /courses/python-full-stack → courses/python-full-stack.html [Python Full Stack Course in Bengaluru — Rest Coder Academy]
prerender: 17/17 routes written.
```

**Prerender is working correctly.** All 4 course pages prerender successfully on every deploy.

### Why the issue looked like a prerender failure

The bug report curl'd the wrong slugs:
```
curl /courses/full-stack-java    # ← slug doesn't exist → hits /* /404.html 404 → 2340 bytes
curl /courses/full-stack-python  # ← slug doesn't exist → hits /* /404.html 404 → 2340 bytes
```

Actual slugs (from `courses.js` and the sitemap):
```
/courses/java-full-stack    ✓ prerendered, ~46KB
/courses/python-full-stack  ✓ prerendered, ~46KB
```

### Real bug found

`FloatingIcons.jsx` `WHATSAPP_MESSAGE_BY_PATH` introduced in #148 used the same wrong slugs:
```js
// Before (never matched)
'/courses/full-stack-java'   → course-specific WhatsApp message
'/courses/full-stack-python' → course-specific WhatsApp message

// After (matches location.pathname correctly)
'/courses/java-full-stack'   → course-specific WhatsApp message
'/courses/python-full-stack' → course-specific WhatsApp message
```

Every visitor on the Java or Python course page who clicked the floating WhatsApp icon got the generic "Hello! Can I get more info on courses and placements." instead of the course-specific pre-fill. Uday couldn't triage Java vs Python enquiries without asking — same problem #148 set out to fix for FDE.

## Change

`FloatingIcons.jsx` — 2 lines. Correct the two slug keys.

## Test plan

- [ ] Visit `/courses/java-full-stack`, click floating WhatsApp icon → pre-filled text reads "I'd like to enquire about the Full Stack Java course"
- [ ] Visit `/courses/python-full-stack`, click floating WhatsApp icon → pre-filled text reads "I'd like to enquire about the Full Stack Python course"
- [ ] Visit `/courses/forward-deployed-engineering` → FDE-specific message unchanged
- [ ] Visit `/courses/mern-stack` → MERN-specific message unchanged
- [ ] Homepage / other pages → generic message unchanged
- [ ] 75/75 tests pass ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)