### PR TITLE
fix(enroll): bind the recorded course to the payment that was actually made (closes #165)

### DIFF
--- a/functions/admin/enrollments.js
+++ b/functions/admin/enrollments.js
@@ -32,17 +32,28 @@ function rupees(paise) {
 
 function rowHtml(r) {
   const paid = r.status === "paid";
+  // A payment we could not confirm with Razorpay (#165). The money is real, but
+  // we could not check which course it was for, so the row deliberately holds
+  // no course and no amount. Rendering it as "registered" like everything else
+  // that is not "paid" would show a student who HAS paid as one who has not —
+  // it needs its own badge and someone to reconcile it against the Razorpay
+  // dashboard using the payment id.
+  const review = r.status === "needs_review";
   const badge = paid
     ? `<span class="badge paid">paid</span>`
-    : `<span class="badge reg">registered</span>`;
+    : review
+      ? `<span class="badge review">needs review</span>`
+      : `<span class="badge reg">registered</span>`;
   return (
     "<tr>" +
     `<td>${escapeHtml(r.fullname)}</td>` +
     `<td><a href="tel:${escapeHtml(r.mobile)}">${escapeHtml(r.mobile)}</a></td>` +
     `<td>${r.email ? `<a href="mailto:${escapeHtml(r.email)}">${escapeHtml(r.email)}</a>` : "—"}</td>` +
-    `<td>${escapeHtml(r.course_name || r.course)}</td>` +
+    `<td>${escapeHtml(r.course_name || r.course) || "<em>unconfirmed</em>"}</td>` +
     `<td>${escapeHtml(r.batch) || "—"}</td>` +
-    `<td>${badge}${paid ? ` <span class="amt">${rupees(r.amount)}</span>` : ""}</td>` +
+    `<td>${badge}${typeof r.amount === "number" ? ` <span class="amt">${rupees(r.amount)}</span>` : ""}` +
+      (review ? ` <span class="pid">${escapeHtml(r.razorpay_payment_id)}</span>` : "") +
+      "</td>" +
     `<td>${escapeHtml(r.referral) || "—"}</td>` +
     `<td class="when">${escapeHtml(r.created_at)}</td>` +
     "</tr>"
@@ -76,6 +87,8 @@ function page(notice, count, body) {
   .badge { font-size:.72rem; font-weight:700; padding:.1rem .45rem; border-radius:999px; text-transform:uppercase; }
   .badge.paid { background:#e7f6ec; color:#1b6b3a; }
   .badge.reg { background:#eef1f8; color:#334; }
+  .badge.review { background:#fff4e5; color:#8a5300; }
+  .pid { font-family:ui-monospace,monospace; font-size:.72rem; color:#5b6472; white-space:nowrap; }
   .amt { font-weight:600; white-space:nowrap; }
 </style></head>
 <body>

--- a/functions/api/enroll/verify.js
+++ b/functions/api/enroll/verify.js
@@ -25,14 +25,29 @@ export async function onRequestPost(context) {
   if (!valid) return json({ error: "Payment could not be verified." }, 400);
 
   const courseId = String(b.course || "").trim();
-  const amount = priceForCourse(courseId);
+  const expected = priceForCourse(courseId);
 
-  // There is no form on our side — the student enters their phone + email in
-  // Razorpay Checkout — so pull those from the verified payment. Any values in
-  // the body are only a fallback. Best-effort: the payment is already verified,
-  // so a failed lookup must never fail the student.
+  // Fetch the payment Razorpay actually captured.
+  //
+  // Two different jobs, with two different failure rules (#165):
+  //
+  //   1. Contact details. There is no form on our side — the student types
+  //      their phone and email into Razorpay Checkout — so these come from the
+  //      payment. Best-effort: a failed lookup must never fail a student who
+  //      has paid.
+  //
+  //   2. WHAT they paid for. Razorpay's signature is an HMAC over
+  //      `order_id|payment_id` only; it does not cover the course. So a real
+  //      payment for a ₹35,000 course could be re-submitted with
+  //      `course: "fde"` and be recorded as a paid ₹50,000 enrolment, with a
+  //      signature that validates. The payment object is the only thing that
+  //      knows which order was really paid and for how much, so this half
+  //      cannot be best-effort.
   let email = str(b.email);
   let mobile = str(b.mobile);
+  let captured = null;
+  let lookupFailed = false;
+
   if (env.RAZORPAY_KEY_ID && keySecret) {
     try {
       const pr = await fetch(
@@ -43,11 +58,32 @@ export async function onRequestPost(context) {
         const p = await pr.json();
         if (p.email) email = str(p.email);
         if (p.contact) mobile = str(p.contact);
+        captured = p;
+      } else {
+        lookupFailed = true;
       }
     } catch {
-      /* keep the fallbacks */
+      lookupFailed = true;
+    }
+  } else {
+    lookupFailed = true;
+  }
+
+  if (captured) {
+    // The payment must belong to the order the caller named, must be money we
+    // actually hold, and must match this course's price. Any mismatch means the
+    // body is describing a different purchase than the one that happened.
+    const belongsToOrder = String(captured.order_id || "") === orderId;
+    const isCaptured = captured.status === "captured";
+    const priceMatches = expected !== null && Number(captured.amount) === expected;
+
+    if (!belongsToOrder || !isCaptured || !priceMatches) {
+      return json({ error: "Payment could not be verified." }, 400);
     }
   }
+
+  // What we hold, not what the body claimed. Null when we could not confirm.
+  const amount = captured ? Number(captured.amount) : null;
 
   try {
     const existing = await env.DB.prepare(
@@ -56,14 +92,21 @@ export async function onRequestPost(context) {
       .bind(orderId)
       .first();
     if (!existing) {
+      // When the lookup failed we could not confirm which course was paid for,
+      // so the row records the payment without asserting one. `needs_review`
+      // rather than `paid` so /admin/enrollments surfaces it: the student has
+      // paid either way, and a human reconciles it against Razorpay.
+      const status = lookupFailed ? "needs_review" : "paid";
       await env.DB.prepare(
         "INSERT INTO enrollments (fullname, mobile, email, experience, course, course_name, batch, referral, amount, currency, razorpay_order_id, razorpay_payment_id, status) " +
-          "VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,'INR',?10,?11,'paid')"
+          "VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,'INR',?10,?11,?12)"
       )
         .bind(
           str(b.fullname), mobile, email, str(b.experience),
-          courseId, str(b.course_name), str(b.batch), str(b.referral),
-          amount || null, orderId, paymentId
+          lookupFailed ? null : courseId,
+          lookupFailed ? null : str(b.course_name),
+          str(b.batch), str(b.referral),
+          amount, orderId, paymentId, status
         )
         .run();
     }

--- a/schema-enrollments.sql
+++ b/schema-enrollments.sql
@@ -16,7 +16,12 @@ CREATE TABLE IF NOT EXISTS enrollments (
   currency          TEXT NOT NULL DEFAULT 'INR',
   razorpay_order_id TEXT,
   razorpay_payment_id TEXT,
-  status            TEXT NOT NULL DEFAULT 'registered',  -- 'registered' | 'paid'
+  -- 'registered'   free interest, no payment
+  -- 'paid'         payment confirmed against Razorpay's payment object
+  -- 'needs_review' payment verified by signature, but Razorpay was unreachable
+  --                so the course and amount could not be confirmed (#165) —
+  --                the money is real; a human reconciles it from the payment id
+  status            TEXT NOT NULL DEFAULT 'registered',
   created_at        TEXT NOT NULL DEFAULT (datetime('now'))
 );
 

--- a/tests/enroll.verify.test.js
+++ b/tests/enroll.verify.test.js
@@ -1,0 +1,183 @@
+/**
+ * What an enrolment row is allowed to claim (#165).
+ *
+ * Razorpay's signature is an HMAC over `order_id|payment_id` only. It does not
+ * cover the course, so a genuine payment for a ₹35,000 course could be
+ * re-submitted with `course: "fde"` and recorded as a paid ₹50,000 enrolment
+ * with a signature that validates. These tests pin the payment object, not the
+ * request body, as the authority on what was bought.
+ */
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { onRequestPost as verifyPost } from "../functions/api/enroll/verify.js";
+
+const SECRET = "test_secret";
+const KEY_ID = "rzp_test_key";
+
+async function sign(orderId, paymentId, secret = SECRET) {
+  const enc = new TextEncoder();
+  const key = await crypto.subtle.importKey("raw", enc.encode(secret),
+    { name: "HMAC", hash: "SHA-256" }, false, ["sign"]);
+  const mac = await crypto.subtle.sign("HMAC", key, enc.encode(`${orderId}|${paymentId}`));
+  return [...new Uint8Array(mac)].map((b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+function makeDB() {
+  const rows = [];
+  return {
+    rows,
+    prepare(sql) {
+      let a = [];
+      const s = {
+        bind(...x) { a = x; return s; },
+        async first() { return rows.find((r) => r.razorpay_order_id === a[0]) || null; },
+        async run() {
+          if (/INSERT INTO enrollments/i.test(sql)) {
+            rows.push({
+              fullname: a[0], mobile: a[1], email: a[2], course: a[4], course_name: a[5],
+              amount: a[8], razorpay_order_id: a[9], razorpay_payment_id: a[10], status: a[11],
+            });
+          }
+        },
+      };
+      return s;
+    },
+  };
+}
+
+/** Razorpay's payment lookup, answering with whatever the test says it holds. */
+const stubPayment = (payment) =>
+  vi.stubGlobal("fetch", async () => new Response(JSON.stringify(payment), { status: 200 }));
+
+const call = async (body, db) =>
+  verifyPost({
+    request: new Request("https://x/api/enroll/verify", {
+      method: "POST", headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+    }),
+    env: { RAZORPAY_KEY_ID: KEY_ID, RAZORPAY_KEY_SECRET: SECRET, DB: db },
+  });
+
+const ORDER = "order_JAVA123";
+const PAYMENT = "pay_ABC123";
+const JAVA = 3500000;
+const FDE = 5000000;
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe("the course has to be the one that was paid for", () => {
+  it("rejects a real payment re-submitted against a dearer course", async () => {
+    // The exact shape of #165: genuine order, genuine payment, valid signature,
+    // swapped course. Before the fix this recorded fde/5000000 as paid.
+    stubPayment({ order_id: ORDER, amount: JAVA, status: "captured" });
+    const db = makeDB();
+    const res = await call({
+      razorpay_order_id: ORDER, razorpay_payment_id: PAYMENT,
+      razorpay_signature: await sign(ORDER, PAYMENT),
+      course: "fde", course_name: "Forward Deployed Engineering",
+    }, db);
+
+    expect(res.status).toBe(400);
+    expect(db.rows).toHaveLength(0);
+  });
+
+  it("accepts the course that matches what was captured", async () => {
+    stubPayment({ order_id: ORDER, amount: JAVA, status: "captured", email: "a@b.c", contact: "9000000000" });
+    const db = makeDB();
+    const res = await call({
+      razorpay_order_id: ORDER, razorpay_payment_id: PAYMENT,
+      razorpay_signature: await sign(ORDER, PAYMENT),
+      course: "java-fs", course_name: "Java Full Stack",
+    }, db);
+
+    expect(res.status).toBe(200);
+    expect(db.rows[0]).toMatchObject({ course: "java-fs", amount: JAVA, status: "paid" });
+  });
+
+  it("records the amount captured, not the price of the claimed course", async () => {
+    // A part payment, or a Razorpay-side discount, must not be written up to
+    // the sticker price just because the body named that course.
+    stubPayment({ order_id: ORDER, amount: JAVA, status: "captured" });
+    const db = makeDB();
+    await call({
+      razorpay_order_id: ORDER, razorpay_payment_id: PAYMENT,
+      razorpay_signature: await sign(ORDER, PAYMENT), course: "java-fs",
+    }, db);
+    expect(db.rows[0].amount).toBe(JAVA);
+    expect(db.rows[0].amount).not.toBe(FDE);
+  });
+
+  it("rejects a payment belonging to a different order", async () => {
+    stubPayment({ order_id: "order_SOMEONE_ELSE", amount: JAVA, status: "captured" });
+    const db = makeDB();
+    const res = await call({
+      razorpay_order_id: ORDER, razorpay_payment_id: PAYMENT,
+      razorpay_signature: await sign(ORDER, PAYMENT), course: "java-fs",
+    }, db);
+    expect(res.status).toBe(400);
+    expect(db.rows).toHaveLength(0);
+  });
+
+  it("rejects a payment that was authorized but never captured", async () => {
+    // Authorized money can still be voided; it is not a paid enrolment.
+    stubPayment({ order_id: ORDER, amount: JAVA, status: "authorized" });
+    const db = makeDB();
+    const res = await call({
+      razorpay_order_id: ORDER, razorpay_payment_id: PAYMENT,
+      razorpay_signature: await sign(ORDER, PAYMENT), course: "java-fs",
+    }, db);
+    expect(res.status).toBe(400);
+    expect(db.rows).toHaveLength(0);
+  });
+
+  it("rejects an unknown course, which has no price to match", async () => {
+    stubPayment({ order_id: ORDER, amount: JAVA, status: "captured" });
+    const db = makeDB();
+    const res = await call({
+      razorpay_order_id: ORDER, razorpay_payment_id: PAYMENT,
+      razorpay_signature: await sign(ORDER, PAYMENT), course: "not-a-course",
+    }, db);
+    expect(res.status).toBe(400);
+  });
+
+  it("still rejects a forged signature before any of this", async () => {
+    stubPayment({ order_id: ORDER, amount: JAVA, status: "captured" });
+    const db = makeDB();
+    const res = await call({
+      razorpay_order_id: ORDER, razorpay_payment_id: PAYMENT,
+      razorpay_signature: "deadbeef", course: "java-fs",
+    }, db);
+    expect(res.status).toBe(400);
+    expect(db.rows).toHaveLength(0);
+  });
+});
+
+describe("when Razorpay cannot be reached", () => {
+  it("acknowledges the student but does not assert a course", async () => {
+    // They have paid. Failing them here would be the worse bug. But we have not
+    // confirmed what for, so the row says so instead of guessing.
+    vi.stubGlobal("fetch", async () => { throw new Error("offline"); });
+    const db = makeDB();
+    const res = await call({
+      razorpay_order_id: ORDER, razorpay_payment_id: PAYMENT,
+      razorpay_signature: await sign(ORDER, PAYMENT), course: "fde",
+    }, db);
+
+    expect(res.status).toBe(200);
+    expect((await res.json()).ok).toBe(true);
+    expect(db.rows[0].status).toBe("needs_review");
+    expect(db.rows[0].course).toBeNull();
+    expect(db.rows[0].amount).toBeNull();
+  });
+
+  it("is still idempotent — a retry does not add a second row", async () => {
+    vi.stubGlobal("fetch", async () => { throw new Error("offline"); });
+    const db = makeDB();
+    const body = {
+      razorpay_order_id: ORDER, razorpay_payment_id: PAYMENT,
+      razorpay_signature: await sign(ORDER, PAYMENT), course: "java-fs",
+    };
+    await call(body, db);
+    await call(body, db);
+    expect(db.rows).toHaveLength(1);
+  });
+});

--- a/tests/functions.integration.test.js
+++ b/tests/functions.integration.test.js
@@ -53,11 +53,14 @@ function makeDB(seed = {}) {
           } else if (/DELETE FROM trainers/i.test(sql)) {
             t.trainers = t.trainers.filter((b) => String(b.id) !== String(args[0]));
           } else if (/INSERT INTO enrollments/i.test(sql)) {
-            if (/'paid'/.test(sql)) {
+            // verify.js binds status as a parameter now (#165) — a payment we
+            // could not confirm records as needs_review rather than paid — so
+            // take it from the args rather than sniffing the SQL for 'paid'.
+            if (/razorpay_order_id/.test(sql)) {
               t.enrollments.push({
                 id: ++ids.enrollments, fullname: args[0], mobile: args[1], email: args[2], experience: args[3],
                 course: args[4], course_name: args[5], batch: args[6], referral: args[7], amount: args[8],
-                razorpay_order_id: args[9], razorpay_payment_id: args[10], status: "paid",
+                razorpay_order_id: args[9], razorpay_payment_id: args[10], status: args[11] ?? "paid",
               });
             } else {
               t.enrollments.push({
@@ -318,17 +321,26 @@ describe("POST /api/enroll/verify", () => {
   it("records a verified paid enrolment, idempotently (no duplicate on retry)", async () => {
     const db = makeDB();
     const sig = await rzpSign("o1", "p1", "sekret");
+    // The captured payment is the authority on what was bought (#165): the
+    // course in the body is only accepted when its price matches this.
+    vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: true,
+      json: async () => ({ order_id: "o1", amount: 5000000, status: "captured" }),
+    });
     const body = {
       razorpay_order_id: "o1", razorpay_payment_id: "p1", razorpay_signature: sig,
       course: "fde", course_name: "Forward Deployed Engineering", fullname: "Asha", mobile: "9", email: "a@b.c",
     };
-    const r1 = await enrollVerify(ctx(jsonReqTo("https://x/api/enroll/verify", body), env(db)));
+    // Needs the key id too: without it verify.js cannot reach Razorpay to
+    // confirm what was paid for, and correctly records needs_review (#165).
+    const fullEnv = { ...env(db), RAZORPAY_KEY_ID: "rzp_test_x" };
+    const r1 = await enrollVerify(ctx(jsonReqTo("https://x/api/enroll/verify", body), fullEnv));
     expect(r1.status).toBe(200);
     expect(db.tables.enrollments).toHaveLength(1);
     expect(db.tables.enrollments[0].status).toBe("paid");
-    expect(db.tables.enrollments[0].amount).toBe(5000000); // server-decided, not from the body
+    expect(db.tables.enrollments[0].amount).toBe(5000000); // what Razorpay captured
 
-    const r2 = await enrollVerify(ctx(jsonReqTo("https://x/api/enroll/verify", body), env(db)));
+    const r2 = await enrollVerify(ctx(jsonReqTo("https://x/api/enroll/verify", body), fullEnv));
     expect(r2.status).toBe(200);
     expect(db.tables.enrollments).toHaveLength(1); // still one — idempotent
   });
@@ -339,7 +351,11 @@ describe("POST /api/enroll/verify", () => {
     // Razorpay is where the student entered their details (no form on our side).
     const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue({
       ok: true,
-      json: async () => ({ email: "student@rzp.test", contact: "+919876500000" }),
+      json: async () => ({
+        email: "student@rzp.test", contact: "+919876500000",
+        // A real payment carries these, and #165 now checks them.
+        order_id: "o9", amount: 3500000, status: "captured",
+      }),
     });
     const res = await enrollVerify(
       ctx(


### PR DESCRIPTION
Closes #165. **P0 — money.**

## The bug

Razorpay's signature is an HMAC over `order_id|payment_id` only. It does not cover the course. `verify.js` took the course from the request body and wrote it, with that course's price, as a paid enrolment. Nothing compared the claim against the order that was actually paid.

With four payable courses at two prices, a genuine ₹35,000 payment re-submitted naming the ₹50,000 course was recorded as a paid FDE enrolment, with a signature that validated.

Reproduced against the real handler before fixing:

```
paid for java-fs : 3500000 paise
recorded as      : fde 5000000 paise
status           : paid
```

**₹15,000 a time**, and `/admin/enrollments` showed them as fully paid. It was harmless while FDE was the only payable course — which is what the comment in `order.js` still assumes — and adding the other three made it live.

## The fix

`verify.js` already fetched the payment for the student's email and phone, so the authority was on hand and unused. It now also requires the payment to:

- belong to the order that was named
- be `captured`, not merely authorized
- match that course's price

and records **the amount actually captured**, not the price of the claimed course.

## The part worth reading carefully

Those two lookups have different failure rules:

- **Contact details** stay best-effort. A student who has paid must never be failed because a lookup hiccupped.
- **What they paid for** cannot be best-effort, or the check is worthless.

So when Razorpay is unreachable the payment is still acknowledged to the student, but the row records **no course and no amount** and is marked `needs_review` rather than asserting something unverified.

That needed handling at the other end too: `/admin/enrollments` rendered anything that was not `"paid"` as `"registered"`, so an unconfirmed payment would have shown a student who **has** paid as one who has not. It gets its own badge and shows the payment id to reconcile against Razorpay.

## Not affected

`order.js` is untouched and was already correct: the amount charged is looked up server-side from the course id and never read from the body. Nobody could ever pay *less* than the sticker price. This is only about what gets recorded afterwards.

## On the two tests I changed

Both asserted the old contract. One of them carried the comment `// server-decided, not from the body` while asserting the price of the body's claimed course, which is precisely the bug. The DB stub also keyed off a literal `'paid'` in the SQL that is now a bound parameter.

Nine new tests, including the original attack. 84 passing, build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018AtUHWXJg6nACaLmB5k4ZQ