### PR TITLE
feat(placements): admin CRUD + D1-backed placement cards (closes #145)

### DIFF
--- a/functions/admin.js
+++ b/functions/admin.js
@@ -72,7 +72,7 @@ function page(notice, count, body) {
   .notice { padding:1rem 1.25rem; color:#b3261e; }
 </style></head>
 <body>
-  <header><h1>Enquiries</h1><span class="count">${count} total</span><a href="/admin/enrollments">Enrolments</a><a href="/admin/batches">Batches</a><a href="/admin/trainers">Trainers</a><a href="/admin/founder">Founder →</a></header>
+  <header><h1>Enquiries</h1><span class="count">${count} total</span><a href="/admin/enrollments">Enrolments</a><a href="/admin/batches">Batches</a><a href="/admin/trainers">Trainers</a><a href="/admin/placements">Placements</a><a href="/admin/founder">Founder →</a></header>
   ${notice ? `<div class="notice">${escapeHtml(notice)}</div>` : ""}
   <div class="wrap">
     <table>

--- a/functions/admin/batches.js
+++ b/functions/admin/batches.js
@@ -127,7 +127,7 @@ function page(rows, error, notice) {
   .hint{font-size:.75rem;color:var(--muted);margin:.3rem 0 0}
 </style></head>
 <body>
-  <header><h1>Batches</h1><a href="/admin/enrollments">Enrolments</a><a href="/admin/trainers">Trainers</a><a href="/admin/batches">Batches</a><a href="/admin/founder">Founder</a><a href="/admin">Enquiries →</a></header>
+  <header><h1>Batches</h1><a href="/admin/enrollments">Enrolments</a><a href="/admin/trainers">Trainers</a><a href="/admin/batches">Batches</a><a href="/admin/placements">Placements</a><a href="/admin/founder">Founder</a><a href="/admin">Enquiries →</a></header>
   <div class="wrap">
     ${error ? `<div class="banner err">${escapeHtml(error)}</div>` : ""}
     ${notice ? `<div class="banner ok">${escapeHtml(notice)}</div>` : ""}

--- a/functions/admin/enrollments.js
+++ b/functions/admin/enrollments.js
@@ -79,7 +79,7 @@ function page(notice, count, body) {
   .amt { font-weight:600; white-space:nowrap; }
 </style></head>
 <body>
-  <header><h1>Enrolments</h1><span class="count">${count} total</span><a href="/admin/trainers">Trainers</a><a href="/admin/batches">Batches</a><a href="/admin/founder">Founder</a><a href="/admin">Enquiries →</a></header>
+  <header><h1>Enrolments</h1><span class="count">${count} total</span><a href="/admin/trainers">Trainers</a><a href="/admin/batches">Batches</a><a href="/admin/placements">Placements</a><a href="/admin/founder">Founder</a><a href="/admin">Enquiries →</a></header>
   ${notice ? `<div class="notice">${escapeHtml(notice)}</div>` : ""}
   <div class="wrap">
     <table>

--- a/functions/admin/founder.js
+++ b/functions/admin/founder.js
@@ -97,7 +97,7 @@ function page(r, error, notice) {
   .hint{font-size:.8rem;color:var(--muted);margin:.3rem 0 1rem;line-height:1.5}
 </style></head>
 <body>
-  <header><h1>Founder page</h1><a href="/admin/enrollments">Enrolments</a><a href="/admin/trainers">Trainers</a><a href="/admin/batches">Batches</a><a href="/admin/founder">Founder</a><a href="/admin">Enquiries →</a></header>
+  <header><h1>Founder page</h1><a href="/admin/enrollments">Enrolments</a><a href="/admin/trainers">Trainers</a><a href="/admin/batches">Batches</a><a href="/admin/placements">Placements</a><a href="/admin/founder">Founder</a><a href="/admin">Enquiries →</a></header>
   <div class="wrap">
     ${error ? `<div class="banner err">${escapeHtml(error)}</div>` : ""}
     ${notice ? `<div class="banner ok">${escapeHtml(notice)}</div>` : ""}

--- a/functions/admin/placements.js
+++ b/functions/admin/placements.js
@@ -1,0 +1,234 @@
+// /admin/placements — publish a placement to the site without a deploy (#145).
+//
+// Same Basic Auth as the rest of the admin panel (ADMIN_PASSWORD, fails closed
+// if unset). GET renders every placement with an edit form each plus an add
+// form; POST handles add / update / publish toggle / delete, writes D1, and
+// redirects back.
+//
+// Why this exists: the team announces placements on Instagram the day they
+// happen, and nobody runs a commit → PR → deploy cycle to mirror them onto the
+// site — so the site's most persuasive section is permanently behind Instagram.
+// Publishing here should cost about what posting to Instagram costs.
+import { escapeHtml, requireAdminAuth } from "../../shared/serverUtil.js";
+import { EDITABLE_FIELDS, inputToColumns, validatePlacement } from "../../shared/placements.js";
+
+const SELECT =
+  "SELECT id, name, designation, company_name, company_logo_url, photo_url, " +
+  "description, background, journey, linkedin_url, course_slug, instagram_url, " +
+  "is_published, display_order FROM placements " +
+  "ORDER BY display_order ASC, created_at DESC";
+
+function html(body, status = 200) {
+  return new Response(body, {
+    status,
+    headers: { "Content-Type": "text/html; charset=utf-8", "cache-control": "no-store" },
+  });
+}
+
+function redirect(request, param, msg) {
+  const url = new URL(request.url);
+  url.search = "";
+  url.searchParams.set(param, msg);
+  return Response.redirect(url.toString(), 303);
+}
+
+// ---------------------------------------------------------------------------
+// GET
+// ---------------------------------------------------------------------------
+export async function onRequestGet(context) {
+  const { request, env } = context;
+  const auth = requireAdminAuth(request, env);
+  if (auth) return auth;
+  if (!env.DB) return html(page([], "Storage not configured.", null), 500);
+
+  let rows = [];
+  try {
+    rows = (await env.DB.prepare(SELECT).all()).results || [];
+  } catch {
+    return html(page([], "Could not load placements — has schema-placements.sql been applied?", null), 500);
+  }
+
+  const url = new URL(request.url);
+  return html(page(rows, url.searchParams.get("err"), url.searchParams.get("ok")), 200);
+}
+
+// ---------------------------------------------------------------------------
+// POST
+// ---------------------------------------------------------------------------
+export async function onRequestPost(context) {
+  const { request, env } = context;
+  const auth = requireAdminAuth(request, env);
+  if (auth) return auth;
+  if (!env.DB) return redirect(request, "err", "Storage not configured.");
+
+  let form;
+  try {
+    form = await request.formData();
+  } catch {
+    return redirect(request, "err", "Bad form submission.");
+  }
+
+  const action = String(form.get("action") || "");
+  const id = String(form.get("id") || "");
+
+  try {
+    if (action === "delete") {
+      if (!id) return redirect(request, "err", "Missing id.");
+      await env.DB.prepare("DELETE FROM placements WHERE id = ?1").bind(id).run();
+      return redirect(request, "ok", "Placement deleted.");
+    }
+
+    // The publish toggle is its own action rather than a checkbox on the edit
+    // form: taking a placement down is the urgent case (a student asks for
+    // their testimonial to be removed), and it should not require re-submitting
+    // and re-validating every other field to do it.
+    if (action === "toggle") {
+      if (!id) return redirect(request, "err", "Missing id.");
+      const res = await env.DB.prepare(
+        "UPDATE placements SET is_published = 1 - is_published, updated_at = datetime('now') " +
+          "WHERE id = ?1 RETURNING is_published",
+      ).bind(id).first();
+      if (!res) return redirect(request, "err", "No such placement.");
+      return redirect(request, "ok", res.is_published ? "Published to the site." : "Hidden from the site.");
+    }
+
+    if (action !== "add" && action !== "update") {
+      return redirect(request, "err", "Unknown action.");
+    }
+
+    const input = {};
+    for (const f of EDITABLE_FIELDS) input[f] = form.get(f);
+
+    const errors = validatePlacement(input);
+    if (errors.length) return redirect(request, "err", errors.join(" "));
+
+    const cols = inputToColumns(input);
+    const order = parseInt(form.get("display_order"), 10);
+    const displayOrder = Number.isFinite(order) ? order : 0;
+
+    if (action === "update") {
+      if (!id) return redirect(request, "err", "Missing id.");
+      const sets = EDITABLE_FIELDS.map((f, i) => `${f} = ?${i + 1}`).join(", ");
+      const n = EDITABLE_FIELDS.length;
+      await env.DB.prepare(
+        `UPDATE placements SET ${sets}, display_order = ?${n + 1}, ` +
+          `updated_at = datetime('now') WHERE id = ?${n + 2}`,
+      )
+        .bind(...EDITABLE_FIELDS.map((f) => cols[f]), displayOrder, id)
+        .run();
+      return redirect(request, "ok", "Placement saved.");
+    }
+
+    // New placements start unpublished. Curating rather than auto-publishing is
+    // the whole reason this is an admin form and not an Instagram sync.
+    const cells = EDITABLE_FIELDS.map((_f, i) => `?${i + 2}`).join(", ");
+    const n = EDITABLE_FIELDS.length;
+    await env.DB.prepare(
+      `INSERT INTO placements (id, ${EDITABLE_FIELDS.join(", ")}, display_order, is_published) ` +
+        `VALUES (?1, ${cells}, ?${n + 2}, 0)`,
+    )
+      .bind(crypto.randomUUID(), ...EDITABLE_FIELDS.map((f) => cols[f]), displayOrder)
+      .run();
+    return redirect(request, "ok", "Added — not on the site until you press Publish.");
+  } catch {
+    return redirect(request, "err", "Could not save. Check the fields and try again.");
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Render
+// ---------------------------------------------------------------------------
+const FIELD_LABELS = {
+  name: "Student name *",
+  designation: "Designation",
+  company_name: "Company",
+  company_logo_url: "Company logo URL",
+  photo_url: "Student photo URL",
+  description: "Testimonial (their own words)",
+  background: "Background (one line)",
+  journey: "Journey (1–3 sentences)",
+  linkedin_url: "LinkedIn URL",
+  course_slug: "Course slug",
+  instagram_url: "Instagram post URL",
+};
+const LONG = new Set(["description", "background", "journey"]);
+
+function field(f, value) {
+  const v = escapeHtml(value == null ? "" : String(value));
+  const input = LONG.has(f)
+    ? `<textarea name="${f}" rows="${f === "description" ? 4 : 2}">${v}</textarea>`
+    : `<input name="${f}" value="${v}"/>`;
+  return `<div class="${LONG.has(f) ? "full" : ""}"><label>${escapeHtml(FIELD_LABELS[f])}</label>${input}</div>`;
+}
+
+function rowForm(r) {
+  const live = r.is_published ? "live" : "hidden";
+  return `<form class="card" method="post">
+    <input type="hidden" name="id" value="${escapeHtml(r.id)}"/>
+    <h2>${escapeHtml(r.name)} <span class="tag ${live}">${live}</span></h2>
+    <div class="grid">
+      ${EDITABLE_FIELDS.map((f) => field(f, r[f])).join("")}
+      <div><label>Display order</label><input name="display_order" value="${escapeHtml(String(r.display_order ?? 0))}"/></div>
+    </div>
+    <div class="actions">
+      <button class="save" name="action" value="update">Save</button>
+      <button class="pub" name="action" value="toggle">${r.is_published ? "Hide from site" : "Publish"}</button>
+      <button class="del" name="action" value="delete"
+        onclick="return confirm('Delete ${escapeHtml(r.name)}? This cannot be undone.')">Delete</button>
+    </div>
+  </form>`;
+}
+
+function page(rows, error, notice) {
+  return `<!doctype html>
+<html lang="en"><head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<meta name="robots" content="noindex, nofollow"/>
+<title>Placements — Rest Coder Academy</title>
+<style>
+  :root { --navy:#03084C; --line:#e4e6ef; --muted:#5b6472; }
+  *{box-sizing:border-box}
+  body{margin:0;font-family:system-ui,-apple-system,Segoe UI,Roboto,sans-serif;color:#1b2030;background:#f5f6fa}
+  header{background:var(--navy);color:#fff;padding:1rem 1.25rem;display:flex;align-items:center;gap:1rem;flex-wrap:wrap}
+  header h1{font-size:1.1rem;margin:0}
+  header a{color:#cdd6ea;font-size:.85rem}
+  .wrap{padding:1.25rem;max-width:920px;margin:0 auto}
+  .banner{padding:.7rem 1rem;border-radius:8px;margin-bottom:1rem;font-size:.9rem}
+  .ok{background:#e7f6ec;color:#1b6b3a;border:1px solid #b6e0c4}
+  .err{background:#fdecea;color:#b3261e;border:1px solid #f1b5ac}
+  .card{background:#fff;border:1px solid var(--line);border-radius:10px;padding:1rem;margin-bottom:1rem}
+  .card h2{font-size:.95rem;margin:0 0 .75rem;color:var(--navy);display:flex;align-items:center;gap:.5rem}
+  .tag{font-size:.68rem;font-weight:700;padding:.1rem .45rem;border-radius:999px;text-transform:uppercase;letter-spacing:.04em}
+  .live{background:#e7f6ec;color:#1b6b3a}
+  .hidden{background:#eef0f4;color:#5b6472}
+  .grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(160px,1fr));gap:.6rem}
+  .grid .full{grid-column:1/-1}
+  label{display:block;font-size:.72rem;color:var(--muted);margin-bottom:.15rem}
+  input,textarea{width:100%;padding:.45rem .55rem;border:1px solid var(--line);border-radius:6px;font-size:.9rem;font-family:inherit}
+  .actions{margin-top:.75rem;display:flex;gap:.5rem;flex-wrap:wrap}
+  button{padding:.5rem 1rem;border:none;border-radius:6px;font-weight:600;font-size:.85rem;cursor:pointer}
+  .save{background:var(--navy);color:#fff}
+  .pub{background:#fff;color:#1b6b3a;border:1px solid #b6e0c4}
+  .del{background:#fff;color:#b3261e;border:1px solid #f1b5ac}
+  .add h2{color:#1b6b3a}
+  .hint{font-size:.75rem;color:var(--muted);margin:.3rem 0 1rem}
+</style></head>
+<body>
+  <header><h1>Placements</h1><a href="/admin/enrollments">Enrolments</a><a href="/admin/trainers">Trainers</a><a href="/admin/batches">Batches</a><a href="/admin/founder">Founder</a><a href="/admin">Enquiries →</a></header>
+  <div class="wrap">
+    ${error ? `<div class="banner err">${escapeHtml(error)}</div>` : ""}
+    ${notice ? `<div class="banner ok">${escapeHtml(notice)}</div>` : ""}
+    <p class="hint">A placement needs <b>either</b> an Instagram post URL (the embed carries the photo, company and caption) <b>or</b> a designation and a company. New entries are <b>hidden</b> until you press Publish. Lower display order shows first. Photo and logo take a full URL — the four original records use <code>bundled:</code> keys for images shipped inside the site and are best left alone.</p>
+    ${rows.map(rowForm).join("") || '<div class="card">No placements yet — add one below.</div>'}
+    <form class="card add" method="post">
+      <h2>+ Add a placement</h2>
+      <div class="grid">
+        ${EDITABLE_FIELDS.map((f) => field(f, "")).join("")}
+        <div><label>Display order</label><input name="display_order" value="0"/></div>
+      </div>
+      <div class="actions"><button class="save" name="action" value="add">Add</button></div>
+    </form>
+  </div>
+</body></html>`;
+}

--- a/functions/admin/trainers.js
+++ b/functions/admin/trainers.js
@@ -150,7 +150,7 @@ function page(rows, error, notice) {
   .hint{font-size:.75rem;color:var(--muted);margin:.3rem 0 1rem}
 </style></head>
 <body>
-  <header><h1>Trainers</h1><a href="/admin/enrollments">Enrolments</a><a href="/admin/trainers">Trainers</a><a href="/admin/batches">Batches</a><a href="/admin/founder">Founder</a><a href="/admin">Enquiries →</a></header>
+  <header><h1>Trainers</h1><a href="/admin/enrollments">Enrolments</a><a href="/admin/trainers">Trainers</a><a href="/admin/batches">Batches</a><a href="/admin/placements">Placements</a><a href="/admin/founder">Founder</a><a href="/admin">Enquiries →</a></header>
   <div class="wrap">
     ${error ? `<div class="banner err">${escapeHtml(error)}</div>` : ""}
     ${notice ? `<div class="banner ok">${escapeHtml(notice)}</div>` : ""}

--- a/functions/api/placements/list.js
+++ b/functions/api/placements/list.js
@@ -1,0 +1,39 @@
+// GET /api/placements/list — published placements for the site (#145).
+//
+// Cached for 5 minutes at the edge. Placements do not need to be real-time —
+// a new one appearing within five minutes of the admin hitting save is fine —
+// and caching is what keeps a section rendered on every page view from turning
+// into a D1 read on every page view.
+//
+// Fails soft: any error returns an empty list with a 200, because the site
+// falls back to its bundled array when the list is empty. A 500 here would
+// turn "placements are briefly stale" into "the most persuasive section on the
+// site is a broken state".
+import { rowToRecord } from "../../../shared/placements.js";
+
+const CACHE = "public, max-age=300";
+
+function json(body, status = 200, cache = "no-store") {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json; charset=utf-8", "cache-control": cache },
+  });
+}
+
+export async function onRequestGet(context) {
+  const { env } = context;
+  if (!env.DB) return json({ placements: [] }, 200, "no-store");
+
+  try {
+    const res = await env.DB.prepare(
+      "SELECT id, name, designation, company_name, company_logo_url, photo_url, " +
+        "description, background, journey, linkedin_url, course_slug, instagram_url " +
+        "FROM placements WHERE is_published = 1 " +
+        "ORDER BY display_order ASC, created_at DESC",
+    ).all();
+    const rows = res.results || [];
+    return json({ placements: rows.map(rowToRecord) }, 200, CACHE);
+  } catch {
+    return json({ placements: [] }, 200, "no-store");
+  }
+}

--- a/schema-placements.sql
+++ b/schema-placements.sql
@@ -1,0 +1,85 @@
+-- Placements — the site's success stories, moved out of a hardcoded array (#145).
+--
+-- Applies to the same D1 database as the existing tables (binding `DB` in
+-- wrangler.toml). Run locally:
+--   npx wrangler d1 execute restcoder-enquiries --local --file=schema-placements.sql
+-- Against the remote DB:
+--   npx wrangler d1 execute restcoder-enquiries --remote --file=schema-placements.sql
+--
+-- Why: the team announces placements on Instagram in real time, but nobody
+-- runs a commit → PR → deploy cycle to add them to the site, so the site is
+-- permanently behind. An admin form makes publishing a placement about as much
+-- work as posting one.
+
+CREATE TABLE IF NOT EXISTS placements (
+  id                TEXT PRIMARY KEY,           -- crypto.randomUUID() from app
+  name              TEXT NOT NULL,              -- student name as shown publicly
+  designation       TEXT,                       -- role at the company
+  company_name      TEXT,
+  company_logo_url  TEXT,
+  photo_url         TEXT,
+  description       TEXT,                       -- the student's own testimonial
+  background        TEXT,                       -- one line of context, for /placements
+  journey           TEXT,                       -- 1-3 sentences, for /placements
+  linkedin_url      TEXT,                       -- enriches Person JSON-LD via sameAs
+  course_slug       TEXT,                       -- links to /courses/<slug>
+  instagram_url     TEXT,                       -- renders IG's official embed instead
+  is_published      INTEGER NOT NULL DEFAULT 0, -- curate rather than auto-publish
+  display_order     INTEGER NOT NULL DEFAULT 0,
+  created_at        TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at        TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+-- The public endpoint only ever reads published rows in display order, so that
+-- is the index. Everything else is an admin query over a table of tens of rows.
+CREATE INDEX IF NOT EXISTS idx_placements_published
+  ON placements (is_published, display_order, created_at);
+
+-- ---------------------------------------------------------------------------
+-- Seed: the records currently hardcoded in placement.js
+-- ---------------------------------------------------------------------------
+-- Seeded so the site looks identical the moment it starts reading from D1 —
+-- the switch should be invisible to a visitor.
+--
+-- `designation` and `company_*` are NULLable and `instagram_url` exists because
+-- of Kota Akshay below: an IG-embed-only record where the embed carries the
+-- photo, company and testimonial. #145's original field list predates that
+-- record; placement.js's own comment says it should migrate as-is, so it does.
+--
+-- photo_url / company_logo_url use `bundled:<key>` for the four records whose
+-- images are Vite asset imports. Their real URLs contain a content hash that
+-- only exists after a build, so no literal URL can be written here. The client
+-- resolves the key against the same imports the fallback array uses, which is
+-- what keeps these four pixel-identical. Anything added through the admin form
+-- carries an ordinary URL and needs no such treatment.
+
+INSERT OR IGNORE INTO placements
+  (id, name, designation, company_name, company_logo_url, photo_url,
+   background, description, is_published, display_order)
+VALUES
+  ('seed-ashish', 'Ashish Jadhav', 'SAP Hybris Developer', 'SAP Hybris',
+   'bundled:sapHybris', 'bundled:ashish',
+   'Non-IT background from Maharashtra; moved to Bengaluru to switch into engineering.',
+   'Uday Sir is an exceptional mentor who transformed my career prospects. Despite being a non-IT background student from Maharashtra, I thrived under his guidance in Bangalore. His teaching style is concise, clear, and engaging. Uday Sir''s patience and willingness to help are admirable. He creates a supportive environment, encouraging students to ask questions. His friendly nature makes complex concepts accessible and enjoyable.',
+   1, 10),
+
+  ('seed-sakshi', 'Sakshi', 'Software Engineer', 'HCL Technologies',
+   'bundled:hcl', 'bundled:sakshi', NULL,
+   'Uday Sir is an exceptional Java programming teacher, known for his deep knowledge and engaging teaching style. His ability to simplify complex concepts makes learning Java both easy and enjoyable. With a passion for coding and a dedication to his students'' success, he ensures that everyone gains a strong foundation in programming. His guidance not only helps students master Java but also instills confidence in problem-solving and logical thinking.',
+   1, 20),
+
+  ('seed-sujith', 'Sujith', 'Software Engineer', 'SKAD IT Solutions',
+   'bundled:skad', 'bundled:sujith', NULL,
+   'The coaching institute offers an exceptional Java and Python Full stack  course with comprehensive coverage of Core Java, Springs,Hibernate,SQL,Python,Django. Uday sir''s expert guidance on backend development is complemented perfectly. His combined industry experience and personalized mentoring ensure students gain practical skills through hands-on projects. The institute maintains small batch sizes, creating an interactive learning environment.',
+   1, 30),
+
+  ('seed-prajwala', 'Prajwala R', 'Test Automation Engineer', 'Quality Service Group',
+   'bundled:qsg', 'bundled:prajwala', NULL,
+   'Uday sir is a fantastic Java trainer who breaks down complex topics into simple, easy-to-grasp concepts. He creates a supportive learning environment that encourages students to ask questions and grow. What sets him apart is his ability to adapt to different learning styles and pace.I''m grateful for his mentorship, which helped me achieve my goals. Finally thanks to all the team members of rest coder academy.',
+   1, 40);
+
+INSERT OR IGNORE INTO placements
+  (id, name, background, instagram_url, is_published, display_order)
+VALUES
+  ('seed-kota-akshay', 'Kota Akshay Rathna Kumar', 'B.Tech CSE, 2026 graduate',
+   'https://www.instagram.com/p/Dc5o-Uatcxz/', 1, 50);

--- a/shared/placements.js
+++ b/shared/placements.js
@@ -1,0 +1,90 @@
+/**
+ * The placement record shape, shared by the API, the admin form and the site (#145).
+ *
+ * D1 rows are snake_case with 0/1 integers; the site's components were written
+ * against a camelCase array with a nested `company` object. Rather than change
+ * every consumer, the row is mapped to the shape they already read — so the
+ * switch from the hardcoded array to D1 is invisible to a visitor and to most
+ * of the component tree.
+ */
+
+/** Every column an admin can set. `id`, timestamps and publish state are not here. */
+export const EDITABLE_FIELDS = [
+  "name",
+  "designation",
+  "company_name",
+  "company_logo_url",
+  "photo_url",
+  "description",
+  "background",
+  "journey",
+  "linkedin_url",
+  "course_slug",
+  "instagram_url",
+];
+
+/**
+ * A record needs *something* to render: either the traditional photo + company
+ * card, or an Instagram embed that carries all of it visually. A row with a
+ * name and nothing else would render an empty card, which is worse than not
+ * rendering it — so it is rejected at the point of entry rather than filtered
+ * out later, where nobody would understand why their placement vanished.
+ */
+export function validatePlacement(input) {
+  const errors = [];
+  const name = String(input.name || "").trim();
+  if (!name) errors.push("Student name is required.");
+
+  const hasEmbed = !!String(input.instagram_url || "").trim();
+  const hasCard = !!String(input.designation || "").trim() && !!String(input.company_name || "").trim();
+  if (!hasEmbed && !hasCard) {
+    errors.push(
+      "Give either an Instagram post URL, or both a designation and a company name — " +
+        "otherwise the card has nothing to show.",
+    );
+  }
+
+  for (const [field, value] of Object.entries(input)) {
+    if (!field.endsWith("_url") || !value) continue;
+    // `bundled:` is how the seeded records point at Vite asset imports whose
+    // real URLs only exist after a build. Anything else must be a real URL.
+    if (String(value).startsWith("bundled:")) continue;
+    if (!/^(https?:\/\/|\/)/.test(String(value))) {
+      errors.push(`${field} must be a full URL or start with "/".`);
+    }
+  }
+
+  if (String(input.instagram_url || "") && !/^https:\/\/(www\.)?instagram\.com\//.test(String(input.instagram_url))) {
+    errors.push("Instagram URL must be an instagram.com link.");
+  }
+
+  return errors;
+}
+
+/** D1 row → the shape the site components already read. */
+export function rowToRecord(row) {
+  const rec = { id: row.id, name: row.name };
+  if (row.designation) rec.designation = row.designation;
+  if (row.photo_url) rec.photo_url = row.photo_url;
+  if (row.description) rec.description = row.description;
+  if (row.background) rec.background = row.background;
+  if (row.journey) rec.journey = row.journey;
+  if (row.linkedin_url) rec.linkedin = row.linkedin_url;
+  if (row.course_slug) rec.courseSlug = row.course_slug;
+  if (row.instagram_url) rec.instagram_url = row.instagram_url;
+  if (row.company_name) {
+    rec.company = { name: row.company_name };
+    if (row.company_logo_url) rec.company.logo = row.company_logo_url;
+  }
+  return rec;
+}
+
+/** Form/JSON input → the columns to write. Trims, and stores "" as NULL. */
+export function inputToColumns(input) {
+  const out = {};
+  for (const field of EDITABLE_FIELDS) {
+    const value = String(input[field] ?? "").trim();
+    out[field] = value === "" ? null : value.slice(0, 4000);
+  }
+  return out;
+}

--- a/src/components/Pages/PlacementsPage.jsx
+++ b/src/components/Pages/PlacementsPage.jsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Link } from "react-router-dom";
 import { useAuth } from "../../App";
-import { placements } from "../organism/placements/placement";
+import usePlacements from "../organism/placements/usePlacements";
 import InstagramEmbed from "../organism/placements/InstagramEmbed";
 import "./PlacementsPage.css";
 
@@ -12,13 +12,18 @@ const ORG_ID = `${ORIGIN}/#org`;
 
 function PlacementsPage() {
   const { openModal } = useAuth();
+  // Reads D1 via /api/placements/list, falling back to the bundled array (#145).
+  // The JSON-LD below is rebuilt from whatever this returns, so a placement
+  // published in the admin form is structured-data-visible on the same render
+  // as it is visible on the page — they cannot drift apart.
+  const { placements } = usePlacements();
   const url = `${ORIGIN}/placements`;
   const description =
     "Real students, real companies, real roles. See where Rest Coder Academy graduates work — " +
     "SAP Hybris, HCL Technologies, SKAD IT Solutions and more.";
 
   // Structured data graph. Every entry here is derived from real, named
-  // placements in placement.js — nothing is invented. Emits:
+  // placements — from D1, or the bundled array — nothing is invented. Emits:
   //  - Review (existing) — reads as reviews of the org, not disconnected.
   //  - Person + alumniOf (new) — makes the alumni relationship explicit,
   //    which Google's SGE and AI answer engines pick up when asked

--- a/src/components/organism/placements/PlacementCard.jsx
+++ b/src/components/organism/placements/PlacementCard.jsx
@@ -8,7 +8,7 @@ import Typography from "@mui/material/Typography";
 import TypoGraphyComponent from "../../atoms/TypoGraphyComponent/TypoGraphyComponent";
 import ButtonComponent from "../../atoms/ButtonComponent/ButtonComponent";
 import { CardMedia, colors, List, ListItem, ListItemText } from "@mui/material";
-import { placements } from "./placement";
+import usePlacements from "./usePlacements";
 import CardGridItem from "../../molecules/Grid/CardGridItem";
 
 import { useRef } from "react";
@@ -22,6 +22,8 @@ import InstagramEmbed from "./InstagramEmbed";
 
 function PlacementCard() {
   const sliderRef = useRef(null);
+  // Reads D1 via /api/placements/list, falling back to the bundled array (#145).
+  const { placements } = usePlacements();
 
    const settings = {
   

--- a/src/components/organism/placements/placement.js
+++ b/src/components/organism/placements/placement.js
@@ -50,6 +50,36 @@ import qsg from "../../../assets/clients/qsg.jpg"
 //                 rendering when the embed fails to load is documented in
 //                 `InstagramEmbed.jsx`. Wider scope (YouTube + LinkedIn URLs,
 //                 admin CRUD) is queued as portal work in #145.
+/**
+ * The bundled images, keyed so a D1 row can point at one (#145).
+ *
+ * Records added through /admin/placements carry ordinary URLs. The four
+ * original records cannot: their images are Vite asset imports whose real URLs
+ * contain a content hash that only exists after a build, so the seed rows in
+ * schema-placements.sql reference them as `bundled:<key>` and this map is what
+ * resolves that back to the imported asset. It is why switching the site from
+ * this array to D1 leaves those four pixel-identical.
+ */
+export const BUNDLED_ASSETS = {
+  ashish, sakshi, sujith, prajwala,
+  sapHybris, hcl, skad, qsg,
+};
+
+/** `bundled:hcl` → the imported asset; any other value passes through. */
+export function resolveAsset(value) {
+  if (typeof value !== "string") return value;
+  if (!value.startsWith("bundled:")) return value;
+  return BUNDLED_ASSETS[value.slice("bundled:".length)] || undefined;
+}
+
+/**
+ * The fallback list.
+ *
+ * The site reads placements from /api/placements/list now (#145). This array
+ * stays as what renders when that fetch fails — a network error, the function
+ * down, D1 unreachable. Placements are the most persuasive section on the
+ * site; an empty one is a worse failure than a slightly stale one.
+ */
 export let placements=[
     {
         name:"Ashish Jadhav",

--- a/src/components/organism/placements/usePlacements.js
+++ b/src/components/organism/placements/usePlacements.js
@@ -1,0 +1,57 @@
+/**
+ * Read placements from D1, falling back to the bundled array (#145).
+ *
+ * Everything the site shows used to live in placement.js, so a new placement
+ * needed a commit, a PR and a deploy — which is why Instagram has many more
+ * placements than the site does. Now /admin/placements writes to D1 and this
+ * reads it.
+ *
+ * Fails soft on purpose. If the fetch errors, or returns nothing, the bundled
+ * array renders instead: an empty placements section is a worse outcome than a
+ * stale one, and this is the section that does most of the persuading.
+ */
+import { useEffect, useState } from "react";
+import { placements as bundled, resolveAsset } from "./placement";
+
+/** Turn the API's asset references into things <img src> can use. */
+function hydrate(record) {
+  const out = { ...record };
+  if (out.photo_url) out.image = resolveAsset(out.photo_url);
+  if (out.company?.logo) out.company = { ...out.company, logo: resolveAsset(out.company.logo) };
+  return out;
+}
+
+export default function usePlacements() {
+  const [state, setState] = useState({ placements: bundled, loading: true });
+
+  useEffect(() => {
+    let live = true;
+    const controller = new AbortController();
+    // Nothing on this page is worth blocking on. If the endpoint is slow the
+    // bundled list is already rendered and stays.
+    const timer = setTimeout(() => controller.abort(), 5000);
+
+    fetch("/api/placements/list", { signal: controller.signal })
+      .then((r) => (r.ok ? r.json() : null))
+      .then((data) => {
+        if (!live) return;
+        const rows = data?.placements;
+        setState({
+          placements: Array.isArray(rows) && rows.length ? rows.map(hydrate) : bundled,
+          loading: false,
+        });
+      })
+      .catch(() => {
+        if (live) setState({ placements: bundled, loading: false });
+      })
+      .finally(() => clearTimeout(timer));
+
+    return () => {
+      live = false;
+      clearTimeout(timer);
+      controller.abort();
+    };
+  }, []);
+
+  return state;
+}

--- a/tests/placements.test.js
+++ b/tests/placements.test.js
@@ -1,0 +1,269 @@
+/**
+ * Placements: D1-backed list, admin CRUD, and the mapping between them (#145).
+ *
+ * The site's placements were hardcoded, so publishing one meant a commit, a PR
+ * and a deploy — which is why Instagram had many more of them than the site
+ * did. These tests cover the three things that has to get right: the public
+ * endpoint never breaks the section, the admin gate actually holds, and a row
+ * round-trips to the shape the components already read.
+ */
+import { describe, it, expect } from "vitest";
+import { onRequestGet as listGet } from "../functions/api/placements/list.js";
+import {
+  onRequestGet as adminGet,
+  onRequestPost as adminPost,
+} from "../functions/admin/placements.js";
+import { inputToColumns, rowToRecord, validatePlacement, EDITABLE_FIELDS } from "../shared/placements.js";
+
+const ctx = (request, env) => ({ request, env, params: {} });
+const authH = (u = "admin", p = "secret") => ({ Authorization: "Basic " + btoa(`${u}:${p}`) });
+
+const formReq = (url, fields) =>
+  new Request(url, {
+    method: "POST",
+    headers: { "content-type": "application/x-www-form-urlencoded", ...authH() },
+    body: new URLSearchParams(fields).toString(),
+  });
+
+/** Fake D1 — mocks only prepare/bind/run/all/first, as the existing suite does. */
+function makeDB(rows = []) {
+  const t = { placements: [...rows] };
+  return {
+    tables: t,
+    prepare(sql) {
+      let args = [];
+      const stmt = {
+        bind(...a) { args = a; return stmt; },
+        async all() {
+          let out = t.placements;
+          if (/is_published = 1/.test(sql)) out = out.filter((p) => p.is_published === 1);
+          out = [...out].sort((a, b) => (a.display_order ?? 0) - (b.display_order ?? 0));
+          return { results: out };
+        },
+        async first() {
+          if (/UPDATE placements SET is_published = 1 - is_published/.test(sql)) {
+            const row = t.placements.find((p) => p.id === args[0]);
+            if (!row) return null;
+            row.is_published = row.is_published ? 0 : 1;
+            return { is_published: row.is_published };
+          }
+          return null;
+        },
+        async run() {
+          if (/^INSERT INTO placements/i.test(sql)) {
+            const rec = { id: args[0], is_published: 0 };
+            EDITABLE_FIELDS.forEach((f, i) => { rec[f] = args[i + 1]; });
+            rec.display_order = args[EDITABLE_FIELDS.length + 1];
+            t.placements.push(rec);
+          } else if (/^UPDATE placements SET name/i.test(sql)) {
+            const row = t.placements.find((p) => p.id === args[args.length - 1]);
+            if (row) {
+              EDITABLE_FIELDS.forEach((f, i) => { row[f] = args[i]; });
+              row.display_order = args[EDITABLE_FIELDS.length];
+            }
+          } else if (/DELETE FROM placements/i.test(sql)) {
+            t.placements = t.placements.filter((p) => p.id !== args[0]);
+          }
+        },
+      };
+      return stmt;
+    },
+  };
+}
+
+const row = (over = {}) => ({
+  id: "p1", name: "Sakshi", designation: "Software Engineer", company_name: "HCL",
+  company_logo_url: "bundled:hcl", photo_url: "bundled:sakshi",
+  description: "…", is_published: 1, display_order: 10, ...over,
+});
+
+// ---------------------------------------------------------------------------
+describe("GET /api/placements/list", () => {
+  it("returns only published rows, in display order", async () => {
+    const db = makeDB([
+      row({ id: "b", name: "Second", display_order: 20 }),
+      row({ id: "a", name: "First", display_order: 10 }),
+      row({ id: "h", name: "Hidden", is_published: 0, display_order: 5 }),
+    ]);
+    const res = await listGet(ctx(new Request("https://x/api/placements/list"), { DB: db }));
+    expect(res.status).toBe(200);
+    const { placements } = await res.json();
+    expect(placements.map((p) => p.name)).toEqual(["First", "Second"]);
+  });
+
+  it("caches for five minutes — this renders on every page view", async () => {
+    const res = await listGet(ctx(new Request("https://x/api/placements/list"), { DB: makeDB([row()]) }));
+    expect(res.headers.get("cache-control")).toBe("public, max-age=300");
+  });
+
+  it("returns an empty list rather than a 500 when D1 throws", async () => {
+    // The site falls back to its bundled array on an empty list. A 500 here
+    // would turn "slightly stale" into "the section is broken".
+    const db = { prepare() { throw new Error("D1 down"); } };
+    const res = await listGet(ctx(new Request("https://x/api/placements/list"), { DB: db }));
+    expect(res.status).toBe(200);
+    expect((await res.json()).placements).toEqual([]);
+    expect(res.headers.get("cache-control")).toBe("no-store");
+  });
+
+  it("returns an empty list when there is no DB binding at all", async () => {
+    const res = await listGet(ctx(new Request("https://x/api/placements/list"), {}));
+    expect(res.status).toBe(200);
+    expect((await res.json()).placements).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+describe("/admin/placements — the gate", () => {
+  const env = (db) => ({ DB: db, ADMIN_PASSWORD: "secret" });
+
+  it("401s without credentials, and with wrong ones", async () => {
+    const db = makeDB();
+    expect((await adminGet(ctx(new Request("https://x/admin/placements"), env(db)))).status).toBe(401);
+    const wrong = new Request("https://x/admin/placements", { headers: { Authorization: "Basic " + btoa("admin:nope") } });
+    expect((await adminGet(ctx(wrong, env(db)))).status).toBe(401);
+  });
+
+  it("fails closed when ADMIN_PASSWORD is unset", async () => {
+    const req = new Request("https://x/admin/placements", { headers: authH() });
+    expect((await adminGet(ctx(req, { DB: makeDB() }))).status).toBe(401);
+  });
+
+  it("401s an unauthenticated write before it touches the database", async () => {
+    const db = makeDB([row()]);
+    const req = new Request("https://x/admin/placements", {
+      method: "POST",
+      headers: { "content-type": "application/x-www-form-urlencoded" },
+      body: "action=delete&id=p1",
+    });
+    expect((await adminPost(ctx(req, env(db)))).status).toBe(401);
+    expect(db.tables.placements).toHaveLength(1);
+  });
+
+  it("escapes a stored testimonial rather than rendering it as markup", async () => {
+    const db = makeDB([row({ description: "<script>alert(1)</script>" })]);
+    const req = new Request("https://x/admin/placements", { headers: authH() });
+    const html = await (await adminGet(ctx(req, env(db)))).text();
+    expect(html).not.toContain("<script>alert(1)</script>");
+    expect(html).toContain("&lt;script&gt;");
+  });
+});
+
+// ---------------------------------------------------------------------------
+describe("/admin/placements — CRUD", () => {
+  const env = (db) => ({ DB: db, ADMIN_PASSWORD: "secret" });
+
+  it("adds a placement, unpublished, so nothing reaches the site unreviewed", async () => {
+    const db = makeDB();
+    const res = await adminPost(ctx(formReq("https://x/admin/placements", {
+      action: "add", name: "Asha", designation: "SDE", company_name: "Infosys", display_order: "5",
+    }), env(db)));
+    expect(res.status).toBe(303);
+    expect(res.headers.get("location")).toContain("ok=");
+    expect(db.tables.placements).toHaveLength(1);
+    expect(db.tables.placements[0].is_published).toBe(0);
+    expect(db.tables.placements[0].name).toBe("Asha");
+  });
+
+  it("rejects a record with nothing to render, and writes no row", async () => {
+    const db = makeDB();
+    const res = await adminPost(ctx(formReq("https://x/admin/placements", { action: "add", name: "Ghost" }), env(db)));
+    expect(res.status).toBe(303);
+    expect(res.headers.get("location")).toContain("err=");
+    expect(db.tables.placements).toHaveLength(0);
+  });
+
+  it("accepts an Instagram-embed-only record — the embed is the card", async () => {
+    const db = makeDB();
+    await adminPost(ctx(formReq("https://x/admin/placements", {
+      action: "add", name: "Kota Akshay", instagram_url: "https://www.instagram.com/p/Dc5o-Uatcxz/",
+    }), env(db)));
+    expect(db.tables.placements).toHaveLength(1);
+  });
+
+  it("refuses a javascript: URL in an asset field", async () => {
+    const db = makeDB();
+    await adminPost(ctx(formReq("https://x/admin/placements", {
+      action: "add", name: "A", designation: "d", company_name: "c", photo_url: "javascript:alert(1)",
+    }), env(db)));
+    expect(db.tables.placements).toHaveLength(0);
+  });
+
+  it("toggles publish without re-submitting every other field", async () => {
+    // Taking a testimonial down is the urgent case; it must not depend on the
+    // rest of the record still validating.
+    const db = makeDB([row({ is_published: 1 })]);
+    const res = await adminPost(ctx(formReq("https://x/admin/placements", { action: "toggle", id: "p1" }), env(db)));
+    expect(res.status).toBe(303);
+    expect(db.tables.placements[0].is_published).toBe(0);
+    await adminPost(ctx(formReq("https://x/admin/placements", { action: "toggle", id: "p1" }), env(db)));
+    expect(db.tables.placements[0].is_published).toBe(1);
+  });
+
+  it("updates an existing placement", async () => {
+    const db = makeDB([row()]);
+    await adminPost(ctx(formReq("https://x/admin/placements", {
+      action: "update", id: "p1", name: "Sakshi R", designation: "Senior Engineer",
+      company_name: "HCL", display_order: "1",
+    }), env(db)));
+    expect(db.tables.placements[0].name).toBe("Sakshi R");
+    expect(db.tables.placements[0].display_order).toBe(1);
+  });
+
+  it("deletes", async () => {
+    const db = makeDB([row()]);
+    await adminPost(ctx(formReq("https://x/admin/placements", { action: "delete", id: "p1" }), env(db)));
+    expect(db.tables.placements).toHaveLength(0);
+  });
+
+  it("rejects an unknown action", async () => {
+    const db = makeDB([row()]);
+    const res = await adminPost(ctx(formReq("https://x/admin/placements", { action: "drop-table", id: "p1" }), env(db)));
+    expect(res.headers.get("location")).toContain("err=");
+    expect(db.tables.placements).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+describe("row → the shape the components already read", () => {
+  it("nests company the way placement.js does", () => {
+    expect(rowToRecord(row())).toMatchObject({
+      name: "Sakshi",
+      designation: "Software Engineer",
+      company: { name: "HCL", logo: "bundled:hcl" },
+    });
+  });
+
+  it("omits empty optional fields instead of emitting nulls", () => {
+    // PlacementsPage builds JSON-LD off these; a null journey would emit an
+    // empty schema property rather than no property.
+    const rec = rowToRecord({ id: "x", name: "A", journey: null, linkedin_url: "" });
+    expect("journey" in rec).toBe(false);
+    expect("linkedin" in rec).toBe(false);
+    expect("company" in rec).toBe(false);
+  });
+
+  it("renames linkedin_url and course_slug to what the page reads", () => {
+    const rec = rowToRecord({ id: "x", name: "A", linkedin_url: "https://in/a", course_slug: "java" });
+    expect(rec.linkedin).toBe("https://in/a");
+    expect(rec.courseSlug).toBe("java");
+  });
+
+  it("stores a blank field as NULL rather than an empty string", () => {
+    const cols = inputToColumns({ name: "A", designation: "  ", journey: "" });
+    expect(cols.name).toBe("A");
+    expect(cols.designation).toBeNull();
+    expect(cols.journey).toBeNull();
+  });
+
+  it("accepts bundled: asset keys, which is how the seeded records keep their images", () => {
+    expect(validatePlacement({
+      name: "A", designation: "d", company_name: "c", photo_url: "bundled:sakshi",
+    })).toEqual([]);
+  });
+
+  it("rejects an instagram_url that is not an instagram.com link", () => {
+    const errs = validatePlacement({ name: "A", instagram_url: "https://evil.test/p/x/" });
+    expect(errs.join(" ")).toContain("instagram.com");
+  });
+});


### PR DESCRIPTION
Closes #145.

## Why

Placement cards were hardcoded in `placement.js`, so publishing one meant a commit, a PR and a deploy. Nobody runs that cycle for a placement — which is why Instagram has many more than the site does, and the site's most persuasive section is permanently behind.

## What

| File | |
|---|---|
| `schema-placements.sql` | table + seed of the current records |
| `functions/api/placements/list.js` | `GET /api/placements/list`, published only, 5-min edge cache |
| `functions/admin/placements.js` | add / edit / publish toggle / display order / delete |
| `shared/placements.js` | one row↔record mapping and one validator, shared by both |
| `usePlacements.js` | fetches, falls back to the bundled array |

## Three things that differ from the ticket, on purpose

**The seed is five records, not four, and there's an `instagram_url` column.** Kota Akshay's record landed after #145 was written — embed-only, no photo/company/testimonial, because the IG embed carries all of it. Its comment in `placement.js` says it should migrate as-is, so it does. That's why `designation` and `company_name` are nullable, and why validation asks for *either* an embed URL *or* a designation-and-company: a row with neither renders an empty card.

**The four original records keep their images via `bundled:<key>`.** Their real URLs carry a Vite content hash that only exists after a build, so no literal URL could go in a seed. The client resolves the key against the same imports the fallback uses.

**The admin screen uses `requireAdminAuth`, not a portal session.** The ticket says "session cookie from #114" — that's the *student portal's* gate, and #114 hasn't landed. Every admin route on `main` uses the same Basic Auth, including the portal-users page from #112. Happy to switch it if you'd rather it wait for the portal.

## Not included

**R2 upload.** There's no R2 binding in `wrangler.toml`. Photo and logo take URLs, which is what the ticket's own schema specifies (`photo_url`, `company_logo_url`). Worth its own ticket if the team wants to upload straight from a phone.

## Failure behaviour

The list endpoint returns `{placements: []}` with a **200** when D1 errors, never a 500 — the site falls back to the bundled array on an empty list, and a 500 would turn "briefly stale" into "the section is broken".

New entries are **unpublished** until someone presses Publish, so nothing reaches the site unreviewed. The publish toggle is its own action, so taking a testimonial down (the urgent case) never depends on the rest of the record still validating.

## Verified

End to end against local D1 through `wrangler pages dev`:

- gate 401s unauthenticated reads **and** writes, and fails closed with no `ADMIN_PASSWORD`
- add → row exists, hidden from `/api/placements/list`
- publish → appears in the list
- invalid record (name only, or a `javascript:` URL) → no row written
- delete → gone
- `/placements` and the homepage carousel render from D1 with **zero broken images** and no console errors; JSON-LD is rebuilt from the fetched data (4 Review + 5 Person + ItemList), so structured data can't drift from what's on the page

22 new tests · 97 passing · build clean · lint clean on every new file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018AtUHWXJg6nACaLmB5k4ZQ