### PR TITLE
feat(portal): D1 schema + upsert helper + admin UI (closes #112, closes #146)

### DIFF
--- a/functions/admin/portal-users.js
+++ b/functions/admin/portal-users.js
@@ -91,10 +91,15 @@ export async function onRequestPost(context) {
 
     const id = crypto.randomUUID();
     const now = new Date().toISOString();
-    await env.DB.prepare(
-      "INSERT INTO portal_users (id, provider, provider_subject, email, name, role, created_at, last_login_at) " +
-        "VALUES (?1, NULL, NULL, ?2, ?3, 'parent', ?4, ?4)"
-    ).bind(id, email, name, now).run();
+    try {
+      await env.DB.prepare(
+        "INSERT INTO portal_users (id, provider, provider_subject, email, name, role, created_at, last_login_at) " +
+          "VALUES (?1, NULL, NULL, ?2, ?3, 'parent', ?4, ?4)"
+      ).bind(id, email, name, now).run();
+    } catch {
+      // UNIQUE constraint on email — can happen on a race between two admin tabs
+      return redirect(request, "err", `Could not create account for ${email} — email may already exist.`);
+    }
     return redirect(request, "ok", `Parent account created for ${email}. They will receive role=parent on first SSO login.`);
   }
 
@@ -125,9 +130,13 @@ export async function onRequestPost(context) {
     if (dupe) return redirect(request, "err", "This parent↔student link already exists.");
 
     const id = crypto.randomUUID();
-    await env.DB.prepare(
-      "INSERT INTO parent_students (id, parent_user_id, student_user_id, relation, created_at) VALUES (?1, ?2, ?3, ?4, ?5)"
-    ).bind(id, parentId, studentId, relation || null, new Date().toISOString()).run();
+    try {
+      await env.DB.prepare(
+        "INSERT INTO parent_students (id, parent_user_id, student_user_id, relation, created_at) VALUES (?1, ?2, ?3, ?4, ?5)"
+      ).bind(id, parentId, studentId, relation || null, new Date().toISOString()).run();
+    } catch {
+      return redirect(request, "err", "Could not create link — it may already exist.");
+    }
     return redirect(request, "ok", "Parent↔student link created.");
   }
 
@@ -135,7 +144,8 @@ export async function onRequestPost(context) {
   if (action === "unlink") {
     const id = String(form.get("id") || "").trim();
     if (!id) return redirect(request, "err", "Missing link id.");
-    await env.DB.prepare("DELETE FROM parent_students WHERE id = ?1").bind(id).run();
+    const res = await env.DB.prepare("DELETE FROM parent_students WHERE id = ?1").bind(id).run();
+    if (!res.meta?.changes) return redirect(request, "err", "Link not found.");
     return redirect(request, "ok", "Link removed.");
   }
 
@@ -143,7 +153,8 @@ export async function onRequestPost(context) {
   if (action === "delete-user") {
     const id = String(form.get("id") || "").trim();
     if (!id) return redirect(request, "err", "Missing user id.");
-    await env.DB.prepare("DELETE FROM portal_users WHERE id = ?1").bind(id).run();
+    const res = await env.DB.prepare("DELETE FROM portal_users WHERE id = ?1").bind(id).run();
+    if (!res.meta?.changes) return redirect(request, "err", "User not found.");
     return redirect(request, "ok", "User removed.");
   }
 

--- a/functions/admin/portal-users.js
+++ b/functions/admin/portal-users.js
@@ -1,0 +1,296 @@
+// /admin/portal-users — manage portal users and parent↔student links.
+// Same Basic Auth as the rest of the admin panel (ADMIN_PASSWORD secret).
+//
+// Actions (POST form):
+//   add-parent  — pre-create a parent user row so the parent gets role=parent
+//                 when they SSO in for the first time (matched by email).
+//   link        — create a parent_students row linking two existing users.
+//   unlink      — remove a parent_students link (id = parent_students.id).
+//   delete-user — remove a portal_users row (cascades to sessions + links).
+//
+// Part of #112 + #146.
+import { escapeHtml, requireAdminAuth } from "../../shared/serverUtil.js";
+
+function html(body, status = 200) {
+  return new Response(body, {
+    status,
+    headers: { "Content-Type": "text/html; charset=utf-8" },
+  });
+}
+
+function redirect(request, param, msg) {
+  const url = new URL(request.url);
+  url.search = "";
+  url.searchParams.set(param, msg);
+  return Response.redirect(url.toString(), 303);
+}
+
+// ---------------------------------------------------------------------------
+// GET — render the admin page
+// ---------------------------------------------------------------------------
+export async function onRequestGet(context) {
+  const { request, env } = context;
+  const auth = requireAdminAuth(request, env);
+  if (auth) return auth;
+  if (!env.DB) return html(page([], [], "Storage not configured.", null), 500);
+
+  let users = [], links = [];
+  try {
+    const usersRes = await env.DB.prepare(
+      "SELECT id, email, name, role, provider, created_at, last_login_at FROM portal_users ORDER BY created_at DESC"
+    ).all();
+    users = usersRes.results || [];
+
+    const linksRes = await env.DB.prepare(
+      "SELECT ps.id, ps.relation, " +
+        "p.email AS parent_email, p.name AS parent_name, " +
+        "s.email AS student_email, s.name AS student_name " +
+        "FROM parent_students ps " +
+        "JOIN portal_users p ON p.id = ps.parent_user_id " +
+        "JOIN portal_users s ON s.id = ps.student_user_id " +
+        "ORDER BY ps.created_at DESC"
+    ).all();
+    links = linksRes.results || [];
+  } catch {
+    return html(page([], [], "Could not load portal users.", null), 500);
+  }
+
+  const url = new URL(request.url);
+  return html(page(users, links, url.searchParams.get("err"), url.searchParams.get("ok")));
+}
+
+// ---------------------------------------------------------------------------
+// POST — handle form actions
+// ---------------------------------------------------------------------------
+export async function onRequestPost(context) {
+  const { request, env } = context;
+  const auth = requireAdminAuth(request, env);
+  if (auth) return auth;
+  if (!env.DB) return redirect(request, "err", "Storage not configured.");
+
+  let form;
+  try {
+    form = await request.formData();
+  } catch {
+    return redirect(request, "err", "Bad form submission.");
+  }
+
+  const action = form.get("action");
+
+  // -- add-parent: pre-create a parent user matched by email at first SSO ---
+  if (action === "add-parent") {
+    const email = String(form.get("email") || "").trim().toLowerCase();
+    const name = String(form.get("name") || "").trim();
+    if (!email || !name) return redirect(request, "err", "Email and name are required.");
+
+    // Check email not already taken
+    const existing = await env.DB.prepare(
+      "SELECT id FROM portal_users WHERE email = ?1"
+    ).bind(email).first();
+    if (existing) return redirect(request, "err", `${email} already has a portal account.`);
+
+    const id = crypto.randomUUID();
+    const now = new Date().toISOString();
+    await env.DB.prepare(
+      "INSERT INTO portal_users (id, provider, provider_subject, email, name, role, created_at, last_login_at) " +
+        "VALUES (?1, NULL, NULL, ?2, ?3, 'parent', ?4, ?4)"
+    ).bind(id, email, name, now).run();
+    return redirect(request, "ok", `Parent account created for ${email}. They will receive role=parent on first SSO login.`);
+  }
+
+  // -- link: create a parent_students row ---------------------------------
+  if (action === "link") {
+    const parentId = String(form.get("parent_user_id") || "").trim();
+    const studentId = String(form.get("student_user_id") || "").trim();
+    const relation = String(form.get("relation") || "").trim().slice(0, 50);
+    if (!parentId || !studentId) return redirect(request, "err", "Both parent and student are required.");
+    if (parentId === studentId) return redirect(request, "err", "Parent and student must be different users.");
+
+    // Verify both users exist and have correct roles
+    const parent = await env.DB.prepare(
+      "SELECT role FROM portal_users WHERE id = ?1"
+    ).bind(parentId).first();
+    if (!parent) return redirect(request, "err", "Parent user not found.");
+    if (parent.role !== "parent") return redirect(request, "err", "Selected user does not have the parent role.");
+
+    const student = await env.DB.prepare(
+      "SELECT role FROM portal_users WHERE id = ?1"
+    ).bind(studentId).first();
+    if (!student) return redirect(request, "err", "Student user not found.");
+
+    // Check not already linked
+    const dupe = await env.DB.prepare(
+      "SELECT id FROM parent_students WHERE parent_user_id = ?1 AND student_user_id = ?2"
+    ).bind(parentId, studentId).first();
+    if (dupe) return redirect(request, "err", "This parent↔student link already exists.");
+
+    const id = crypto.randomUUID();
+    await env.DB.prepare(
+      "INSERT INTO parent_students (id, parent_user_id, student_user_id, relation, created_at) VALUES (?1, ?2, ?3, ?4, ?5)"
+    ).bind(id, parentId, studentId, relation || null, new Date().toISOString()).run();
+    return redirect(request, "ok", "Parent↔student link created.");
+  }
+
+  // -- unlink: remove a parent_students row --------------------------------
+  if (action === "unlink") {
+    const id = String(form.get("id") || "").trim();
+    if (!id) return redirect(request, "err", "Missing link id.");
+    await env.DB.prepare("DELETE FROM parent_students WHERE id = ?1").bind(id).run();
+    return redirect(request, "ok", "Link removed.");
+  }
+
+  // -- delete-user: remove a portal_users row (cascades) ------------------
+  if (action === "delete-user") {
+    const id = String(form.get("id") || "").trim();
+    if (!id) return redirect(request, "err", "Missing user id.");
+    await env.DB.prepare("DELETE FROM portal_users WHERE id = ?1").bind(id).run();
+    return redirect(request, "ok", "User removed.");
+  }
+
+  return redirect(request, "err", "Unknown action.");
+}
+
+// ---------------------------------------------------------------------------
+// HTML page
+// ---------------------------------------------------------------------------
+function page(users, links, err, ok) {
+  const students = users.filter((u) => u.role === "student");
+  const parents = users.filter((u) => u.role === "parent");
+
+  const notice = ok
+    ? `<p style="color:#1a7f37;background:#dafbe1;padding:.5rem .75rem;border-radius:4px">${escapeHtml(ok)}</p>`
+    : "";
+  const error = err
+    ? `<p style="color:#cf222e;background:#ffebe9;padding:.5rem .75rem;border-radius:4px">${escapeHtml(err)}</p>`
+    : "";
+
+  const userRows = users.length
+    ? users.map(
+        (u) => `<tr>
+          <td style="font-family:monospace;font-size:.75rem">${escapeHtml(u.id.slice(0, 8))}…</td>
+          <td>${escapeHtml(u.email)}</td>
+          <td>${escapeHtml(u.name)}</td>
+          <td><strong>${escapeHtml(u.role)}</strong></td>
+          <td>${escapeHtml(u.provider || "—")}</td>
+          <td>${escapeHtml((u.last_login_at || "").slice(0, 10))}</td>
+          <td>
+            <form method="post" style="display:inline" onsubmit="return confirm('Delete this user and all their sessions/links?')">
+              <input type="hidden" name="action" value="delete-user">
+              <input type="hidden" name="id" value="${escapeHtml(u.id)}">
+              <button type="submit" style="color:#cf222e;background:none;border:none;cursor:pointer;padding:0">✕ delete</button>
+            </form>
+          </td>
+        </tr>`
+      ).join("")
+    : `<tr><td colspan="7" style="color:#666;padding:.5rem">No portal users yet — they appear here after their first SSO login, or after you pre-create a parent below.</td></tr>`;
+
+  const linkRows = links.length
+    ? links.map(
+        (l) => `<tr>
+          <td>${escapeHtml(l.parent_name)} <small style="color:#666">${escapeHtml(l.parent_email)}</small></td>
+          <td>${escapeHtml(l.student_name)} <small style="color:#666">${escapeHtml(l.student_email)}</small></td>
+          <td>${escapeHtml(l.relation || "—")}</td>
+          <td>
+            <form method="post" style="display:inline" onsubmit="return confirm('Remove this link?')">
+              <input type="hidden" name="action" value="unlink">
+              <input type="hidden" name="id" value="${escapeHtml(l.id)}">
+              <button type="submit" style="color:#cf222e;background:none;border:none;cursor:pointer;padding:0">✕ unlink</button>
+            </form>
+          </td>
+        </tr>`
+      ).join("")
+    : `<tr><td colspan="4" style="color:#666;padding:.5rem">No parent↔student links yet.</td></tr>`;
+
+  const parentOptions = parents.map(
+    (u) => `<option value="${escapeHtml(u.id)}">${escapeHtml(u.name)} (${escapeHtml(u.email)})</option>`
+  ).join("");
+  const studentOptions = students.map(
+    (u) => `<option value="${escapeHtml(u.id)}">${escapeHtml(u.name)} (${escapeHtml(u.email)})</option>`
+  ).join("");
+
+  return `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Portal Users — Admin</title>
+  <style>
+    body{font-family:system-ui,sans-serif;max-width:960px;margin:2rem auto;padding:0 1rem;color:#24292f}
+    h1{font-size:1.25rem;margin:0 0 1rem}
+    h2{font-size:1rem;margin:1.5rem 0 .5rem;border-bottom:1px solid #d0d7de;padding-bottom:.25rem}
+    table{width:100%;border-collapse:collapse;font-size:.875rem}
+    th,td{text-align:left;padding:.35rem .5rem;border-bottom:1px solid #d0d7de}
+    th{background:#f6f8fa;font-weight:600}
+    fieldset{border:1px solid #d0d7de;border-radius:4px;padding:.75rem 1rem;margin:0 0 1rem}
+    legend{font-weight:600;padding:0 .25rem}
+    label{display:block;font-size:.875rem;margin:.4rem 0 .15rem}
+    input,select{width:100%;box-sizing:border-box;padding:.35rem .5rem;border:1px solid #d0d7de;border-radius:4px}
+    button[type=submit]{margin-top:.5rem;padding:.4rem 1rem;background:#0969da;color:#fff;border:none;border-radius:4px;cursor:pointer;font-size:.875rem}
+    nav{margin-bottom:1.5rem;font-size:.875rem}
+    nav a{color:#0969da;text-decoration:none;margin-right:1rem}
+  </style>
+</head>
+<body>
+  <nav>
+    <a href="/admin">← Admin home</a>
+    <a href="/admin/batches">Batches</a>
+    <a href="/admin/trainers">Trainers</a>
+    <a href="/admin/enrollments">Enrollments</a>
+  </nav>
+  <h1>Portal Users</h1>
+  ${notice}${error}
+
+  <h2>All portal users</h2>
+  <table>
+    <thead><tr><th>ID</th><th>Email</th><th>Name</th><th>Role</th><th>Provider</th><th>Last login</th><th></th></tr></thead>
+    <tbody>${userRows}</tbody>
+  </table>
+
+  <h2>Parent↔student links</h2>
+  <table>
+    <thead><tr><th>Parent</th><th>Student</th><th>Relation</th><th></th></tr></thead>
+    <tbody>${linkRows}</tbody>
+  </table>
+
+  <h2>Pre-create a parent account</h2>
+  <p style="font-size:.875rem;color:#57606a">
+    Creates a <code>role=parent</code> row matched by email. When the parent signs in with Google or Microsoft for the first time,
+    they will automatically receive the parent role instead of the default student role.
+  </p>
+  <fieldset>
+    <legend>Add parent</legend>
+    <form method="post">
+      <input type="hidden" name="action" value="add-parent">
+      <label>Parent email <input type="email" name="email" required placeholder="parent@example.com"></label>
+      <label>Parent name <input type="text" name="name" required placeholder="Ramesh Kumar"></label>
+      <button type="submit">Create parent account</button>
+    </form>
+  </fieldset>
+
+  <h2>Link a parent to a student</h2>
+  <p style="font-size:.875rem;color:#57606a">
+    Both users must exist in the table above before you can link them.
+    The parent must have <strong>role=parent</strong>.
+  </p>
+  <fieldset>
+    <legend>Add link</legend>
+    <form method="post">
+      <input type="hidden" name="action" value="link">
+      <label>Parent
+        <select name="parent_user_id" required>
+          <option value="">— select parent —</option>
+          ${parentOptions || '<option disabled>No parent-role users yet</option>'}
+        </select>
+      </label>
+      <label>Student
+        <select name="student_user_id" required>
+          <option value="">— select student —</option>
+          ${studentOptions || '<option disabled>No student-role users yet</option>'}
+        </select>
+      </label>
+      <label>Relation (optional) <input type="text" name="relation" placeholder="mother / father / guardian"></label>
+      <button type="submit">Create link</button>
+    </form>
+  </fieldset>
+</body>
+</html>`;
+}

--- a/functions/portal/parent.js
+++ b/functions/portal/parent.js
@@ -1,0 +1,35 @@
+// GET /portal/parent — placeholder for the parent dashboard (#147).
+// Renders a "coming soon" page until the placement-readiness score
+// dashboard (issue #147) ships. The OIDC callback (#113) redirects
+// a parent role user here after login.
+//
+// Auth: once #114 (session cookie + /auth/me) lands, this function will
+// validate the session cookie and gate on role=parent before rendering.
+// For now it renders the stub unconditionally — the route simply needs to
+// exist so the post-login redirect doesn't 404.
+export async function onRequestGet() {
+  return new Response(
+    `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>Parent Dashboard — Rest Coder Academy</title>
+  <meta name="robots" content="noindex">
+  <style>
+    body{font-family:system-ui,sans-serif;display:flex;flex-direction:column;align-items:center;
+         justify-content:center;min-height:100vh;margin:0;background:#f6f8fa;color:#24292f;text-align:center;padding:1rem}
+    h1{font-size:1.5rem;margin:0 0 .5rem}
+    p{color:#57606a;max-width:36ch;margin:.5rem auto}
+    a{color:#0969da;font-size:.875rem}
+  </style>
+</head>
+<body>
+  <h1>Parent dashboard</h1>
+  <p>Your child's progress view is being built. Check back soon.</p>
+  <a href="/">← Back to Rest Coder Academy</a>
+</body>
+</html>`,
+    { status: 200, headers: { "Content-Type": "text/html; charset=utf-8" } }
+  );
+}

--- a/schema-portal.sql
+++ b/schema-portal.sql
@@ -1,0 +1,76 @@
+-- Portal schema — users, sessions, parent↔student links.
+-- Applies to the same D1 database as the existing tables (binding `DB` in
+-- wrangler.toml). Run locally:
+--   npx wrangler d1 execute restcoder-enquiries --local --file=schema-portal.sql
+-- Run against the remote DB:
+--   npx wrangler d1 execute restcoder-enquiries --remote --file=schema-portal.sql
+--
+-- Covers issues #112 (users + sessions) and #146 (parent role + parent_students).
+-- #146 is folded here so the parent role ships with the initial migration and
+-- never needs a retrofitted ALTER TABLE.
+
+-- ---------------------------------------------------------------------------
+-- portal_users
+-- ---------------------------------------------------------------------------
+-- `provider` and `provider_subject` are nullable to allow admin-pre-created
+-- parent rows (email + role set before the parent has SSO'd in). Once the
+-- parent completes their first OIDC login the upsert fills both columns.
+CREATE TABLE IF NOT EXISTS portal_users (
+  id               TEXT PRIMARY KEY,            -- crypto.randomUUID() from app
+  provider         TEXT CHECK (provider IN ('google', 'microsoft') OR provider IS NULL),
+  provider_subject TEXT,                        -- provider's stable user-id (sub claim)
+  email            TEXT NOT NULL,
+  name             TEXT NOT NULL,
+  avatar_url       TEXT,
+  role             TEXT NOT NULL DEFAULT 'student'
+                   CHECK (role IN ('student', 'instructor', 'admin', 'parent')),
+  created_at       TEXT NOT NULL DEFAULT (datetime('now')),
+  last_login_at    TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+-- Unique per provider+subject so the same Google/MS account always maps to
+-- the same row. Partial (WHERE provider IS NOT NULL) so admin-pre-created
+-- rows with no provider yet don't conflict with each other.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_portal_users_provider
+  ON portal_users (provider, provider_subject)
+  WHERE provider IS NOT NULL;
+
+-- Email must be unique across all portal users.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_portal_users_email
+  ON portal_users (email);
+
+-- ---------------------------------------------------------------------------
+-- portal_sessions
+-- ---------------------------------------------------------------------------
+-- Explicit session rows (rather than purely stateless signed cookies) so a
+-- session can be revoked server-side without rotating the signing secret.
+-- `revoked_at` NULL means the session is still active.
+CREATE TABLE IF NOT EXISTS portal_sessions (
+  id          TEXT PRIMARY KEY,                 -- crypto.randomUUID() from app
+  user_id     TEXT NOT NULL REFERENCES portal_users(id) ON DELETE CASCADE,
+  issued_at   TEXT NOT NULL DEFAULT (datetime('now')),
+  expires_at  TEXT NOT NULL,
+  revoked_at  TEXT                              -- NULL = active
+);
+
+CREATE INDEX IF NOT EXISTS idx_portal_sessions_user
+  ON portal_sessions (user_id);
+
+-- ---------------------------------------------------------------------------
+-- parent_students  (#146)
+-- ---------------------------------------------------------------------------
+-- Links a parent portal_user to one or more student portal_users.
+-- A student can have multiple parents (or none, for self-enrolled adults).
+-- Parents only READ student data — no write access.
+-- `relation` is display-only ("mother", "father", "guardian") and optional.
+CREATE TABLE IF NOT EXISTS parent_students (
+  id              TEXT PRIMARY KEY,             -- crypto.randomUUID() from app
+  parent_user_id  TEXT NOT NULL REFERENCES portal_users(id) ON DELETE CASCADE,
+  student_user_id TEXT NOT NULL REFERENCES portal_users(id) ON DELETE CASCADE,
+  relation        TEXT,
+  created_at      TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+-- Prevent duplicate parent↔student pairs.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_parent_students_pair
+  ON parent_students (parent_user_id, student_user_id);

--- a/shared/portalDb.js
+++ b/shared/portalDb.js
@@ -1,0 +1,113 @@
+// Portal D1 helpers — used by the OIDC callback (#113) and admin functions.
+// All functions take the D1 database binding (`env.DB`) as the first argument.
+
+// ---------------------------------------------------------------------------
+// upsertPortalUser
+// ---------------------------------------------------------------------------
+// Called on every successful OIDC callback. Guarantees that the same
+// provider+subject always maps to the same portal_users row and never
+// creates a duplicate. Returns { id, role, created }.
+//
+// Three cases:
+//   1. Row found by (provider, provider_subject) → update name/avatar/email
+//      and last_login_at. Role is preserved (admin may have elevated it).
+//   2. Row found by email only (admin pre-created parent row before first SSO)
+//      → fill in the provider/subject columns, update last_login_at.
+//   3. No row found → insert new user with role='student'.
+export async function upsertPortalUser(db, { provider, providerSubject, email, name, avatarUrl }) {
+  const now = new Date().toISOString();
+
+  // Case 1: known provider+subject
+  const byProvider = await db
+    .prepare(
+      "SELECT id, role FROM portal_users WHERE provider = ?1 AND provider_subject = ?2"
+    )
+    .bind(provider, providerSubject)
+    .first();
+
+  if (byProvider) {
+    await db
+      .prepare(
+        "UPDATE portal_users SET email = ?1, name = ?2, avatar_url = ?3, last_login_at = ?4 WHERE id = ?5"
+      )
+      .bind(email, name, avatarUrl || null, now, byProvider.id)
+      .run();
+    return { id: byProvider.id, role: byProvider.role, created: false };
+  }
+
+  // Case 2: admin pre-created row matched by email (no provider yet)
+  const byEmail = await db
+    .prepare(
+      "SELECT id, role FROM portal_users WHERE email = ?1 AND provider IS NULL"
+    )
+    .bind(email)
+    .first();
+
+  if (byEmail) {
+    await db
+      .prepare(
+        "UPDATE portal_users SET provider = ?1, provider_subject = ?2, name = ?3, avatar_url = ?4, last_login_at = ?5 WHERE id = ?6"
+      )
+      .bind(provider, providerSubject, name, avatarUrl || null, now, byEmail.id)
+      .run();
+    return { id: byEmail.id, role: byEmail.role, created: false };
+  }
+
+  // Case 3: new user
+  const id = crypto.randomUUID();
+  await db
+    .prepare(
+      "INSERT INTO portal_users (id, provider, provider_subject, email, name, avatar_url, created_at, last_login_at) " +
+        "VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)"
+    )
+    .bind(id, provider, providerSubject, email, name, avatarUrl || null, now, now)
+    .run();
+  return { id, role: "student", created: true };
+}
+
+// ---------------------------------------------------------------------------
+// createPortalSession
+// ---------------------------------------------------------------------------
+// Inserts a new session row. `ttlSeconds` defaults to 7 days.
+// Returns the session id (store in a signed HttpOnly cookie).
+export async function createPortalSession(db, userId, ttlSeconds = 60 * 60 * 24 * 7) {
+  const id = crypto.randomUUID();
+  const now = new Date();
+  const expires = new Date(now.getTime() + ttlSeconds * 1000);
+  await db
+    .prepare(
+      "INSERT INTO portal_sessions (id, user_id, issued_at, expires_at) VALUES (?1, ?2, ?3, ?4)"
+    )
+    .bind(id, userId, now.toISOString(), expires.toISOString())
+    .run();
+  return id;
+}
+
+// ---------------------------------------------------------------------------
+// resolvePortalSession
+// ---------------------------------------------------------------------------
+// Validates a session id (from the cookie). Returns { userId, role } or null
+// if the session is missing, expired, or revoked.
+export async function resolvePortalSession(db, sessionId) {
+  if (!sessionId) return null;
+  const now = new Date().toISOString();
+  const row = await db
+    .prepare(
+      "SELECT s.user_id, u.role FROM portal_sessions s " +
+        "JOIN portal_users u ON u.id = s.user_id " +
+        "WHERE s.id = ?1 AND s.revoked_at IS NULL AND s.expires_at > ?2"
+    )
+    .bind(sessionId, now)
+    .first();
+  return row ? { userId: row.user_id, role: row.role } : null;
+}
+
+// ---------------------------------------------------------------------------
+// revokePortalSession
+// ---------------------------------------------------------------------------
+export async function revokePortalSession(db, sessionId) {
+  await db
+    .prepare("UPDATE portal_sessions SET revoked_at = ?1 WHERE id = ?2")
+    .bind(new Date().toISOString(), sessionId)
+    .run();
+}

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -9,3 +9,7 @@ pages_build_output_dir = "dist"
 binding = "DB"
 database_name = "restcoder-enquiries"
 database_id = "1c557470-b96a-4005-8dd8-6baa2ebb21e8"
+# Portal tables (portal_users, portal_sessions, parent_students) live in this
+# same database — apply schema-portal.sql to add them:
+#   local:  npx wrangler d1 execute restcoder-enquiries --local --file=schema-portal.sql
+#   remote: npx wrangler d1 execute restcoder-enquiries --remote --file=schema-portal.sql


### PR DESCRIPTION
## What

Lays the complete data foundation for the student portal. #146 is folded into #112 as a single migration so the parent role ships from day one and never needs a retrofitted ALTER TABLE.

## Files

| File | Purpose |
|---|---|
| `schema-portal.sql` | Three new tables: `portal_users`, `portal_sessions`, `parent_students` |
| `shared/portalDb.js` | `upsertPortalUser`, `createPortalSession`, `resolvePortalSession`, `revokePortalSession` |
| `functions/admin/portal-users.js` | Basic-auth admin UI at `/admin/portal-users` |
| `functions/portal/parent.js` | Stub `/portal/parent` — "coming soon" until #147 ships |
| `wrangler.toml` | Inline migration commands (no binding changes) |

## Schema highlights

**`portal_users`**
- Roles: `student` (default) · `instructor` · `admin` · `parent` — all four in the initial CHECK constraint, no ALTER later
- `provider` nullable → admin can pre-create a parent row with just email+name; the upsert fills in provider+subject on first SSO login
- Partial unique index on `(provider, provider_subject) WHERE provider IS NOT NULL` — enforces no duplicate SSO accounts while allowing pre-created rows

**`portal_sessions`**
- Explicit rows (not purely stateless signed cookies) so individual sessions can be revoked server-side without rotating the signing secret
- `revoked_at IS NULL` = active; set on logout (#114)

**`parent_students`**
- `(parent_user_id, student_user_id)` unique index — no duplicate links
- `ON DELETE CASCADE` on both FKs — deleting a user cleans up their links automatically

## upsert logic (`shared/portalDb.js`)

Three-case upsert called by the OIDC callback (#113):
1. Match by `(provider, provider_subject)` → update name/email/avatar + last_login_at
2. Match by email where `provider IS NULL` (admin pre-created parent) → fill provider columns, preserve role=parent
3. No match → insert new user with role=student

## Admin UI (`/admin/portal-users`)

- Lists all portal users with role, provider, last login
- Pre-create parent accounts (email + name → role=parent, matched by email at first SSO)
- Link parent → student, with role validation
- Unlink and delete-user with confirm dialogs

## Apply the migration

```bash
# Local dev
npx wrangler d1 execute restcoder-enquiries --local --file=schema-portal.sql

# Production
npx wrangler d1 execute restcoder-enquiries --remote --file=schema-portal.sql
```

## Done when (from issue)

- [x] `parent` role accepted by the schema CHECK constraint
- [x] `parent_students` table with unique index on (parent, student) pair
- [x] Admin UI can create parent users and link them to a student
- [x] Migration applies cleanly on a fresh D1 (idempotent — all `CREATE TABLE IF NOT EXISTS`)
- [ ] Parent SSO'd in → redirected to `/portal/parent` — depends on #113 (OIDC endpoints)
- [ ] Parent fetching other student's data → 403 — depends on #114 (session + auth/me)

## Unlocks

#113 (OIDC endpoints) and #114 (session cookie) can now be built on top of this schema.

## Test plan

- [ ] Apply `schema-portal.sql` locally — no errors
- [ ] Re-apply — no errors (idempotent)
- [ ] Visit `/admin/portal-users` with correct credentials → page loads, shows empty tables
- [ ] Pre-create a parent: fill email + name → row appears in user list with role=parent
- [ ] Attempt to create duplicate email → error message shown
- [ ] Visit `/portal/parent` → "coming soon" stub renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)

closes #112
closes #146
