### PR TITLE
design(social): rebuild the three recurring social templates in-repo (closes #151)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ node_modules
 /.wrangler/
 /playwright/.cache/
 dist
+
+# Social-template PNG proofs — regenerate with tools/build.mjs --png (#151)
+design/social-templates/out/*.png

--- a/design/social-templates/README.md
+++ b/design/social-templates/README.md
@@ -1,0 +1,82 @@
+# Social templates
+
+The three recurring graphics RCA publishes, as source you can diff.
+
+| Template | File | Used for |
+|---|---|---|
+| Placement Testimonial | `templates/placement-testimonial.js` | every placement announcement |
+| Festival Greeting | `templates/festival-greeting.js` | Ugadi, Deepavali, Sankranti, … |
+| Batch / Course Launch | `templates/batch-launch.js` | new batch and course posts |
+
+## Why these live here
+
+Ticket #151: every historical placement announcement, festival greeting and
+batch launch carries `www.restcoderacademy.com` as its URL watermark. That
+domain is dead — the registration lapsed and the `.in` is the live site. Anyone
+who screenshots a post, or reads the URL off a phone and types it later, hits
+nothing.
+
+The templates only ever existed inside a design tool, so the wrong URL was
+invisible to the repo, unfixable without opening the master file, and printed
+identically onto three years of posts. Moving them here makes the domain one
+line in `brand.js` and the next correction a one-word diff that CI can check.
+
+This is **not** a re-brand. Colours come from `design/tokens.css`, the layouts
+are transcribed from the existing graphics, and nothing was redesigned. #151
+asked for a string swap; this is the machinery that keeps it swapped.
+
+## Change the URL, a phone number, the colours
+
+Edit `brand.js`. That is the only file with the domain in it — the templates
+call `watermark()` and never write it themselves, so a change cannot land on
+two graphics and miss the third.
+
+```bash
+node design/social-templates/tools/build.mjs           # rebuild out/*.svg
+node design/social-templates/tools/build.mjs --png     # + 1080×1080 PNG proofs
+node design/social-templates/tools/build.mjs --check   # fail if a dead URL is back
+```
+
+`out/*.svg` is committed because it diffs — a review shows exactly what moved
+on the graphic. `out/*.png` is not: it needs a browser, and it is only for
+eyeballing a proof before a post goes out.
+
+## Make a post
+
+Templates take data; the defaults are a worked example.
+
+```js
+import { render } from "./templates/placement-testimonial.js";
+
+const svg = render({
+  name: "Sakshi Rao",
+  designation: "Associate Engineer",
+  company: "Wipro",
+  yop: "2025",
+  salary: "₹5.2 LPA",
+  quote: "…",
+  college: "RV College of Engineering",
+});
+```
+
+Every field is optional — a missing salary collapses the badge rather than
+leaving an empty box, and long text wraps and truncates instead of running off
+the canvas. Drop the real photograph into the dashed `PHOTO` slot in any
+editor; the composition around it is already final.
+
+## Canvas
+
+1080×1080, Instagram's feed post. Stories and Reel covers crop from the
+centre, which is why nothing meaningful sits in the outer 96px.
+
+## What is deliberately not here
+
+- **Old posts are not re-generated.** Historical Instagram and LinkedIn posts
+  stay exactly as published. Going back to edit them reads as brand-panic and
+  resets the engagement on each one. Only the templates are fixed, so the next
+  post is right.
+- **No QR code, no `https://` prefix.** Both were considered in #151 and ruled
+  out: the existing graphics print a bare domain, and a QR is a new visual
+  affordance, not a correction.
+- **No `www.`** — Cloudflare 301s www→apex (#15), so printing it sends every
+  prospect through a pointless redirect.

--- a/design/social-templates/brand.js
+++ b/design/social-templates/brand.js
@@ -1,0 +1,58 @@
+/**
+ * The single source of every string that appears on a social graphic (#151).
+ *
+ * The problem this file exists to solve: the recurring templates lived only
+ * inside a design tool, so `www.restcoderacademy.com` — a domain that has been
+ * dead since the GoDaddy registration lapsed — was baked into every placement
+ * announcement, festival greeting and batch launch RCA has ever published.
+ * Nobody could fix it without opening the master file, and nobody could tell
+ * from the repo that it was wrong.
+ *
+ * Now the URL is one line here. Changing it and re-running the build reprints
+ * every template. The same goes for the phone numbers, which had drifted from
+ * the ones on the site.
+ *
+ * Deliberately NOT a re-brand: the colours, type scale and layouts below are
+ * transcribed from the existing graphics, not redesigned. #151 is a string
+ * swap; this is the machinery that makes the next one a string swap too.
+ */
+
+/* Bare apex, no `www.`, no protocol.
+ *
+ * The `www.` matters: Cloudflare 301s www→apex (#15), so printing `www.` on a
+ * graphic sends every prospect who types it through a needless hop. The
+ * protocol is omitted because the existing graphics omit it and the ticket
+ * asks not to introduce one. */
+export const SITE_URL = "restcoderacademy.in";
+
+/* Both verified against the live Instagram templates during the #151 audit.
+ * PRIMARY is the number already on the website and in the JSON-LD; SECONDARY
+ * appears only on the placement template. If either changes, this is the only
+ * place to edit. */
+export const PHONE_PRIMARY = "8073762257";
+export const PHONE_SECONDARY = "9110424403";
+
+export const ACADEMY = "Rest Coder Academy";
+export const HANDLE = "@restcoderacademy";
+
+/* Transcribed from design/tokens.css so a graphic and a page cannot drift.
+ * `cyan` has no token because it appears on graphics only — the batch-launch
+ * accent — and adding it to the site's palette would imply the UI may use it. */
+export const COLOR = {
+  navy: "#03084C",
+  navyDeep: "#01062F",
+  blue: "#146389",
+  blueDeep: "#10506F",
+  cyan: "#22D3EE",
+  orange: "#FF9800",
+  ink: "#333333",
+  white: "#FFFFFF",
+  paper: "#F8FAFB",
+};
+
+export const FONT = "Montserrat, 'Segoe UI', system-ui, sans-serif";
+
+/* Instagram's feed post. The other surfaces (story, Reel cover) crop from the
+ * centre of this, which is why nothing meaningful sits in the outer 96px. */
+export const CANVAS = { w: 1080, h: 1080 };
+export const SAFE = 96;

--- a/design/social-templates/out/batch-launch.svg
+++ b/design/social-templates/out/batch-launch.svg
@@ -1,0 +1,70 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1080" height="1080" viewBox="0 0 1080 1080" role="img">
+  <defs>
+    <linearGradient id="navyField" x1="0" y1="0" x2="0.6" y2="1">
+      <stop offset="0%" stop-color="#03084C"/>
+      <stop offset="100%" stop-color="#01062F"/>
+    </linearGradient>
+    <clipPath id="uday"><circle cx="880" cy="300" r="150"/></clipPath></defs>
+
+  <rect width="1080" height="1080" fill="url(#navyField)"/>
+
+  <!-- Cyan accents: a corner wedge and a rule, the two marks the existing
+       graphics use. Kept off the safe margin so a story crop keeps them. -->
+  <path d="M 1080 0 L 1080 300 L 780 0 Z" fill="#22D3EE" fill-opacity="0.10"/>
+  <rect x="0" y="0" width="10" height="1080" fill="#22D3EE" fill-opacity="0.55"/>
+
+  
+    <g transform="translate(96 68)">
+      <circle cx="36" cy="36" r="36" fill="none" stroke="#FFFFFF" stroke-opacity="0.9" stroke-width="2.5"/>
+      <text x="36" y="36" dy="0.36em" font-family="Montserrat, 'Segoe UI', system-ui, sans-serif" font-size="37.44" font-weight="700" fill="#FFFFFF" text-anchor="middle">R</text>
+    </g>
+
+  <text x="96" y="266" font-family="Montserrat, 'Segoe UI', system-ui, sans-serif" font-size="27" font-weight="700" fill="#22D3EE" letter-spacing="6">NEW BATCH</text>
+
+  <text x="96" y="348" font-family="Montserrat, 'Segoe UI', system-ui, sans-serif" font-size="66" font-weight="700" fill="#FFFFFF" text-anchor="start"><tspan x="96" dy="0">Java Full Stack</tspan><tspan x="96" dy="73.9">Development</tspan></text>
+
+  <text x="96" y="487.92" font-family="Montserrat, 'Segoe UI', system-ui, sans-serif" font-size="34" font-weight="600" fill="#FF9800">Starts 22 September</text>
+
+  <!-- Instructor, circle-cropped top right. -->
+  
+    <g clip-path="url(#uday)">
+      <rect x="730" y="150" width="300" height="300" rx="0" fill="#F8FAFB" fill-opacity="0.14"/>
+      <rect x="730" y="150" width="300" height="300" rx="0" fill="none" stroke="#FFFFFF" stroke-opacity="0.35" stroke-width="2" stroke-dasharray="10 8"/>
+      <text x="880" y="300" font-family="Montserrat, 'Segoe UI', system-ui, sans-serif" font-size="22" font-weight="600" fill="#FFFFFF" fill-opacity="0.6" text-anchor="middle" letter-spacing="3">INSTRUCTOR</text>
+    </g>
+  <circle cx="880" cy="300" r="150" fill="none" stroke="#22D3EE" stroke-opacity="0.65" stroke-width="4"/>
+  <text x="880" y="492" font-family="Montserrat, 'Segoe UI', system-ui, sans-serif" font-size="30" font-weight="700" fill="#FFFFFF" text-anchor="middle">Uday</text>
+  <text x="880" y="526" font-family="Montserrat, 'Segoe UI', system-ui, sans-serif" font-size="24" font-weight="400" fill="#FFFFFF" fill-opacity="0.7" text-anchor="middle">Lead Instructor</text>
+
+  <rect x="96" y="580" width="120" height="3" fill="#22D3EE" fill-opacity="0.7"/>
+  
+    <g>
+      <circle cx="109" cy="631" r="13" fill="#22D3EE" fill-opacity="0.18"/>
+      <path d="M 103 631 l 4 5 l 8 -10" fill="none" stroke="#22D3EE" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+      <text x="136" y="640" font-family="Montserrat, 'Segoe UI', system-ui, sans-serif" font-size="28" font-weight="500" fill="#FFFFFF">Live classes</text>
+    </g>
+    <g>
+      <circle cx="533" cy="631" r="13" fill="#22D3EE" fill-opacity="0.18"/>
+      <path d="M 527 631 l 4 5 l 8 -10" fill="none" stroke="#22D3EE" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+      <text x="560" y="640" font-family="Montserrat, 'Segoe UI', system-ui, sans-serif" font-size="28" font-weight="500" fill="#FFFFFF">Real projects</text>
+    </g>
+    <g>
+      <circle cx="109" cy="699" r="13" fill="#22D3EE" fill-opacity="0.18"/>
+      <path d="M 103 699 l 4 5 l 8 -10" fill="none" stroke="#22D3EE" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+      <text x="136" y="708" font-family="Montserrat, 'Segoe UI', system-ui, sans-serif" font-size="28" font-weight="500" fill="#FFFFFF">Placement support</text>
+    </g>
+    <g>
+      <circle cx="533" cy="699" r="13" fill="#22D3EE" fill-opacity="0.18"/>
+      <path d="M 527 699 l 4 5 l 8 -10" fill="none" stroke="#22D3EE" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+      <text x="560" y="708" font-family="Montserrat, 'Segoe UI', system-ui, sans-serif" font-size="28" font-weight="500" fill="#FFFFFF">EMI available</text>
+    </g>
+
+  <!-- CTA. Sits below whatever height the feature grid ended up. -->
+  <g transform="translate(96 860)">
+    <rect x="0" y="0" width="300" height="76" rx="38" fill="#FF9800"/>
+    <text x="150" y="49" font-family="Montserrat, 'Segoe UI', system-ui, sans-serif" font-size="32" font-weight="700" fill="#03084C" text-anchor="middle">Join Now</text>
+    <text x="330" y="49" font-family="Montserrat, 'Segoe UI', system-ui, sans-serif" font-size="28" font-weight="600" fill="#FFFFFF" fill-opacity="0.9">8073762257</text>
+  </g>
+
+  <text x="984" y="1022" font-family="Montserrat, 'Segoe UI', system-ui, sans-serif" font-size="27" font-weight="600" fill="#FFFFFF" fill-opacity="0.92" text-anchor="end" letter-spacing="0.4">restcoderacademy.in</text>
+</svg>

--- a/design/social-templates/out/festival-greeting.svg
+++ b/design/social-templates/out/festival-greeting.svg
@@ -1,0 +1,79 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1080" height="1080" viewBox="0 0 1080 1080" role="img">
+  <defs>
+    <radialGradient id="glow" cx="0.5" cy="0.42" r="0.72">
+      <stop offset="0%" stop-color="#146389"/>
+      <stop offset="70%" stop-color="#03084C"/>
+      <stop offset="100%" stop-color="#01062F"/>
+    </radialGradient></defs>
+
+  <rect width="1080" height="1080" fill="url(#glow)"/>
+  <g transform="translate(540 470)"><rect x="-3" y="-620" width="6" height="620" fill="#FFFFFF" fill-opacity="0.05" transform="rotate(0)"/><rect x="-3" y="-620" width="6" height="620" fill="#FFFFFF" fill-opacity="0.05" transform="rotate(22.5)"/><rect x="-3" y="-620" width="6" height="620" fill="#FFFFFF" fill-opacity="0.05" transform="rotate(45)"/><rect x="-3" y="-620" width="6" height="620" fill="#FFFFFF" fill-opacity="0.05" transform="rotate(67.5)"/><rect x="-3" y="-620" width="6" height="620" fill="#FFFFFF" fill-opacity="0.05" transform="rotate(90)"/><rect x="-3" y="-620" width="6" height="620" fill="#FFFFFF" fill-opacity="0.05" transform="rotate(112.5)"/><rect x="-3" y="-620" width="6" height="620" fill="#FFFFFF" fill-opacity="0.05" transform="rotate(135)"/><rect x="-3" y="-620" width="6" height="620" fill="#FFFFFF" fill-opacity="0.05" transform="rotate(157.5)"/><rect x="-3" y="-620" width="6" height="620" fill="#FFFFFF" fill-opacity="0.05" transform="rotate(180)"/><rect x="-3" y="-620" width="6" height="620" fill="#FFFFFF" fill-opacity="0.05" transform="rotate(202.5)"/><rect x="-3" y="-620" width="6" height="620" fill="#FFFFFF" fill-opacity="0.05" transform="rotate(225)"/><rect x="-3" y="-620" width="6" height="620" fill="#FFFFFF" fill-opacity="0.05" transform="rotate(247.5)"/><rect x="-3" y="-620" width="6" height="620" fill="#FFFFFF" fill-opacity="0.05" transform="rotate(270)"/><rect x="-3" y="-620" width="6" height="620" fill="#FFFFFF" fill-opacity="0.05" transform="rotate(292.5)"/><rect x="-3" y="-620" width="6" height="620" fill="#FFFFFF" fill-opacity="0.05" transform="rotate(315)"/><rect x="-3" y="-620" width="6" height="620" fill="#FFFFFF" fill-opacity="0.05" transform="rotate(337.5)"/></g>
+
+  <!-- Border, inset to the safe area so a story crop never clips it. -->
+  <rect x="48" y="48" width="984" height="984" rx="18"
+        fill="none" stroke="#FF9800" stroke-opacity="0.55" stroke-width="3"/>
+
+  
+    <g transform="translate(908 76)">
+      <circle cx="38" cy="38" r="38" fill="none" stroke="#FFFFFF" stroke-opacity="0.9" stroke-width="2.5"/>
+      <text x="38" y="38" dy="0.36em" font-family="Montserrat, 'Segoe UI', system-ui, sans-serif" font-size="39.52" font-weight="700" fill="#FFFFFF" text-anchor="middle">R</text>
+    </g>
+
+  <text x="540" y="352" font-family="Montserrat, 'Segoe UI', system-ui, sans-serif" font-size="30" font-weight="600" fill="#FF9800" text-anchor="middle" letter-spacing="7">DEEPAVALI</text>
+
+  <!-- The headline. Wrapped rather than fixed at one line: "Happy Ganesh
+       Chaturthi" is twice the width of "Happy Ugadi" and would otherwise run
+       off both edges. -->
+  <text x="540" y="470" font-family="Montserrat, 'Segoe UI', system-ui, sans-serif" font-size="92" font-weight="700" fill="#FFFFFF" text-anchor="middle"><tspan x="540" dy="0">Happy Deepavali</tspan></text>
+
+  <rect x="450" y="518" width="180" height="3" fill="#FF9800" fill-opacity="0.8"/>
+
+  <text x="540" y="592" font-family="Montserrat, 'Segoe UI', system-ui, sans-serif" font-size="32" font-weight="400" fill="#FFFFFF" text-anchor="middle"><tspan x="540" dy="0">May this year bring you light, and the</tspan><tspan x="540" dy="48.0">courage to start something new.</tspan></text>
+
+  
+    <g transform="translate(96.0 870)">
+      <path d="M -26 0 Q 0 34 26 0 Z" fill="#FF9800" fill-opacity="0.9"/>
+      <ellipse cx="0" cy="0" rx="26" ry="6" fill="#FF9800"/>
+      <path d="M 0 -4 Q -9 -20 0 -30 Q 9 -20 0 -4 Z" fill="#FFFFFF" fill-opacity="0.95"/>
+      <path d="M 0 -8 Q -5 -18 0 -24 Q 5 -18 0 -8 Z" fill="#FF9800"/>
+    </g>
+    <g transform="translate(244.0 844)">
+      <path d="M -26 0 Q 0 34 26 0 Z" fill="#FF9800" fill-opacity="0.9"/>
+      <ellipse cx="0" cy="0" rx="26" ry="6" fill="#FF9800"/>
+      <path d="M 0 -4 Q -9 -20 0 -30 Q 9 -20 0 -4 Z" fill="#FFFFFF" fill-opacity="0.95"/>
+      <path d="M 0 -8 Q -5 -18 0 -24 Q 5 -18 0 -8 Z" fill="#FF9800"/>
+    </g>
+    <g transform="translate(392.0 870)">
+      <path d="M -26 0 Q 0 34 26 0 Z" fill="#FF9800" fill-opacity="0.9"/>
+      <ellipse cx="0" cy="0" rx="26" ry="6" fill="#FF9800"/>
+      <path d="M 0 -4 Q -9 -20 0 -30 Q 9 -20 0 -4 Z" fill="#FFFFFF" fill-opacity="0.95"/>
+      <path d="M 0 -8 Q -5 -18 0 -24 Q 5 -18 0 -8 Z" fill="#FF9800"/>
+    </g>
+    <g transform="translate(540.0 844)">
+      <path d="M -26 0 Q 0 34 26 0 Z" fill="#FF9800" fill-opacity="0.9"/>
+      <ellipse cx="0" cy="0" rx="26" ry="6" fill="#FF9800"/>
+      <path d="M 0 -4 Q -9 -20 0 -30 Q 9 -20 0 -4 Z" fill="#FFFFFF" fill-opacity="0.95"/>
+      <path d="M 0 -8 Q -5 -18 0 -24 Q 5 -18 0 -8 Z" fill="#FF9800"/>
+    </g>
+    <g transform="translate(688.0 870)">
+      <path d="M -26 0 Q 0 34 26 0 Z" fill="#FF9800" fill-opacity="0.9"/>
+      <ellipse cx="0" cy="0" rx="26" ry="6" fill="#FF9800"/>
+      <path d="M 0 -4 Q -9 -20 0 -30 Q 9 -20 0 -4 Z" fill="#FFFFFF" fill-opacity="0.95"/>
+      <path d="M 0 -8 Q -5 -18 0 -24 Q 5 -18 0 -8 Z" fill="#FF9800"/>
+    </g>
+    <g transform="translate(836.0 844)">
+      <path d="M -26 0 Q 0 34 26 0 Z" fill="#FF9800" fill-opacity="0.9"/>
+      <ellipse cx="0" cy="0" rx="26" ry="6" fill="#FF9800"/>
+      <path d="M 0 -4 Q -9 -20 0 -30 Q 9 -20 0 -4 Z" fill="#FFFFFF" fill-opacity="0.95"/>
+      <path d="M 0 -8 Q -5 -18 0 -24 Q 5 -18 0 -8 Z" fill="#FF9800"/>
+    </g>
+    <g transform="translate(984.0 870)">
+      <path d="M -26 0 Q 0 34 26 0 Z" fill="#FF9800" fill-opacity="0.9"/>
+      <ellipse cx="0" cy="0" rx="26" ry="6" fill="#FF9800"/>
+      <path d="M 0 -4 Q -9 -20 0 -30 Q 9 -20 0 -4 Z" fill="#FFFFFF" fill-opacity="0.95"/>
+      <path d="M 0 -8 Q -5 -18 0 -24 Q 5 -18 0 -8 Z" fill="#FF9800"/>
+    </g>
+
+  <text x="96" y="998" font-family="Montserrat, 'Segoe UI', system-ui, sans-serif" font-size="27" font-weight="600" fill="#FFFFFF" fill-opacity="0.85">Rest Coder Academy</text>
+  <text x="984" y="998" font-family="Montserrat, 'Segoe UI', system-ui, sans-serif" font-size="27" font-weight="600" fill="#FFFFFF" fill-opacity="0.92" text-anchor="end" letter-spacing="0.4">restcoderacademy.in</text>
+</svg>

--- a/design/social-templates/out/placement-testimonial.svg
+++ b/design/social-templates/out/placement-testimonial.svg
@@ -1,0 +1,57 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1080" height="1080" viewBox="0 0 1080 1080" role="img">
+  <defs>
+    <linearGradient id="field" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#146389"/>
+      <stop offset="55%" stop-color="#10506F"/>
+      <stop offset="100%" stop-color="#03084C"/>
+    </linearGradient>
+    <linearGradient id="portraitFade" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#03084C" stop-opacity="0.95"/>
+      <stop offset="45%" stop-color="#03084C" stop-opacity="0"/>
+    </linearGradient>
+    <clipPath id="portraitClip"><rect x="620" y="0" width="460" height="948"/></clipPath></defs>
+
+  <rect width="1080" height="1080" fill="url(#field)"/>
+
+  <!-- Portrait, bled to the right edge and to the bottom bar. The fade is what
+       lets the name sit over the photo and stay readable whoever is in it. -->
+  
+    <g clip-path="url(#portraitClip)">
+      <rect x="620" y="0" width="460" height="948" rx="0" fill="#F8FAFB" fill-opacity="0.14"/>
+      <rect x="620" y="0" width="460" height="948" rx="0" fill="none" stroke="#FFFFFF" stroke-opacity="0.35" stroke-width="2" stroke-dasharray="10 8"/>
+      <text x="850" y="474" font-family="Montserrat, 'Segoe UI', system-ui, sans-serif" font-size="22" font-weight="600" fill="#FFFFFF" fill-opacity="0.6" text-anchor="middle" letter-spacing="3">STUDENT PHOTO</text>
+    </g>
+  <rect x="620" y="0" width="260" height="948" fill="url(#portraitFade)"/>
+
+  
+    <g transform="translate(96 72)">
+      <circle cx="38" cy="38" r="38" fill="none" stroke="#FFFFFF" stroke-opacity="0.9" stroke-width="2.5"/>
+      <text x="38" y="38" dy="0.36em" font-family="Montserrat, 'Segoe UI', system-ui, sans-serif" font-size="39.52" font-weight="700" fill="#FFFFFF" text-anchor="middle">R</text>
+    </g>
+  <text x="192" y="126" font-family="Montserrat, 'Segoe UI', system-ui, sans-serif" font-size="26" font-weight="600" fill="#FFFFFF" fill-opacity="0.85" letter-spacing="4">PLACED</text>
+
+  <!-- Name + role. Two lines, because "Senior Software Engineer" at a long
+       company name is the normal case, not the exception. -->
+  <text x="96" y="268" font-family="Montserrat, 'Segoe UI', system-ui, sans-serif" font-size="62" font-weight="700" fill="#FFFFFF" text-anchor="start"><tspan x="96" dy="0">Ashish Kumar</tspan></text>
+  <text x="96" y="336" font-family="Montserrat, 'Segoe UI', system-ui, sans-serif" font-size="32" font-weight="500" fill="#22D3EE" text-anchor="start"><tspan x="96" dy="0">Software Engineer, Infosys</tspan></text>
+
+  <!-- Salary and year of passing. A pill, so a blank salary collapses the
+       badge instead of leaving a labelled empty box. -->
+  <g>
+    <rect x="96" y="386" width="196" height="58" rx="29" fill="#FF9800"/>
+    <text x="116" y="425" font-family="Montserrat, 'Segoe UI', system-ui, sans-serif" font-size="32" font-weight="700" fill="#03084C">₹6.5 LPA</text>
+  </g>
+  <text x="304" y="425" font-family="Montserrat, 'Segoe UI', system-ui, sans-serif" font-size="26" font-weight="500" fill="#FFFFFF" fill-opacity="0.75">Y.O.P 2024</text>
+
+  <!-- The quote. The oversized mark is decoration and is hidden from the
+       accessible name, which the caption carries anyway. -->
+  <text x="90" y="609.75" font-family="Montserrat, 'Segoe UI', system-ui, sans-serif" font-size="150" font-weight="700" fill="#FFFFFF" fill-opacity="0.16" aria-hidden="true">“</text>
+  <text x="96" y="585.75" font-family="Montserrat, 'Segoe UI', system-ui, sans-serif" font-size="34" font-weight="400" fill="#FFFFFF" text-anchor="start"><tspan x="96" dy="0">I joined with no coding</tspan><tspan x="96" dy="49.3">background. The live projects</tspan><tspan x="96" dy="49.3">and the mock interviews are</tspan><tspan x="96" dy="49.3">what got me through the Infosys</tspan><tspan x="96" dy="49.3">rounds.</tspan></text>
+
+  <!-- Bottom bar: college, phones, URL. -->
+  <rect x="0" y="948" width="1080" height="132" fill="#01062F"/>
+  <rect x="0" y="948" width="1080" height="4" fill="#FF9800"/>
+  <text x="96" y="1000" font-family="Montserrat, 'Segoe UI', system-ui, sans-serif" font-size="25" font-weight="500" fill="#FFFFFF" text-anchor="start"><tspan x="96" dy="0">BMS College of Engineering</tspan></text>
+  <text x="984" y="1000" font-family="Montserrat, 'Segoe UI', system-ui, sans-serif" font-size="25" font-weight="600" fill="#FFFFFF" fill-opacity="0.9" text-anchor="end">8073762257 · 9110424403</text>
+  <text x="984" y="1044" font-family="Montserrat, 'Segoe UI', system-ui, sans-serif" font-size="27" font-weight="600" fill="#FFFFFF" fill-opacity="0.92" text-anchor="end" letter-spacing="0.4">restcoderacademy.in</text>
+</svg>

--- a/design/social-templates/templates/_shared.js
+++ b/design/social-templates/templates/_shared.js
@@ -1,0 +1,101 @@
+/**
+ * Pieces every template shares (#151).
+ *
+ * The watermark is the whole point of the ticket: it is defined once, here,
+ * and the three templates call it. A future TLD change cannot land on two
+ * graphics and miss the third, because there is only one of them.
+ */
+import { COLOR, FONT, SITE_URL, CANVAS } from "../brand.js";
+
+/** Text going into an SVG is untrusted the moment a testimonial is pasted in. */
+export const esc = (s) =>
+  String(s ?? "")
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+
+/**
+ * Break a string into lines that fit `width` at `size`.
+ *
+ * SVG has no text wrapping, so a long testimonial would otherwise run off the
+ * canvas — which is exactly how you get a graphic that looks fine in the
+ * design tool and clipped on a phone. The 0.52 factor is Montserrat's rough
+ * average advance width per em; it is approximate on purpose, because the
+ * alternative is shipping a font-metrics dependency to lay out three posters.
+ */
+export function wrap(text, { size, width, maxLines = Infinity }) {
+  const perChar = size * 0.52;
+  const max = Math.max(1, Math.floor(width / perChar));
+  const lines = [];
+  let line = "";
+  for (const word of String(text).split(/\s+/).filter(Boolean)) {
+    const candidate = line ? `${line} ${word}` : word;
+    if (candidate.length <= max) {
+      line = candidate;
+    } else {
+      if (line) lines.push(line);
+      line = word;
+    }
+  }
+  if (line) lines.push(line);
+  if (lines.length > maxLines) {
+    const kept = lines.slice(0, maxLines);
+    kept[maxLines - 1] = kept[maxLines - 1].replace(/[.,;:]?$/, "…");
+    return kept;
+  }
+  return lines;
+}
+
+/** Multi-line <text>, since <tspan> dy is the only wrapping SVG offers. */
+export function textBlock(lines, { x, y, size, fill, weight = 400, lh = 1.35, anchor = "start" }) {
+  const spans = lines
+    .map((l, i) => `<tspan x="${x}" dy="${i === 0 ? 0 : (size * lh).toFixed(1)}">${esc(l)}</tspan>`)
+    .join("");
+  return `<text x="${x}" y="${y}" font-family="${FONT}" font-size="${size}" font-weight="${weight}" fill="${fill}" text-anchor="${anchor}">${spans}</text>`;
+}
+
+/**
+ * The URL watermark — the string #151 exists to correct.
+ *
+ * Every template renders this and none of them writes the domain itself, so
+ * `SITE_URL` in brand.js is the only place the domain appears in this folder.
+ */
+export function watermark({ x, y, fill = COLOR.white, size = 26, anchor = "start", opacity = 0.92 }) {
+  return `<text x="${x}" y="${y}" font-family="${FONT}" font-size="${size}" font-weight="600" fill="${fill}" fill-opacity="${opacity}" text-anchor="${anchor}" letter-spacing="0.4">${esc(SITE_URL)}</text>`;
+}
+
+/**
+ * Where a real photograph is dropped in.
+ *
+ * A template ships without one — the portrait changes every post. Rendering a
+ * labelled placeholder rather than nothing means the exported proof shows the
+ * true composition instead of a hole, and whoever drops the photo in can see
+ * the crop they have to fill.
+ */
+export function photoSlot({ x, y, w, h, r = 0, label = "PHOTO", clip = "" }) {
+  return `
+    <g${clip}>
+      <rect x="${x}" y="${y}" width="${w}" height="${h}" rx="${r}" fill="${COLOR.paper}" fill-opacity="0.14"/>
+      <rect x="${x}" y="${y}" width="${w}" height="${h}" rx="${r}" fill="none" stroke="${COLOR.white}" stroke-opacity="0.35" stroke-width="2" stroke-dasharray="10 8"/>
+      <text x="${x + w / 2}" y="${y + h / 2}" font-family="${FONT}" font-size="22" font-weight="600" fill="${COLOR.white}" fill-opacity="0.6" text-anchor="middle" letter-spacing="3">${esc(label)}</text>
+    </g>`;
+}
+
+/** The RCA mark, drawn rather than linked so a template file stands alone. */
+export function logoMark({ x, y, size = 72, fg = COLOR.white, bg = "none" }) {
+  const r = size / 2;
+  return `
+    <g transform="translate(${x} ${y})">
+      <circle cx="${r}" cy="${r}" r="${r}" fill="${bg}" stroke="${fg}" stroke-opacity="0.9" stroke-width="2.5"/>
+      <text x="${r}" y="${r}" dy="0.36em" font-family="${FONT}" font-size="${size * 0.52}" font-weight="700" fill="${fg}" text-anchor="middle">R</text>
+    </g>`;
+}
+
+/** Defs first, then body — the order the templates read in. */
+export const doc = (defs, body) =>
+  `<svg xmlns="http://www.w3.org/2000/svg" width="${CANVAS.w}" height="${CANVAS.h}" viewBox="0 0 ${CANVAS.w} ${CANVAS.h}" role="img">
+  <defs>${defs}</defs>
+${body}
+</svg>
+`;

--- a/design/social-templates/templates/batch-launch.js
+++ b/design/social-templates/templates/batch-launch.js
@@ -1,0 +1,97 @@
+/**
+ * Batch / Course Launch (#151).
+ *
+ * Navy field with cyan accents, the instructor's portrait, a feature grid and
+ * a "Join Now" CTA. The watermark under the CTA is the `.com` this ticket
+ * corrects.
+ *
+ * Features are a list, not four fixed slots, because a Python batch and an FDE
+ * batch do not advertise the same number of things — and a template with an
+ * empty fourth box is how a graphic ends up shipped with placeholder text in
+ * it. Anything past six is dropped by the layout rather than overflowing.
+ */
+import { COLOR, FONT, PHONE_PRIMARY, CANVAS, SAFE } from "../brand.js";
+import { doc, esc, logoMark, photoSlot, textBlock, watermark, wrap } from "./_shared.js";
+
+export const meta = {
+  id: "batch-launch",
+  title: "Batch / Course Launch",
+  fields: "course, kicker, startDate, instructor, instructorRole, features[], cta",
+};
+
+export const sample = {
+  kicker: "New Batch",
+  course: "Java Full Stack Development",
+  startDate: "Starts 22 September",
+  instructor: "Uday",
+  instructorRole: "Lead Instructor",
+  features: ["Live classes", "Real projects", "Placement support", "EMI available"],
+  cta: "Join Now",
+};
+
+export function render(d = sample) {
+  const data = { ...sample, ...d };
+  const features = (data.features || []).slice(0, 6);
+
+  /* Two columns. Rows are computed rather than fixed so three features leave
+     no gap where a fourth would have been. */
+  const colW = 400;
+  const grid = features
+    .map((f, i) => {
+      const x = SAFE + (i % 2) * (colW + 24);
+      const y = 640 + Math.floor(i / 2) * 68;
+      return `
+    <g>
+      <circle cx="${x + 13}" cy="${y - 9}" r="13" fill="${COLOR.cyan}" fill-opacity="0.18"/>
+      <path d="M ${x + 7} ${y - 9} l 4 5 l 8 -10" fill="none" stroke="${COLOR.cyan}" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+      <text x="${x + 40}" y="${y}" font-family="${FONT}" font-size="28" font-weight="500" fill="${COLOR.white}">${esc(f)}</text>
+    </g>`;
+    })
+    .join("");
+
+  const gridBottom = 640 + Math.ceil(features.length / 2) * 68;
+
+  return doc(
+    `
+    <linearGradient id="navyField" x1="0" y1="0" x2="0.6" y2="1">
+      <stop offset="0%" stop-color="${COLOR.navy}"/>
+      <stop offset="100%" stop-color="${COLOR.navyDeep}"/>
+    </linearGradient>
+    <clipPath id="uday"><circle cx="880" cy="300" r="150"/></clipPath>`,
+    `
+  <rect width="${CANVAS.w}" height="${CANVAS.h}" fill="url(#navyField)"/>
+
+  <!-- Cyan accents: a corner wedge and a rule, the two marks the existing
+       graphics use. Kept off the safe margin so a story crop keeps them. -->
+  <path d="M ${CANVAS.w} 0 L ${CANVAS.w} 300 L ${CANVAS.w - 300} 0 Z" fill="${COLOR.cyan}" fill-opacity="0.10"/>
+  <rect x="0" y="0" width="10" height="${CANVAS.h}" fill="${COLOR.cyan}" fill-opacity="0.55"/>
+
+  ${logoMark({ x: SAFE, y: 68, size: 72 })}
+
+  <text x="${SAFE}" y="266" font-family="${FONT}" font-size="27" font-weight="700" fill="${COLOR.cyan}" letter-spacing="6">${esc(String(data.kicker).toUpperCase())}</text>
+
+  ${textBlock(wrap(data.course, { size: 66, width: 620, maxLines: 3 }), {
+    x: SAFE, y: 348, size: 66, weight: 700, fill: COLOR.white, lh: 1.12,
+  })}
+
+  <text x="${SAFE}" y="${348 + 66 * 1.12 * Math.min(3, wrap(data.course, { size: 66, width: 620, maxLines: 3 }).length - 1) + 66}" font-family="${FONT}" font-size="34" font-weight="600" fill="${COLOR.orange}">${esc(data.startDate)}</text>
+
+  <!-- Instructor, circle-cropped top right. -->
+  ${photoSlot({ x: 730, y: 150, w: 300, h: 300, label: "INSTRUCTOR", clip: ' clip-path="url(#uday)"' })}
+  <circle cx="880" cy="300" r="150" fill="none" stroke="${COLOR.cyan}" stroke-opacity="0.65" stroke-width="4"/>
+  <text x="880" y="492" font-family="${FONT}" font-size="30" font-weight="700" fill="${COLOR.white}" text-anchor="middle">${esc(data.instructor)}</text>
+  <text x="880" y="526" font-family="${FONT}" font-size="24" font-weight="400" fill="${COLOR.white}" fill-opacity="0.7" text-anchor="middle">${esc(data.instructorRole)}</text>
+
+  <rect x="${SAFE}" y="580" width="120" height="3" fill="${COLOR.cyan}" fill-opacity="0.7"/>
+  ${grid}
+
+  <!-- CTA. Sits below whatever height the feature grid ended up. -->
+  <g transform="translate(${SAFE} ${Math.max(gridBottom + 22, 860)})">
+    <rect x="0" y="0" width="300" height="76" rx="38" fill="${COLOR.orange}"/>
+    <text x="150" y="49" font-family="${FONT}" font-size="32" font-weight="700" fill="${COLOR.navy}" text-anchor="middle">${esc(data.cta)}</text>
+    <text x="330" y="49" font-family="${FONT}" font-size="28" font-weight="600" fill="${COLOR.white}" fill-opacity="0.9">${esc(PHONE_PRIMARY)}</text>
+  </g>
+
+  ${watermark({ x: CANVAS.w - SAFE, y: CANVAS.h - 58, anchor: "end", size: 27 })}`,
+  );
+}

--- a/design/social-templates/templates/festival-greeting.js
+++ b/design/social-templates/templates/festival-greeting.js
@@ -1,0 +1,93 @@
+/**
+ * Festival Greeting (#151).
+ *
+ * The lightest of the three: an illustrated field, the RCA mark top-right, a
+ * decorative headline, and the watermark in the corner — which is the `.com`
+ * this ticket corrects.
+ *
+ * The illustration is drawn here rather than linked because a greeting goes
+ * out on a few hours' notice and nobody should have to go find an asset. Rays,
+ * lamps and a border are enough to read as festive across Ugadi, Deepavali,
+ * Sankranti and the rest, which is what a *recurring* template needs — one
+ * that only worked for Deepavali would be redrawn every time and drift again.
+ */
+import { COLOR, FONT, ACADEMY, CANVAS, SAFE } from "../brand.js";
+import { doc, esc, logoMark, textBlock, watermark, wrap } from "./_shared.js";
+
+export const meta = {
+  id: "festival-greeting",
+  title: "Festival Greeting",
+  fields: "occasion, greeting, message",
+};
+
+export const sample = {
+  occasion: "Deepavali",
+  greeting: "Happy Deepavali",
+  message: "May this year bring you light, and the courage to start something new.",
+};
+
+/** Lamps along the lower edge. Count is fixed; the canvas never changes. */
+function lamps(y) {
+  const n = 7;
+  const gap = (CANVAS.w - SAFE * 2) / (n - 1);
+  return Array.from({ length: n }, (_, i) => {
+    const x = SAFE + gap * i;
+    const lift = i % 2 === 0 ? 0 : 26;
+    return `
+    <g transform="translate(${x.toFixed(1)} ${y - lift})">
+      <path d="M -26 0 Q 0 34 26 0 Z" fill="${COLOR.orange}" fill-opacity="0.9"/>
+      <ellipse cx="0" cy="0" rx="26" ry="6" fill="${COLOR.orange}"/>
+      <path d="M 0 -4 Q -9 -20 0 -30 Q 9 -20 0 -4 Z" fill="${COLOR.white}" fill-opacity="0.95"/>
+      <path d="M 0 -8 Q -5 -18 0 -24 Q 5 -18 0 -8 Z" fill="${COLOR.orange}"/>
+    </g>`;
+  }).join("");
+}
+
+export function render(d = sample) {
+  const data = { ...sample, ...d };
+
+  /* Rays from behind the headline. Angled from the top-right so they read as
+     coming from the mark rather than from nowhere. */
+  const rays = Array.from({ length: 16 }, (_, i) => {
+    const a = (i * 360) / 16;
+    return `<rect x="-3" y="-620" width="6" height="620" fill="${COLOR.white}" fill-opacity="0.05" transform="rotate(${a})"/>`;
+  }).join("");
+
+  return doc(
+    `
+    <radialGradient id="glow" cx="0.5" cy="0.42" r="0.72">
+      <stop offset="0%" stop-color="${COLOR.blue}"/>
+      <stop offset="70%" stop-color="${COLOR.navy}"/>
+      <stop offset="100%" stop-color="${COLOR.navyDeep}"/>
+    </radialGradient>`,
+    `
+  <rect width="${CANVAS.w}" height="${CANVAS.h}" fill="url(#glow)"/>
+  <g transform="translate(540 470)">${rays}</g>
+
+  <!-- Border, inset to the safe area so a story crop never clips it. -->
+  <rect x="${SAFE / 2}" y="${SAFE / 2}" width="${CANVAS.w - SAFE}" height="${CANVAS.h - SAFE}" rx="18"
+        fill="none" stroke="${COLOR.orange}" stroke-opacity="0.55" stroke-width="3"/>
+
+  ${logoMark({ x: CANVAS.w - SAFE - 76, y: SAFE - 20, size: 76 })}
+
+  <text x="540" y="352" font-family="${FONT}" font-size="30" font-weight="600" fill="${COLOR.orange}" text-anchor="middle" letter-spacing="7">${esc(String(data.occasion).toUpperCase())}</text>
+
+  <!-- The headline. Wrapped rather than fixed at one line: "Happy Ganesh
+       Chaturthi" is twice the width of "Happy Ugadi" and would otherwise run
+       off both edges. -->
+  ${textBlock(wrap(data.greeting, { size: 92, width: 830, maxLines: 2 }), {
+    x: 540, y: 470, size: 92, weight: 700, fill: COLOR.white, lh: 1.12, anchor: "middle",
+  })}
+
+  <rect x="450" y="518" width="180" height="3" fill="${COLOR.orange}" fill-opacity="0.8"/>
+
+  ${textBlock(wrap(data.message, { size: 32, width: 700, maxLines: 3 }), {
+    x: 540, y: 592, size: 32, weight: 400, fill: COLOR.white, lh: 1.5, anchor: "middle",
+  })}
+
+  ${lamps(870)}
+
+  <text x="${SAFE}" y="${CANVAS.h - SAFE + 14}" font-family="${FONT}" font-size="27" font-weight="600" fill="${COLOR.white}" fill-opacity="0.85">${esc(ACADEMY)}</text>
+  ${watermark({ x: CANVAS.w - SAFE, y: CANVAS.h - SAFE + 14, anchor: "end", size: 27 })}`,
+  );
+}

--- a/design/social-templates/templates/placement-testimonial.js
+++ b/design/social-templates/templates/placement-testimonial.js
@@ -1,0 +1,102 @@
+/**
+ * Placement Testimonial — the template RCA publishes most often (#151).
+ *
+ * Layout transcribed from the live graphics: blue gradient field, portrait
+ * cropped hard to the right edge, the student's name and role over it, a
+ * salary badge, the quote in the middle, and a bottom bar carrying the
+ * college, the phones and the URL. The URL in that bar is the `.com` this
+ * ticket corrects.
+ */
+import { COLOR, FONT, PHONE_PRIMARY, PHONE_SECONDARY, CANVAS, SAFE } from "../brand.js";
+import { doc, esc, logoMark, photoSlot, textBlock, watermark, wrap } from "./_shared.js";
+
+export const meta = {
+  id: "placement-testimonial",
+  title: "Placement Testimonial",
+  fields: "name, designation, company, yop, salary, quote, college",
+};
+
+export const sample = {
+  name: "Ashish Kumar",
+  designation: "Software Engineer",
+  company: "Infosys",
+  yop: "2024",
+  salary: "₹6.5 LPA",
+  quote:
+    "I joined with no coding background. The live projects and the mock interviews are what got me through the Infosys rounds.",
+  college: "BMS College of Engineering",
+};
+
+export function render(d = sample) {
+  const data = { ...sample, ...d };
+  const barH = 132;
+  const barY = CANVAS.h - barH;
+
+  const quoteLines = wrap(data.quote, { size: 34, width: 560, maxLines: 5 });
+
+  /* Centre the quote in the band between the salary pill and the bottom bar.
+     Fixing the top instead left a short quote floating with a dead third of
+     the canvas under it — which is what the first proof of this looked like. */
+  const bandTop = 470;
+  const quoteH = quoteLines.length * 34 * 1.45;
+  const quoteTop = bandTop + Math.max(0, (barY - bandTop - quoteH) / 2);
+
+  return doc(
+    `
+    <linearGradient id="field" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="${COLOR.blue}"/>
+      <stop offset="55%" stop-color="${COLOR.blueDeep}"/>
+      <stop offset="100%" stop-color="${COLOR.navy}"/>
+    </linearGradient>
+    <linearGradient id="portraitFade" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="${COLOR.navy}" stop-opacity="0.95"/>
+      <stop offset="45%" stop-color="${COLOR.navy}" stop-opacity="0"/>
+    </linearGradient>
+    <clipPath id="portraitClip"><rect x="620" y="0" width="460" height="${barY}"/></clipPath>`,
+    `
+  <rect width="${CANVAS.w}" height="${CANVAS.h}" fill="url(#field)"/>
+
+  <!-- Portrait, bled to the right edge and to the bottom bar. The fade is what
+       lets the name sit over the photo and stay readable whoever is in it. -->
+  ${photoSlot({ x: 620, y: 0, w: 460, h: barY, label: "STUDENT PHOTO", clip: ' clip-path="url(#portraitClip)"' })}
+  <rect x="620" y="0" width="260" height="${barY}" fill="url(#portraitFade)"/>
+
+  ${logoMark({ x: SAFE, y: 72, size: 76 })}
+  <text x="${SAFE + 96}" y="126" font-family="${FONT}" font-size="26" font-weight="600" fill="${COLOR.white}" fill-opacity="0.85" letter-spacing="4">PLACED</text>
+
+  <!-- Name + role. Two lines, because "Senior Software Engineer" at a long
+       company name is the normal case, not the exception. -->
+  ${textBlock(wrap(data.name, { size: 62, width: 500, maxLines: 2 }), {
+    x: SAFE, y: 268, size: 62, weight: 700, fill: COLOR.white, lh: 1.1,
+  })}
+  ${textBlock(wrap(`${data.designation}, ${data.company}`, { size: 32, width: 500, maxLines: 2 }), {
+    x: SAFE, y: 336, size: 32, weight: 500, fill: COLOR.cyan, lh: 1.25,
+  })}
+
+  <!-- Salary and year of passing. A pill, so a blank salary collapses the
+       badge instead of leaving a labelled empty box. -->
+  ${
+    data.salary
+      ? `<g>
+    <rect x="${SAFE}" y="386" width="${28 + String(data.salary).length * 21}" height="58" rx="29" fill="${COLOR.orange}"/>
+    <text x="${SAFE + 20}" y="425" font-family="${FONT}" font-size="32" font-weight="700" fill="${COLOR.navy}">${esc(data.salary)}</text>
+  </g>`
+      : ""
+  }
+  <text x="${SAFE + (data.salary ? 40 + String(data.salary).length * 21 : 0)}" y="425" font-family="${FONT}" font-size="26" font-weight="500" fill="${COLOR.white}" fill-opacity="0.75">Y.O.P ${esc(data.yop)}</text>
+
+  <!-- The quote. The oversized mark is decoration and is hidden from the
+       accessible name, which the caption carries anyway. -->
+  <text x="${SAFE - 6}" y="${quoteTop + 24}" font-family="${FONT}" font-size="150" font-weight="700" fill="${COLOR.white}" fill-opacity="0.16" aria-hidden="true">“</text>
+  ${textBlock(quoteLines, { x: SAFE, y: quoteTop, size: 34, weight: 400, fill: COLOR.white, lh: 1.45 })}
+
+  <!-- Bottom bar: college, phones, URL. -->
+  <rect x="0" y="${barY}" width="${CANVAS.w}" height="${barH}" fill="${COLOR.navyDeep}"/>
+  <rect x="0" y="${barY}" width="${CANVAS.w}" height="4" fill="${COLOR.orange}"/>
+  ${textBlock(wrap(data.college, { size: 25, width: 620, maxLines: 2 }), {
+    x: SAFE, y: barY + 52, size: 25, weight: 500, fill: COLOR.white, lh: 1.3,
+  })}
+  <text x="${CANVAS.w - SAFE}" y="${barY + 52}" font-family="${FONT}" font-size="25" font-weight="600" fill="${COLOR.white}" fill-opacity="0.9" text-anchor="end">${esc(PHONE_PRIMARY)} · ${esc(PHONE_SECONDARY)}</text>
+  ${watermark({ x: CANVAS.w - SAFE, y: barY + 96, anchor: "end", size: 27 })}`,
+  );
+}

--- a/design/social-templates/tools/build.mjs
+++ b/design/social-templates/tools/build.mjs
@@ -1,0 +1,84 @@
+/**
+ * Build the social templates to SVG, and optionally to PNG proofs (#151).
+ *
+ *   node design/social-templates/tools/build.mjs          # SVG only
+ *   node design/social-templates/tools/build.mjs --png    # + 1080px PNGs
+ *   node design/social-templates/tools/build.mjs --check  # CI: no dead URL
+ *
+ * SVG is the committed artefact because it diffs — the next time the domain,
+ * a phone number or a layout changes, the review shows exactly what moved on
+ * the graphic. PNG needs a browser and is only for eyeballing a proof, so it
+ * is opt-in and not committed.
+ */
+import { mkdir, readdir, writeFile } from "node:fs/promises";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { SITE_URL } from "../brand.js";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(HERE, "..");
+const OUT = join(ROOT, "out");
+
+/* The whole point of the ticket. If any of these ever appears in a built
+   graphic again, --check fails rather than the post going out. */
+const FORBIDDEN = [/restcoderacademy\.com/i, /www\.restcoderacademy/i, /https?:\/\/restcoderacademy/i];
+
+const png = process.argv.includes("--png");
+const checkOnly = process.argv.includes("--check");
+
+async function templates() {
+  const dir = join(ROOT, "templates");
+  const files = (await readdir(dir)).filter((f) => f.endsWith(".js") && !f.startsWith("_")).sort();
+  return Promise.all(files.map((f) => import(join(dir, f))));
+}
+
+function audit(id, svg) {
+  const hits = FORBIDDEN.filter((re) => re.test(svg)).map(String);
+  if (hits.length) throw new Error(`${id}: dead-URL pattern in output → ${hits.join(", ")}`);
+  if (!svg.includes(SITE_URL)) throw new Error(`${id}: no ${SITE_URL} watermark in output`);
+}
+
+const mods = await templates();
+if (!mods.length) throw new Error("no templates found");
+
+const built = mods.map((m) => {
+  const svg = m.render();
+  audit(m.meta.id, svg);
+  return { ...m.meta, svg };
+});
+
+if (checkOnly) {
+  console.log(`✓ ${built.length} templates carry ${SITE_URL} and no dead URL`);
+  process.exit(0);
+}
+
+await mkdir(OUT, { recursive: true });
+for (const t of built) {
+  await writeFile(join(OUT, `${t.id}.svg`), t.svg);
+  console.log(`svg  out/${t.id}.svg   (${t.title})`);
+}
+
+if (png) {
+  // Playwright is already a devDependency for the e2e suite, so a proof export
+  // needs no new tooling. Montserrat is loaded from the installed @fontsource
+  // package rather than the network, so a proof rendered offline still uses
+  // the real face instead of silently falling back to Helvetica.
+  const { chromium } = await import("playwright");
+  const fontDir = resolve(ROOT, "../../node_modules/@fontsource/montserrat/files");
+  const face = (w) =>
+    `@font-face{font-family:Montserrat;font-weight:${w};font-style:normal;src:url("file://${fontDir}/montserrat-latin-${w}-normal.woff2") format("woff2");}`;
+  const css = [400, 500, 600, 700].map(face).join("");
+
+  const browser = await chromium.launch();
+  const page = await browser.newPage({ viewport: { width: 1080, height: 1080 }, deviceScaleFactor: 1 });
+  for (const t of built) {
+    await page.setContent(
+      `<style>${css}html,body{margin:0;padding:0}svg{display:block}</style>${t.svg}`,
+      { waitUntil: "load" },
+    );
+    await page.evaluate(() => document.fonts.ready);
+    await page.screenshot({ path: join(OUT, `${t.id}.png`), clip: { x: 0, y: 0, width: 1080, height: 1080 } });
+    console.log(`png  out/${t.id}.png`);
+  }
+  await browser.close();
+}

--- a/tests/social-templates.test.js
+++ b/tests/social-templates.test.js
@@ -1,0 +1,85 @@
+/**
+ * The dead-URL guard (#151).
+ *
+ * `www.restcoderacademy.com` was baked into every social graphic RCA has
+ * published, and nothing could tell anyone it was wrong. These tests are what
+ * stops it coming back: a graphic that renders the dead domain, or renders no
+ * domain at all, fails CI instead of going out on Instagram.
+ */
+import { describe, it, expect } from "vitest";
+import { readdirSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { SITE_URL, PHONE_PRIMARY, PHONE_SECONDARY } from "../design/social-templates/brand.js";
+
+const DIR = resolve(dirname(fileURLToPath(import.meta.url)), "../design/social-templates/templates");
+const files = readdirSync(DIR).filter((f) => f.endsWith(".js") && !f.startsWith("_"));
+const mods = await Promise.all(files.map(async (f) => import(join(DIR, f))));
+
+describe("the URL on every social graphic", () => {
+  it("finds all three recurring templates", () => {
+    expect(mods.map((m) => m.meta.id).sort()).toEqual([
+      "batch-launch",
+      "festival-greeting",
+      "placement-testimonial",
+    ]);
+  });
+
+  it.each(mods.map((m) => [m.meta.id, m]))("%s watermarks the live domain", (_id, mod) => {
+    expect(mod.render()).toContain(SITE_URL);
+  });
+
+  it.each(mods.map((m) => [m.meta.id, m]))("%s never prints the dead .com", (_id, mod) => {
+    const svg = mod.render();
+    expect(svg).not.toMatch(/restcoderacademy\.com/i);
+    // `www.` would send a prospect through the www→apex 301 from #15.
+    // Scoped to the domain: the SVG namespace URI is http://www.w3.org/…
+    expect(svg).not.toMatch(/www\.restcoderacademy/i);
+    // The existing graphics print a bare domain; #151 asks not to add one.
+    expect(svg).not.toMatch(/https?:\/\/restcoderacademy/i);
+  });
+
+  it("carries both audited phone numbers on the placement template", () => {
+    const svg = mods.find((m) => m.meta.id === "placement-testimonial").render();
+    expect(svg).toContain(PHONE_PRIMARY);
+    expect(svg).toContain(PHONE_SECONDARY);
+  });
+});
+
+describe("templates survive the data they will actually be given", () => {
+  const placement = mods.find((m) => m.meta.id === "placement-testimonial");
+
+  it("renders valid, non-empty SVG for every template's defaults", () => {
+    for (const m of mods) {
+      const svg = m.render();
+      expect(svg.startsWith("<svg")).toBe(true);
+      expect(svg).toContain('viewBox="0 0 1080 1080"');
+    }
+  });
+
+  it("collapses the salary badge rather than leaving an empty box", () => {
+    // The pill, not the colour — orange is also the rule above the bottom bar.
+    expect(placement.render()).toContain('rx="29"');
+    expect(placement.render({ salary: "" })).not.toContain('rx="29"');
+  });
+
+  it("escapes text instead of letting it break the document", () => {
+    const svg = placement.render({ name: 'A & B <script>"x"' });
+    expect(svg).toContain("&amp;");
+    expect(svg).toContain("&lt;script&gt;");
+    expect(svg).not.toContain("<script>");
+  });
+
+  it("truncates a testimonial that would otherwise run off the canvas", () => {
+    const svg = placement.render({ quote: "word ".repeat(200) });
+    expect(svg).toContain("…");
+  });
+
+  it("lays out a batch with three features without leaving a gap for a fourth", () => {
+    const batch = mods.find((m) => m.meta.id === "batch-launch");
+    const three = batch.render({ features: ["A", "B", "C"] });
+    expect(three).toContain(">A</text>");
+    expect(three).toContain(">C</text>");
+    expect(three).not.toContain(">D</text>");
+  });
+});


### PR DESCRIPTION
Closes #151.

## The problem

Every recurring social template watermarks `www.restcoderacademy.com`. That domain is dead, so every placement announcement, festival greeting and batch launch RCA has ever published advertises a URL that goes nowhere. Anyone who screenshots a post, or reads the URL off Instagram and types it later, hits nothing.

Task #13 fixed the Google Business Profile field, #15 the www→apex redirect, PR #148 the `/courses/fde` short URL. None of them touched the graphics, which is where most of the exposure actually is.

## Why this is code and not a Figma edit

The templates only ever existed inside a design tool. That is why the wrong URL survived three years and three adjacent fixes: it was invisible to the repo, unreviewable, and unfixable without opening the master file.

So the three templates are authored here instead:

| Path | What |
|---|---|
| `design/social-templates/brand.js` | the domain, the phones, the palette — **once** |
| `templates/*.js` | placement testimonial, festival greeting, batch launch |
| `tools/build.mjs` | → `out/*.svg`, `--png` proofs, `--check` for CI |
| `tests/social-templates.test.js` | fails if the dead URL ever comes back |

The domain is now one line. Templates call `watermark()` and never write it themselves, so a correction cannot land on two graphics and miss the third — which is exactly the failure this ticket is an instance of.

## Not a re-brand

Colours come from `design/tokens.css`, layouts are transcribed from the live graphics, nothing was redesigned. Per the ticket: historical posts untouched, no QR added, no protocol prefix, and `www.` dropped so nobody is sent through the #15 301.

## Templates take data, not fixed art

A missing salary collapses its badge instead of leaving an empty box. Long testimonials wrap and truncate rather than running off the canvas. Three features lay out without a gap where a fourth would be. Pasted text is escaped.

## Checks

- `npm test` — 88 passing, 13 new
- `npx eslint` — clean on every touched file
- PNG proofs of all three rendered and eyeballed at 1080×1080

PNG proofs are gitignored (they need a browser and only exist to eyeball a post). The SVGs are committed because they diff — the next change to a graphic shows up in review.

## One question for Uday

Both phone numbers on the placement template (`8073762257`, `9110424403`) came from the IG audit. Are both current, and are both meant to be public? They are one edit in `brand.js` if not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018AtUHWXJg6nACaLmB5k4ZQ