### PR TITLE
feat(portal): course home and lesson list for the student portal (#137) [supersedes #139]

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,8 @@ app ships to students on rural connections.
 
 ## Student portal (Phase 1)
 
-`/portal/login` and `/portal` are the student portal (#110, #111). They are
+`/portal/login`, `/portal` and `/portal/courses/:slug` are the student portal
+(#110, #111, #137). They are
 **inert until configured**: with no OAuth secrets set, `/auth/me` reports no
 providers and the login screen says "coming soon" rather than rendering buttons
 that lead to a provider error page. The marketing site is unaffected either way.

--- a/README.md
+++ b/README.md
@@ -217,6 +217,11 @@ app ships to students on rural connections.
 providers and the login screen says "coming soon" rather than rendering buttons
 that lead to a provider error page. The marketing site is unaffected either way.
 
+Sessions are **stateless** — a signed HS256 JWT in an HttpOnly cookie, no
+`sessions` table, so a request verifies a signature instead of paying a D1 read.
+Logout clears the cookie; it cannot revoke a token server-side before its 30-day
+expiry. See the note at the foot of `schema-users.sql`.
+
 ### Owner-provisioned secrets
 
 These cannot be created from the repo. Set them as Cloudflare Pages secrets:

--- a/README.md
+++ b/README.md
@@ -259,3 +259,19 @@ npx wrangler d1 execute restcoder-enquiries --file=./schema-users.sql
 | `GET /auth/:provider/callback` | exchange the code, **verify the ID token against the provider's JWKS**, upsert into `users`, issue the session cookie |
 | `GET /auth/me` | the current user, or 401. Also reports which providers are configured. |
 | `POST /auth/logout` | clear the session cookie |
+| `GET /api/portal/courses` | the signed-in student's enrolled courses, or 401 |
+| `GET /api/portal/courses/:slug` | one enrolled course with its published lessons. **404 when the student is not enrolled**, so slugs cannot be probed. |
+
+### Course content (Phase 2)
+
+Courses and lessons live in the same D1 database as `users`:
+
+```
+npx wrangler d1 execute restcoder-enquiries --file=./schema-courses.sql
+```
+
+`enrolments_users` is the resolved link between a portal account and a course.
+The older `enrollments` table cannot serve that role: it identifies a person by
+the email typed into the enquiry form and a course by free text, and its rows
+predate any sign-in. The backfill that maps one to the other is at the foot of
+`schema-courses.sql`.

--- a/README.md
+++ b/README.md
@@ -209,3 +209,48 @@ app ships to students on rural connections.
   view leads — so form submissions were silently dropped whenever it was asleep.
   It was **replaced** by the D1 + Pages Function setup above (see issues #2, #17,
   #19, #20). `trcabe.onrender.com` is no longer used.
+
+## Student portal (Phase 1)
+
+`/portal/login` and `/portal` are the student portal (#110, #111). They are
+**inert until configured**: with no OAuth secrets set, `/auth/me` reports no
+providers and the login screen says "coming soon" rather than rendering buttons
+that lead to a provider error page. The marketing site is unaffected either way.
+
+### Owner-provisioned secrets
+
+These cannot be created from the repo. Set them as Cloudflare Pages secrets:
+
+| Secret | Where it comes from |
+|---|---|
+| `SESSION_SECRET` | any long random string — signs the session cookie |
+| `GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET` | Google Cloud Console → OAuth 2.0 Client ID (Web application) |
+| `MS_CLIENT_ID` / `MS_CLIENT_SECRET` | Entra → App registrations → Certificates & secrets |
+| `MS_TENANT` | optional; defaults to `common` (work **and** personal accounts) |
+
+Register these redirect URIs with **both** providers:
+
+```
+https://restcoderacademy.in/auth/google/callback
+https://restcoderacademy.in/auth/microsoft/callback
+```
+
+The redirect is always this site's own origin, never the `rca://` deep link —
+a custom scheme cannot be a registered redirect for a confidential client, and
+the token exchange has to happen server-side. The native shell is handed back
+at the end of the callback.
+
+### Database
+
+```
+npx wrangler d1 execute restcoder-enquiries --file=./schema-users.sql
+```
+
+### The endpoints
+
+| Route | What it does |
+|---|---|
+| `GET /auth/:provider/start` | redirect to consent, with PKCE + state in HttpOnly cookies. **503 when unconfigured.** |
+| `GET /auth/:provider/callback` | exchange the code, **verify the ID token against the provider's JWKS**, upsert into `users`, issue the session cookie |
+| `GET /auth/me` | the current user, or 401. Also reports which providers are configured. |
+| `POST /auth/logout` | clear the session cookie |

--- a/functions/api/portal/courses.js
+++ b/functions/api/portal/courses.js
@@ -1,0 +1,29 @@
+// GET /api/portal/courses — the signed-in student's enrolled courses (#136).
+// Session-guarded: no cookie, no course data. Never cached, because the
+// response is specific to one student.
+import { getSession } from "../../../shared/auth.js";
+import { listEnrolledCourses } from "../../../shared/courses.js";
+
+const json = (body, status = 200) =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json", "cache-control": "no-store" },
+  });
+
+export async function onRequestGet(context) {
+  const { request, env } = context;
+
+  const session = await getSession(request, env);
+  if (!session) return json({ error: "unauthenticated" }, 401);
+
+  // No D1 binding is a server fault, not an empty course list. Returning []
+  // here would tell a student who has enrolments that they have none.
+  if (!env.DB) return json({ error: "unavailable" }, 503);
+
+  try {
+    const courses = await listEnrolledCourses(env.DB, session.uid);
+    return json({ courses });
+  } catch {
+    return json({ error: "unavailable" }, 503);
+  }
+}

--- a/functions/api/portal/courses/[slug].js
+++ b/functions/api/portal/courses/[slug].js
@@ -1,0 +1,32 @@
+// GET /api/portal/courses/:slug — one enrolled course with its lessons (#136).
+//
+// A student who is not enrolled gets the same 404 as a slug that does not
+// exist. A 403 would confirm the course is real, which is not something an
+// outsider should be able to learn by guessing slugs.
+import { getSession } from "../../../../shared/auth.js";
+import { getEnrolledCourse } from "../../../../shared/courses.js";
+
+const json = (body, status = 200) =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json", "cache-control": "no-store" },
+  });
+
+export async function onRequestGet(context) {
+  const { request, env, params } = context;
+
+  const session = await getSession(request, env);
+  if (!session) return json({ error: "unauthenticated" }, 401);
+  if (!env.DB) return json({ error: "unavailable" }, 503);
+
+  const slug = String(params.slug || "");
+  if (!slug) return json({ error: "not_found" }, 404);
+
+  try {
+    const course = await getEnrolledCourse(env.DB, session.uid, slug);
+    if (!course) return json({ error: "not_found" }, 404);
+    return json({ course });
+  } catch {
+    return json({ error: "unavailable" }, 503);
+  }
+}

--- a/functions/auth/[provider]/callback.js
+++ b/functions/auth/[provider]/callback.js
@@ -1,0 +1,99 @@
+// GET /auth/:provider/callback — exchange the code, verify the ID token against
+// the provider's JWKS, upsert the user in D1, and issue our own session (#42).
+import { signSession, sessionCookie, readCookie } from "../../../shared/auth.js";
+import { isConfigured, providerConfig, redirectUri, verifyIdToken } from "../../../shared/oidc.js";
+
+const clearTx = (headers) => {
+  for (const n of ["rca_oauth_state", "rca_oauth_verifier", "rca_oauth_next"]) {
+    headers.append("set-cookie", `${n}=; HttpOnly; Secure; SameSite=Lax; Path=/auth; Max-Age=0`);
+  }
+};
+
+// Errors go back to the login screen as a code in the query string, so the UI
+// can say something useful. Nothing from the provider is echoed into the page.
+function fail(reason) {
+  const headers = new Headers({ location: `/portal/login?error=${encodeURIComponent(reason)}` });
+  clearTx(headers);
+  return new Response(null, { status: 302, headers });
+}
+
+export async function onRequestGet(context) {
+  const { request, env, params } = context;
+  const provider = String(params.provider || "");
+  if (!isConfigured(provider, env)) return fail("not_configured");
+
+  const url = new URL(request.url);
+  // The user pressed "cancel" on the consent screen.
+  if (url.searchParams.get("error")) return fail("cancelled");
+
+  const code = url.searchParams.get("code");
+  const state = url.searchParams.get("state");
+  const expectedState = readCookie(request, "rca_oauth_state");
+  const verifier = readCookie(request, "rca_oauth_verifier");
+  if (!code || !state || !expectedState || state !== expectedState || !verifier) {
+    return fail("bad_state");
+  }
+
+  const cfg = providerConfig(provider, env);
+
+  let tokens;
+  try {
+    const res = await fetch(cfg.token, {
+      method: "POST",
+      headers: { "content-type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams({
+        grant_type: "authorization_code",
+        code,
+        client_id: cfg.clientId,
+        client_secret: cfg.clientSecret,
+        redirect_uri: redirectUri(request, provider),
+        code_verifier: verifier,
+      }),
+    });
+    if (!res.ok) return fail("token_exchange");
+    tokens = await res.json();
+  } catch {
+    return fail("token_exchange");
+  }
+  if (!tokens.id_token) return fail("token_exchange");
+
+  const claims = await verifyIdToken(tokens.id_token, cfg);
+  if (!claims) return fail("bad_token");
+
+  if (!env.DB) return fail("storage");
+  let user;
+  try {
+    await env.DB.prepare(
+      "INSERT INTO users (provider, subject, email, name, picture, last_login) " +
+        "VALUES (?1, ?2, ?3, ?4, ?5, datetime('now')) " +
+        "ON CONFLICT (provider, subject) DO UPDATE SET " +
+        "email = excluded.email, name = excluded.name, picture = excluded.picture, " +
+        "last_login = datetime('now')",
+    )
+      .bind(provider, claims.sub, claims.email || null, claims.name || null, claims.picture || null)
+      .run();
+    const row = await env.DB.prepare(
+      "SELECT id, email, name, picture, role FROM users WHERE provider = ?1 AND subject = ?2",
+    )
+      .bind(provider, claims.sub)
+      .first();
+    user = row;
+  } catch {
+    return fail("storage");
+  }
+  if (!user) return fail("storage");
+
+  const token = await signSession(
+    { uid: user.id, email: user.email, name: user.name, picture: user.picture, role: user.role, provider },
+    env.SESSION_SECRET,
+  );
+
+  const nextRaw = readCookie(request, "rca_oauth_next");
+  const next = nextRaw ? decodeURIComponent(nextRaw) : "/portal";
+  const safeNext = next.startsWith("/") && !next.startsWith("//") ? next : "/portal";
+
+  const headers = new Headers({ location: safeNext });
+  clearTx(headers);
+  headers.append("set-cookie", sessionCookie(token));
+  return new Response(null, { status: 302, headers });
+}

--- a/functions/auth/[provider]/start.js
+++ b/functions/auth/[provider]/start.js
@@ -1,0 +1,53 @@
+// GET /auth/:provider/start — begin the Authorization Code + PKCE flow (#42).
+//
+// The verifier and the CSRF state are held in short-lived HttpOnly cookies
+// rather than in a store: they only have to survive the round trip to the
+// provider and back to /callback on this same origin.
+import { codeChallenge, isConfigured, providerConfig, randomString, redirectUri } from "../../../shared/oidc.js";
+
+const TX_TTL = 600; // 10 minutes is longer than any real consent screen takes
+
+function txCookie(name, value) {
+  return `${name}=${value}; HttpOnly; Secure; SameSite=Lax; Path=/auth; Max-Age=${TX_TTL}`;
+}
+
+export async function onRequestGet(context) {
+  const { request, env, params } = context;
+  const provider = String(params.provider || "");
+
+  // Inert until configured: no client id, no redirect to a provider error page.
+  if (!isConfigured(provider, env)) {
+    return new Response(
+      JSON.stringify({ error: "not_configured", provider }),
+      { status: 503, headers: { "content-type": "application/json" } },
+    );
+  }
+
+  const cfg = providerConfig(provider, env);
+  const state = randomString(16);
+  const verifier = randomString(32);
+  const challenge = await codeChallenge(verifier);
+
+  // Where to land inside the app afterwards. Only a same-site path is kept —
+  // an absolute URL here would make this an open redirect.
+  const requested = new URL(request.url).searchParams.get("next") || "/portal";
+  const next = requested.startsWith("/") && !requested.startsWith("//") ? requested : "/portal";
+
+  const url = new URL(cfg.authorize);
+  url.searchParams.set("client_id", cfg.clientId);
+  url.searchParams.set("redirect_uri", redirectUri(request, provider));
+  url.searchParams.set("response_type", "code");
+  url.searchParams.set("scope", cfg.scope);
+  url.searchParams.set("state", state);
+  url.searchParams.set("code_challenge", challenge);
+  url.searchParams.set("code_challenge_method", "S256");
+  // Ask for an account chooser rather than silently reusing whichever account
+  // the phone happens to be signed into.
+  url.searchParams.set("prompt", "select_account");
+
+  const headers = new Headers({ location: url.toString() });
+  headers.append("set-cookie", txCookie("rca_oauth_state", state));
+  headers.append("set-cookie", txCookie("rca_oauth_verifier", verifier));
+  headers.append("set-cookie", txCookie("rca_oauth_next", encodeURIComponent(next)));
+  return new Response(null, { status: 302, headers });
+}

--- a/functions/auth/logout.js
+++ b/functions/auth/logout.js
@@ -1,0 +1,14 @@
+// POST /auth/logout — clear the session cookie. POST rather than GET so a
+// prefetch or an <img> cannot sign a student out.
+import { clearSessionCookie } from "../../shared/auth.js";
+
+export async function onRequestPost() {
+  return new Response(JSON.stringify({ ok: true }), {
+    status: 200,
+    headers: {
+      "content-type": "application/json",
+      "cache-control": "no-store",
+      "set-cookie": clearSessionCookie(),
+    },
+  });
+}

--- a/functions/auth/me.js
+++ b/functions/auth/me.js
@@ -1,0 +1,33 @@
+// GET /auth/me — who the caller is, or 401. The portal's route guard calls
+// this on load; it is also what tells the login screen whether any provider is
+// configured, so the UI never has to guess.
+import { getSession } from "../../shared/auth.js";
+import { configuredProviders } from "../../shared/oidc.js";
+
+const json = (body, status) =>
+  new Response(JSON.stringify(body), {
+    status,
+    // A session-bearing response must never be cached by a proxy or the app shell.
+    headers: { "content-type": "application/json", "cache-control": "no-store" },
+  });
+
+export async function onRequestGet(context) {
+  const { request, env } = context;
+  const providers = configuredProviders(env);
+  const session = await getSession(request, env);
+  if (!session) return json({ authenticated: false, providers }, 401);
+  return json(
+    {
+      authenticated: true,
+      providers,
+      user: {
+        id: session.uid,
+        email: session.email,
+        name: session.name,
+        picture: session.picture,
+        role: session.role || "student",
+      },
+    },
+    200,
+  );
+}

--- a/schema-courses.sql
+++ b/schema-courses.sql
@@ -1,0 +1,63 @@
+-- Phase 2: course + lesson content for the student portal (#136).
+-- Lives in the same D1 database as the Phase 1 `users` table so a student's
+-- enrolments join to their account without a second datastore.
+
+CREATE TABLE IF NOT EXISTS courses (
+  id         INTEGER PRIMARY KEY AUTOINCREMENT,
+  slug       TEXT NOT NULL,                          -- URL id, e.g. 'fde'
+  title      TEXT NOT NULL,
+  summary    TEXT,
+  cover_url  TEXT,
+  published  INTEGER NOT NULL DEFAULT 0,             -- 0 until it is ready to show
+  created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_courses_slug ON courses (slug);
+
+CREATE TABLE IF NOT EXISTS lessons (
+  id               INTEGER PRIMARY KEY AUTOINCREMENT,
+  course_id        INTEGER NOT NULL REFERENCES courses(id) ON DELETE CASCADE,
+  position         INTEGER NOT NULL,                 -- order within the course, 1-based
+  title            TEXT NOT NULL,
+  notes            TEXT,                             -- markdown, the data-light half of a lesson
+  video_url        TEXT,                             -- filled in by the Phase 2 upload ticket
+  duration_seconds INTEGER,
+  published        INTEGER NOT NULL DEFAULT 0,
+  created_at       TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+-- The course page reads lessons for one course in order; this is that query.
+CREATE INDEX IF NOT EXISTS idx_lessons_course_position ON lessons (course_id, position);
+
+-- The resolved link between a portal account and a course.
+--
+-- The existing `enrollments` table cannot serve this. It predates the portal:
+-- it identifies a person by the email typed into the enquiry form and a course
+-- by a free-text string, and a row is written before the student has ever
+-- signed in. Joining portal reads to it directly would mean matching on email
+-- on every request and trusting a string to name a course. So enrolment is
+-- resolved once, into this table, keyed by the ids that actually exist.
+CREATE TABLE IF NOT EXISTS enrolments_users (
+  id            INTEGER PRIMARY KEY AUTOINCREMENT,
+  user_id       INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  course_id     INTEGER NOT NULL REFERENCES courses(id) ON DELETE CASCADE,
+  -- Which `enrollments` row this came from, when it came from one. Null for a
+  -- link an admin created by hand.
+  enrollment_id INTEGER,
+  created_at    TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+-- A student is enrolled in a course once, not once per sign-in.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_enrolments_users_pair
+  ON enrolments_users (user_id, course_id);
+
+-- Backfill, run after a student first signs in. Matches the enquiry-form email
+-- to the account email and the enrolment's course string to a course slug.
+-- Case-insensitive on email because the two came from different keyboards.
+--
+--   INSERT OR IGNORE INTO enrolments_users (user_id, course_id, enrollment_id)
+--   SELECT u.id, c.id, e.id
+--     FROM enrollments e
+--     JOIN users   u ON lower(u.email) = lower(e.email)
+--     JOIN courses c ON c.slug = e.course
+--    WHERE e.email IS NOT NULL;

--- a/schema-users.sql
+++ b/schema-users.sql
@@ -1,0 +1,17 @@
+-- Student-portal user accounts (Phase 1). Populated on first Google/Microsoft
+-- sign-in; the portal keys everything student-specific off `id`.
+CREATE TABLE IF NOT EXISTS users (
+  id         INTEGER PRIMARY KEY AUTOINCREMENT,
+  provider   TEXT NOT NULL,                          -- 'google' | 'microsoft'
+  subject    TEXT NOT NULL,                          -- provider's stable user id ('sub')
+  email      TEXT,
+  name       TEXT,
+  picture    TEXT,
+  role       TEXT NOT NULL DEFAULT 'student',        -- 'student' | 'instructor' | 'admin'
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  last_login TEXT
+);
+
+-- One account per (provider, subject) — the login upsert matches on this.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_users_provider_subject
+  ON users (provider, subject);

--- a/schema-users.sql
+++ b/schema-users.sql
@@ -15,3 +15,15 @@ CREATE TABLE IF NOT EXISTS users (
 -- One account per (provider, subject) — the login upsert matches on this.
 CREATE UNIQUE INDEX IF NOT EXISTS idx_users_provider_subject
   ON users (provider, subject);
+
+-- Looked up when an admin searches for a student by address.
+CREATE INDEX IF NOT EXISTS idx_users_email ON users (email);
+
+-- No `sessions` table on purpose: the portal is stateless. The session is a
+-- signed HS256 JWT in an HttpOnly cookie (shared/auth.js), so a normal request
+-- verifies a signature instead of paying a D1 read. The trade-off is that
+-- logout clears the cookie rather than revoking a row, so a stolen token stays
+-- valid for the rest of its 30-day TTL and cannot be killed server-side. That
+-- is acceptable while the portal only shows a student their own course pages.
+-- Add this table (and shorten the TTL) before it holds anything heavier --
+-- payments, instructor grading, anything an admin role can reach.

--- a/shared/auth.js
+++ b/shared/auth.js
@@ -1,0 +1,76 @@
+// Signed-cookie sessions for the student portal. A compact HS256 JWT signed
+// with the SESSION_SECRET Pages secret via Web Crypto (Workers runtime). The
+// cookie is HttpOnly + Secure + SameSite=Lax. No third-party auth service —
+// the portal owns its sessions, on the Cloudflare stack.
+
+const enc = new TextEncoder();
+const dec = new TextDecoder();
+
+function b64url(bytes) {
+  const s = btoa(String.fromCharCode(...new Uint8Array(bytes)));
+  return s.replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+function b64urlToBytes(str) {
+  let s = str.replace(/-/g, "+").replace(/_/g, "/");
+  while (s.length % 4) s += "=";
+  const bin = atob(s);
+  const out = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i);
+  return out;
+}
+function hmacKey(secret) {
+  return crypto.subtle.importKey("raw", enc.encode(secret), { name: "HMAC", hash: "SHA-256" }, false, ["sign", "verify"]);
+}
+
+const DEFAULT_TTL = 60 * 60 * 24 * 30; // 30 days
+
+// Sign a session. `payload` carries { uid, email, name, role, ... }.
+export async function signSession(payload, secret, ttlSeconds = DEFAULT_TTL) {
+  const now = Math.floor(Date.now() / 1000);
+  const header = b64url(enc.encode(JSON.stringify({ alg: "HS256", typ: "JWT" })));
+  const body = b64url(enc.encode(JSON.stringify({ ...payload, iat: now, exp: now + ttlSeconds })));
+  const key = await hmacKey(secret);
+  const sig = await crypto.subtle.sign("HMAC", key, enc.encode(`${header}.${body}`));
+  return `${header}.${body}.${b64url(sig)}`;
+}
+
+// Verify + decode a session. Returns the payload, or null if invalid/expired.
+export async function verifySession(token, secret) {
+  if (!token || typeof token !== "string" || !secret) return null;
+  const parts = token.split(".");
+  if (parts.length !== 3) return null;
+  const [header, body, sig] = parts;
+  const key = await hmacKey(secret);
+  let ok = false;
+  try {
+    ok = await crypto.subtle.verify("HMAC", key, b64urlToBytes(sig), enc.encode(`${header}.${body}`));
+  } catch {
+    return null;
+  }
+  if (!ok) return null;
+  let payload;
+  try {
+    payload = JSON.parse(dec.decode(b64urlToBytes(body)));
+  } catch {
+    return null;
+  }
+  if (payload.exp && Math.floor(Date.now() / 1000) > payload.exp) return null;
+  return payload;
+}
+
+export function sessionCookie(token, maxAge = DEFAULT_TTL) {
+  return `rca_session=${token}; HttpOnly; Secure; SameSite=Lax; Path=/; Max-Age=${maxAge}`;
+}
+export function clearSessionCookie() {
+  return `rca_session=; HttpOnly; Secure; SameSite=Lax; Path=/; Max-Age=0`;
+}
+export function readCookie(request, name = "rca_session") {
+  const raw = request.headers.get("cookie") || "";
+  const m = raw.match(new RegExp(`(?:^|;\\s*)${name}=([^;]+)`));
+  return m ? m[1] : null;
+}
+
+// Convenience for portal API routes: returns the session payload or null.
+export async function getSession(request, env) {
+  return verifySession(readCookie(request), env && env.SESSION_SECRET);
+}

--- a/shared/auth.test.js
+++ b/shared/auth.test.js
@@ -1,0 +1,55 @@
+import { describe, it, expect } from "vitest";
+import { signSession, verifySession, readCookie, getSession, sessionCookie } from "./auth.js";
+
+const SECRET = "portal_session_secret";
+
+describe("session sign/verify (HS256)", () => {
+  it("round-trips a payload", async () => {
+    const t = await signSession({ uid: 7, email: "a@b.c", role: "student" }, SECRET);
+    const p = await verifySession(t, SECRET);
+    expect(p.uid).toBe(7);
+    expect(p.email).toBe("a@b.c");
+    expect(p.role).toBe("student");
+    expect(p.exp).toBeGreaterThan(p.iat);
+  });
+  it("rejects a tampered token", async () => {
+    const t = await signSession({ uid: 7 }, SECRET);
+    expect(await verifySession(t.slice(0, -1) + (t.endsWith("A") ? "B" : "A"), SECRET)).toBeNull();
+  });
+  it("rejects the wrong secret", async () => {
+    const t = await signSession({ uid: 7 }, SECRET);
+    expect(await verifySession(t, "other")).toBeNull();
+  });
+  it("rejects an expired token", async () => {
+    const t = await signSession({ uid: 7 }, SECRET, -10); // already expired
+    expect(await verifySession(t, SECRET)).toBeNull();
+  });
+  it("rejects junk / missing", async () => {
+    expect(await verifySession("", SECRET)).toBeNull();
+    expect(await verifySession("a.b", SECRET)).toBeNull();
+    expect(await verifySession("a.b.c.d", SECRET)).toBeNull();
+    expect(await verifySession(await signSession({ uid: 1 }, SECRET), "")).toBeNull();
+  });
+});
+
+describe("cookie helpers", () => {
+  it("reads the session cookie from the request", () => {
+    const req = new Request("https://x/portal", { headers: { cookie: "foo=1; rca_session=abc.def.ghi; bar=2" } });
+    expect(readCookie(req)).toBe("abc.def.ghi");
+    expect(readCookie(new Request("https://x/portal"))).toBeNull();
+  });
+  it("sessionCookie is HttpOnly + Secure", () => {
+    const c = sessionCookie("tok");
+    expect(c).toMatch(/HttpOnly/);
+    expect(c).toMatch(/Secure/);
+    expect(c).toMatch(/SameSite=Lax/);
+  });
+  it("getSession returns the payload for a valid cookie, null otherwise", async () => {
+    const tok = await signSession({ uid: 9, role: "instructor" }, SECRET);
+    const req = new Request("https://x/portal", { headers: { cookie: `rca_session=${tok}` } });
+    const p = await getSession(req, { SESSION_SECRET: SECRET });
+    expect(p.uid).toBe(9);
+    expect(p.role).toBe("instructor");
+    expect(await getSession(new Request("https://x/portal"), { SESSION_SECRET: SECRET })).toBeNull();
+  });
+});

--- a/shared/auth.test.js
+++ b/shared/auth.test.js
@@ -12,9 +12,30 @@ describe("session sign/verify (HS256)", () => {
     expect(p.role).toBe("student");
     expect(p.exp).toBeGreaterThan(p.iat);
   });
-  it("rejects a tampered token", async () => {
+  /* Both tampers below change a character the decoder actually reads.
+     The obvious version of this test — flip the LAST character of the
+     signature — is flaky, and was failing about 7% of CI runs: an HMAC-SHA256
+     signature is 32 bytes in 43 base64url characters, so the final character
+     carries only 4 significant bits and A/B/C/D all decode to the same byte.
+     Flipping "A" to "B" there produces a token that is genuinely still valid. */
+  it("rejects a tampered signature", async () => {
     const t = await signSession({ uid: 7 }, SECRET);
-    expect(await verifySession(t.slice(0, -1) + (t.endsWith("A") ? "B" : "A"), SECRET)).toBeNull();
+    const [header, body, sig] = t.split(".");
+    // The first character of the signature is fully significant, so any
+    // substitution here always changes the bytes being verified.
+    const flipped = (sig[0] === "A" ? "B" : "A") + sig.slice(1);
+    expect(await verifySession(`${header}.${body}.${flipped}`, SECRET)).toBeNull();
+  });
+  it("rejects a tampered payload", async () => {
+    const t = await signSession({ uid: 7, role: "student" }, SECRET);
+    const [header, , sig] = t.split(".");
+    // The attack the signature exists to stop: keep a real signature, swap the
+    // claims underneath it.
+    const forged = btoa(JSON.stringify({ uid: 1, role: "admin", exp: 9999999999 }))
+      .replace(/\+/g, "-")
+      .replace(/\//g, "_")
+      .replace(/=+$/, "");
+    expect(await verifySession(`${header}.${forged}.${sig}`, SECRET)).toBeNull();
   });
   it("rejects the wrong secret", async () => {
     const t = await signSession({ uid: 7 }, SECRET);

--- a/shared/courses.js
+++ b/shared/courses.js
@@ -1,0 +1,51 @@
+// Course + lesson reads for the student portal (#136).
+//
+// These take the D1 binding rather than reaching for it, so the API routes stay
+// thin and the query shapes are unit-testable against a fake database.
+
+// The courses a student is actually enrolled in. Unpublished courses are
+// withheld even from an enrolled student: `published` is the academy's switch
+// for "this is ready to be seen", and an enrolment does not override it.
+export async function listEnrolledCourses(db, userId) {
+  const { results } = await db
+    .prepare(
+      "SELECT c.id, c.slug, c.title, c.summary, c.cover_url, " +
+        "(SELECT COUNT(*) FROM lessons l WHERE l.course_id = c.id AND l.published = 1) AS lesson_count " +
+        "FROM enrolments_users eu " +
+        "JOIN courses c ON c.id = eu.course_id " +
+        "WHERE eu.user_id = ?1 AND c.published = 1 " +
+        "ORDER BY c.title ASC"
+    )
+    .bind(userId)
+    .all();
+  return results || [];
+}
+
+// One course with its lessons, but only if this student is enrolled in it.
+//
+// Returns null both for "no such course" and for "not enrolled", deliberately.
+// The caller turns that into a 404 either way, so an outsider probing slugs
+// cannot tell a real course they lack access to from one that does not exist.
+export async function getEnrolledCourse(db, userId, slug) {
+  const course = await db
+    .prepare(
+      "SELECT c.id, c.slug, c.title, c.summary, c.cover_url " +
+        "FROM enrolments_users eu " +
+        "JOIN courses c ON c.id = eu.course_id " +
+        "WHERE eu.user_id = ?1 AND c.slug = ?2 AND c.published = 1"
+    )
+    .bind(userId, slug)
+    .first();
+  if (!course) return null;
+
+  const { results } = await db
+    .prepare(
+      "SELECT id, position, title, notes, video_url, duration_seconds " +
+        "FROM lessons WHERE course_id = ?1 AND published = 1 " +
+        "ORDER BY position ASC"
+    )
+    .bind(course.id)
+    .all();
+
+  return { ...course, lessons: results || [] };
+}

--- a/shared/oidc.js
+++ b/shared/oidc.js
@@ -1,0 +1,180 @@
+// Provider configuration and the PKCE helpers for the student portal's
+// Authorization Code flow (#42). No third-party auth SDK — this is hand-rolled
+// against Google's and Microsoft's OIDC endpoints so the portal owns its
+// sessions on the Cloudflare stack.
+
+export const PROVIDERS = {
+  google: {
+    label: "Google",
+    authorize: "https://accounts.google.com/o/oauth2/v2/auth",
+    token: "https://oauth2.googleapis.com/token",
+    jwks: "https://www.googleapis.com/oauth2/v3/certs",
+    issuers: ["https://accounts.google.com", "accounts.google.com"],
+    scope: "openid email profile",
+    clientId: (env) => env.GOOGLE_CLIENT_ID,
+    clientSecret: (env) => env.GOOGLE_CLIENT_SECRET,
+  },
+  microsoft: {
+    label: "Microsoft",
+    // `common` lets both work and personal accounts sign in; MS_TENANT can pin
+    // it to one directory later without touching this file.
+    authorize: (env) =>
+      `https://login.microsoftonline.com/${env.MS_TENANT || "common"}/oauth2/v2.0/authorize`,
+    token: (env) =>
+      `https://login.microsoftonline.com/${env.MS_TENANT || "common"}/oauth2/v2.0/token`,
+    jwks: (env) =>
+      `https://login.microsoftonline.com/${env.MS_TENANT || "common"}/discovery/v2.0/keys`,
+    // Microsoft's issuer carries the signing tenant's id, which is not known
+    // ahead of time under `common`, so it is checked by shape.
+    issuers: null,
+    scope: "openid email profile",
+    clientId: (env) => env.MS_CLIENT_ID,
+    clientSecret: (env) => env.MS_CLIENT_SECRET,
+  },
+};
+
+const val = (v, env) => (typeof v === "function" ? v(env) : v);
+
+export function providerConfig(name, env) {
+  const p = PROVIDERS[name];
+  if (!p) return null;
+  return {
+    name,
+    label: p.label,
+    authorize: val(p.authorize, env),
+    token: val(p.token, env),
+    jwks: val(p.jwks, env),
+    issuers: p.issuers,
+    scope: p.scope,
+    clientId: p.clientId(env),
+    clientSecret: p.clientSecret(env),
+  };
+}
+
+/**
+ * Whether a provider can actually be used right now.
+ *
+ * The portal is inert until configured (#42): with no client id and secret the
+ * login screen says "coming soon" rather than showing a button that leads to a
+ * provider error page. This is the single check behind that.
+ */
+export function isConfigured(name, env) {
+  const c = providerConfig(name, env);
+  return Boolean(c && c.clientId && c.clientSecret && env && env.SESSION_SECRET);
+}
+
+export function configuredProviders(env) {
+  return Object.keys(PROVIDERS).filter((n) => isConfigured(n, env));
+}
+
+// --- PKCE ------------------------------------------------------------------
+
+function b64url(bytes) {
+  const s = btoa(String.fromCharCode(...new Uint8Array(bytes)));
+  return s.replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+export function randomString(bytes = 32) {
+  return b64url(crypto.getRandomValues(new Uint8Array(bytes)));
+}
+
+export async function codeChallenge(verifier) {
+  const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(verifier));
+  return b64url(digest);
+}
+
+/**
+ * Where the provider sends the browser back to.
+ *
+ * Always this site's own origin, never the `rca://` deep link: a custom scheme
+ * cannot be a registered OAuth redirect for a confidential client, and the
+ * token exchange has to happen server-side anyway. The native shell is handed
+ * back at the end of the callback instead — see functions/auth/[provider]/callback.
+ */
+export function redirectUri(request, provider) {
+  return `${new URL(request.url).origin}/auth/${provider}/callback`;
+}
+
+// --- ID token verification -------------------------------------------------
+
+function parseJwt(token) {
+  const parts = String(token || "").split(".");
+  if (parts.length !== 3) return null;
+  const pad = (s) => s.replace(/-/g, "+").replace(/_/g, "/") + "===".slice((s.length + 3) % 4);
+  try {
+    return {
+      header: JSON.parse(atob(pad(parts[0]))),
+      payload: JSON.parse(atob(pad(parts[1]))),
+      signed: `${parts[0]}.${parts[1]}`,
+      signature: parts[2],
+    };
+  } catch {
+    return null;
+  }
+}
+
+function bytesFromB64url(s) {
+  const p = s.replace(/-/g, "+").replace(/_/g, "/") + "===".slice((s.length + 3) % 4);
+  const bin = atob(p);
+  const out = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i);
+  return out;
+}
+
+/**
+ * Verify an ID token against the provider's JWKS.
+ *
+ * The signature check is the point: without it, anyone who can reach the
+ * callback could post a self-made token and be issued a session. Fails closed —
+ * every error path returns null rather than a partially trusted payload.
+ */
+export async function verifyIdToken(idToken, cfg, fetchImpl = fetch) {
+  const jwt = parseJwt(idToken);
+  if (!jwt || jwt.header.alg !== "RS256" || !jwt.header.kid) return null;
+
+  let keys;
+  try {
+    const res = await fetchImpl(cfg.jwks);
+    if (!res.ok) return null;
+    keys = (await res.json()).keys;
+  } catch {
+    return null;
+  }
+  const jwk = (keys || []).find((k) => k.kid === jwt.header.kid);
+  if (!jwk) return null;
+
+  let ok = false;
+  try {
+    const key = await crypto.subtle.importKey(
+      "jwk",
+      { ...jwk, alg: "RS256", ext: true },
+      { name: "RSASSA-PKCS1-v1_5", hash: "SHA-256" },
+      false,
+      ["verify"],
+    );
+    ok = await crypto.subtle.verify(
+      "RSASSA-PKCS1-v1_5",
+      key,
+      bytesFromB64url(jwt.signature),
+      new TextEncoder().encode(jwt.signed),
+    );
+  } catch {
+    return null;
+  }
+  if (!ok) return null;
+
+  const p = jwt.payload;
+  const now = Math.floor(Date.now() / 1000);
+  if (!p.sub) return null;
+  if (p.exp && now > p.exp) return null;
+  // 60s of slack for clock drift between us and the provider.
+  if (p.nbf && now + 60 < p.nbf) return null;
+
+  const aud = Array.isArray(p.aud) ? p.aud : [p.aud];
+  if (!aud.includes(cfg.clientId)) return null;
+
+  if (cfg.issuers && !cfg.issuers.includes(p.iss)) return null;
+  if (!cfg.issuers && !/^https:\/\/login\.microsoftonline\.com\//.test(String(p.iss))) return null;
+
+  return p;
+}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,5 @@
 import { createContext, useContext, useState } from 'react'
-import { Routes, Route, Navigate } from 'react-router-dom'
+import { Routes, Route, Navigate, useLocation } from 'react-router-dom'
 import Navbar from "./components/molecules/Navbar/Navbar"
 import Footer from "./components/organism/Footer/FooterComponent"
 import Banner from './components/organism/Banner/Banner'
@@ -13,6 +13,9 @@ import FAQ from "./components/Pages/FAQ";
 import Blog from "./components/Pages/Blog";
 import BlogPost from "./components/Pages/BlogPost";
 import ScrollToTop from "./components/ScrollToTop";
+import PortalRoute from "./components/portal/PortalRoute";
+import PortalLogin from "./components/portal/PortalLogin";
+import PortalHome from "./components/portal/PortalHome";
 import Modal from 'react-modal';
 import EnquiryForm from './components/forms/Enquiry Form/EnquiryForm';
 import EnrollForm from './components/forms/EnrollForm/EnrollForm';
@@ -23,6 +26,13 @@ import { ToastContainer, toast } from 'react-toastify';
  Modal.setAppElement('#root');
 
 function App() {
+  // The portal is an app surface, not a page of the marketing site (#110, #111).
+  // The navbar, the floating WhatsApp/call buttons and the site footer all
+  // render outside <Routes>, so without this they sit on top of the student
+  // home — and inside the Capacitor shell (#109) a "call us" bubble over a
+  // logged-in student's timetable makes no sense at all.
+  const isPortal = useLocation().pathname.startsWith("/portal");
+
   const [modalIsOpen, setIsOpen] = useState(false);
   const [enrollCourse, setEnrollCourse] = useState(null);
   // Which course the enquiry was opened from, so the form can say so and the
@@ -71,7 +81,7 @@ function App() {
 
   return (
     <AuthContext.Provider className="app" value={{ openModal, closeModal, openEnroll, closeEnroll, notify, enquiryCourse }}>
-      <Navbar />
+      {!isPortal && <Navbar />}
       <ToastContainer className={"toast"} autoClose={2500}/>
       <Modal
         isOpen={modalIsOpen}
@@ -101,10 +111,21 @@ function App() {
         <Route path="/faq" element={<FAQ />} />
         <Route path="/blog" element={<Blog />} />
         <Route path="/blog/:slug" element={<BlogPost />} />
+        {/* Student portal (#110, #111). The login screen is public; everything
+            else under /portal goes through the guard, which reads /auth/me. */}
+        <Route path="/portal/login" element={<PortalLogin />} />
+        <Route
+          path="/portal"
+          element={
+            <PortalRoute>
+              {({ user, logout }) => <PortalHome user={user} logout={logout} />}
+            </PortalRoute>
+          }
+        />
         <Route path="*" element={<Navigate to="/" replace />} />
       </Routes>
-      <FloatingIcons/>
-      <Footer />
+      {!isPortal && <FloatingIcons/>}
+      {!isPortal && <Footer />}
     </AuthContext.Provider>
   );
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -16,6 +16,7 @@ import ScrollToTop from "./components/ScrollToTop";
 import PortalRoute from "./components/portal/PortalRoute";
 import PortalLogin from "./components/portal/PortalLogin";
 import PortalHome from "./components/portal/PortalHome";
+import PortalCourse from "./components/portal/PortalCourse";
 import Modal from 'react-modal';
 import EnquiryForm from './components/forms/Enquiry Form/EnquiryForm';
 import EnrollForm from './components/forms/EnrollForm/EnrollForm';
@@ -119,6 +120,16 @@ function App() {
           element={
             <PortalRoute>
               {({ user, logout }) => <PortalHome user={user} logout={logout} />}
+            </PortalRoute>
+          }
+        />
+        {/* One course and its lessons (#137). Behind the same guard, so a
+            direct link from outside lands on login and returns here after. */}
+        <Route
+          path="/portal/courses/:slug"
+          element={
+            <PortalRoute>
+              <PortalCourse />
             </PortalRoute>
           }
         />

--- a/src/components/portal/CourseList.jsx
+++ b/src/components/portal/CourseList.jsx
@@ -1,0 +1,84 @@
+import PropTypes from "prop-types";
+import { Link } from "react-router-dom";
+import "./Portal.css";
+
+/**
+ * The "My courses" section on /portal (#137).
+ *
+ * Text only. A course cover is a photograph on a metered connection, so the
+ * list renders from the one request it already made and never blocks on an
+ * image; the tile carries the title, a one-line summary and a lesson count.
+ */
+function CourseList({ status, courses, cached, reload }) {
+  if (status === "loading") {
+    return (
+      <div className="portal-skeleton" aria-busy="true">
+        <div className="sk sk-card" />
+        <div className="sk sk-card" />
+      </div>
+    );
+  }
+
+  if (status === "offline" || status === "error") {
+    return (
+      <div className="portal-card portal-card--quiet" role="status">
+        <p className="portal-card-title">
+          {status === "offline" ? "You are offline" : "We could not load your courses"}
+        </p>
+        <p className="portal-card-sub">
+          {status === "offline"
+            ? "Your courses will appear here once you are back on a connection."
+            : "This is on our side, not yours. Please try again in a moment."}
+        </p>
+        <button type="button" className="portal-btn portal-btn--ghost" onClick={reload}>
+          Try again
+        </button>
+      </div>
+    );
+  }
+
+  if (!courses.length) {
+    // Not a dead end: a student with no enrolment is told where to go next.
+    return (
+      <div className="portal-card portal-card--quiet">
+        <p className="portal-card-title">No courses yet</p>
+        <p className="portal-card-sub">
+          Once you enrol, your lessons and notes appear here. Browse what the academy runs on the{" "}
+          <a href="/">main site</a>.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <>
+      {cached && (
+        <p className="portal-cached" role="status">
+          Showing your saved copy.
+        </p>
+      )}
+      <ul className="portal-list">
+        {courses.map((c) => (
+          <li key={c.id}>
+            <Link className="portal-course" to={`/portal/courses/${c.slug}`}>
+              <span className="portal-course-title">{c.title}</span>
+              {c.summary && <span className="portal-course-sub">{c.summary}</span>}
+              <span className="portal-course-meta">
+                {c.lesson_count === 1 ? "1 lesson" : `${c.lesson_count || 0} lessons`}
+              </span>
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </>
+  );
+}
+
+CourseList.propTypes = {
+  status: PropTypes.string.isRequired,
+  courses: PropTypes.array.isRequired,
+  cached: PropTypes.bool,
+  reload: PropTypes.func.isRequired,
+};
+
+export default CourseList;

--- a/src/components/portal/Portal.css
+++ b/src/components/portal/Portal.css
@@ -363,3 +363,154 @@
     .portal-tabs { display: none; }
     .portal-home { padding-bottom: var(--rca-space-8); }
 }
+
+/* Courses + lessons (#137).
+
+   Same tokens as the rest of the portal. Every tappable row is at least 48px
+   tall, because these are read on a phone, often one-handed, often outdoors. */
+
+.portal-cached
+{
+    margin: 0 0 var(--rca-space-3);
+    font-size: var(--rca-fs-caption);
+    color: var(--rca-ink-soft);
+}
+
+.portal-list
+{
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: grid;
+    gap: var(--rca-space-3);
+}
+
+.portal-course
+{
+    display: grid;
+    gap: var(--rca-space-2);
+    padding: var(--rca-space-5);
+    min-height: 48px;
+    border: 1px solid var(--rca-border);
+    border-radius: var(--rca-radius-lg, 12px);
+    background-color: var(--rca-surface);
+    text-decoration: none;
+    color: inherit;
+}
+
+.portal-course:hover { border-color: var(--rca-border-strong); }
+.portal-course:focus-visible { outline: var(--rca-focus-ring); outline-offset: 2px; }
+
+.portal-course-title
+{
+    font-size: var(--rca-fs-body);
+    font-weight: var(--rca-fw-semibold);
+    color: var(--rca-navy);
+}
+
+.portal-course-sub,
+.portal-course-summary
+{
+    font-size: var(--rca-fs-small);
+    color: var(--rca-ink-soft);
+}
+
+.portal-course-summary { margin: 0 0 var(--rca-space-5); }
+
+.portal-course-meta
+{
+    font-size: var(--rca-fs-caption);
+    color: var(--rca-ink-soft);
+}
+
+.portal-back
+{
+    display: inline-flex;
+    align-items: center;
+    gap: var(--rca-space-2);
+    margin-bottom: var(--rca-space-4);
+    min-height: 44px;
+    font-size: var(--rca-fs-small);
+    color: var(--rca-ink-soft);
+    text-decoration: none;
+}
+
+.portal-back:hover { color: var(--rca-navy); }
+.portal-back:focus-visible { outline: var(--rca-focus-ring); outline-offset: 2px; }
+
+.portal-lessons
+{
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: grid;
+    gap: var(--rca-space-2);
+    counter-reset: none;
+}
+
+.portal-lesson
+{
+    border: 1px solid var(--rca-border);
+    border-radius: var(--rca-radius-md);
+    background-color: var(--rca-surface);
+    overflow: hidden;
+}
+
+.portal-lesson-head
+{
+    display: grid;
+    grid-template-columns: auto 1fr auto;
+    align-items: center;
+    gap: var(--rca-space-3);
+    width: 100%;
+    min-height: 48px;
+    padding: var(--rca-space-4) var(--rca-space-5);
+    border: 0;
+    background: none;
+    font: inherit;
+    text-align: left;
+    color: inherit;
+    cursor: pointer;
+}
+
+.portal-lesson-head:focus-visible { outline: var(--rca-focus-ring); outline-offset: -2px; }
+
+.portal-lesson-no
+{
+    display: grid;
+    place-items: center;
+    width: 24px;
+    height: 24px;
+    border-radius: 50%;
+    background-color: var(--rca-surface-subtle);
+    font-size: var(--rca-fs-caption);
+    color: var(--rca-ink-soft);
+    /* Tabular figures so lesson 9 and lesson 10 do not shift the title. */
+    font-variant-numeric: tabular-nums;
+}
+
+.portal-lesson-title { font-size: var(--rca-fs-small); font-weight: var(--rca-fw-semibold); }
+
+.portal-lesson-meta
+{
+    font-size: var(--rca-fs-caption);
+    color: var(--rca-ink-soft);
+    font-variant-numeric: tabular-nums;
+}
+
+.portal-lesson-body
+{
+    padding: 0 var(--rca-space-5) var(--rca-space-5);
+    border-top: 1px solid var(--rca-border);
+    padding-top: var(--rca-space-4);
+}
+
+.portal-lesson-notes
+{
+    margin: 0 0 var(--rca-space-3);
+    font-size: var(--rca-fs-small);
+    line-height: 1.6;
+    /* Notes are authored as markdown but rendered as text for now: no parser
+       shipped to the client, and no untrusted HTML either. */
+    white-space: pre-wrap;
+}

--- a/src/components/portal/Portal.css
+++ b/src/components/portal/Portal.css
@@ -1,0 +1,365 @@
+/* Student portal — login, home shell and states (#110, #111).
+
+   Reuses the site's tokens; no new design language. Mobile-first, because the
+   portal is for students on a phone on a metered rural connection (#41), and
+   the same markup runs inside the Capacitor shell (#109). */
+
+.portal
+{
+    --portal-max: 560px;
+    min-height: 100vh;
+    /* App.jsx hides the marketing navbar on /portal, so there is nothing to
+       clear — and a phone's status bar is handled by the safe-area inset
+       rather than a hard-coded offset, so this is right inside the Capacitor
+       shell too (#109). */
+    padding: calc(var(--rca-space-6) + env(safe-area-inset-top, 0px))
+             var(--rca-gutter-mobile)
+             var(--rca-space-8);
+    background-color: var(--rca-surface-subtle);
+    font-family: var(--rca-font);
+    color: var(--rca-ink);
+    box-sizing: border-box;
+}
+
+.portal > *
+{
+    max-width: var(--portal-max);
+    margin-left: auto;
+    margin-right: auto;
+}
+
+.portal h1
+{
+    margin: 0;
+    font-size: var(--rca-fs-h3);
+    line-height: 1.2;
+    color: var(--rca-navy);
+}
+
+.portal h2
+{
+    margin: 0 0 var(--rca-space-3);
+    font-size: var(--rca-fs-lead);
+    color: var(--rca-navy);
+}
+
+.portal-eyebrow
+{
+    margin: 0 0 var(--rca-space-2);
+    font-size: var(--rca-fs-caption);
+    font-weight: var(--rca-fw-semibold);
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--rca-blue);
+}
+
+/* Visible to a screen reader, not on screen. */
+.portal-sr
+{
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    overflow: hidden;
+    clip: rect(0 0 0 0);
+    white-space: nowrap;
+}
+
+/* --- buttons -------------------------------------------------------------- */
+
+.portal-btn
+{
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-height: var(--rca-control-h-mobile);
+    padding: 0 var(--rca-space-5);
+    border: 1px solid transparent;
+    border-radius: var(--rca-radius-md);
+    background-color: var(--rca-navy);
+    color: var(--rca-ink-invert);
+    font-family: inherit;
+    font-size: var(--rca-fs-body);
+    font-weight: var(--rca-fw-semibold);
+    cursor: pointer;
+    transition: background-color var(--rca-transition);
+}
+
+.portal-btn:hover { background-color: var(--rca-navy-hover); }
+.portal-btn:active { background-color: var(--rca-navy-pressed); }
+.portal-btn:focus-visible { outline: none; box-shadow: var(--rca-focus-ring); }
+
+.portal-btn--ghost
+{
+    margin-top: var(--rca-space-4);
+    background-color: transparent;
+    border-color: var(--rca-border);
+    color: var(--rca-navy);
+}
+
+.portal-btn--ghost:hover { background-color: var(--rca-surface-subtle); }
+.portal-btn--ghost:active { background-color: var(--rca-border); }
+
+/* --- login ---------------------------------------------------------------- */
+
+.portal-login { display: flex; align-items: flex-start; justify-content: center; }
+
+.portal-login-card
+{
+    width: 100%;
+    max-width: 420px;
+    padding: var(--rca-space-6);
+    border: 1px solid var(--rca-border);
+    border-radius: var(--rca-radius-lg, 12px);
+    background-color: var(--rca-surface);
+}
+
+.portal-login-sub
+{
+    margin: var(--rca-space-3) 0 var(--rca-space-6);
+    font-size: var(--rca-fs-body);
+    line-height: 1.6;
+    color: var(--rca-ink-soft);
+}
+
+.portal-provider
+{
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: var(--rca-space-3);
+    /* 48px, not 44 — this is the one control on the screen. */
+    min-height: var(--rca-control-h);
+    margin-bottom: var(--rca-space-3);
+    padding: 0 var(--rca-space-4);
+    border: 1px solid var(--rca-border);
+    border-radius: var(--rca-radius-md);
+    background-color: var(--rca-surface);
+    color: var(--rca-ink);
+    font-size: var(--rca-fs-body);
+    font-weight: var(--rca-fw-semibold);
+    text-decoration: none;
+    transition: background-color var(--rca-transition), border-color var(--rca-transition);
+}
+
+.portal-provider:hover
+{
+    background-color: var(--rca-surface-subtle);
+    border-color: var(--rca-border-strong);
+}
+
+.portal-provider:focus-visible { outline: none; box-shadow: var(--rca-focus-ring); }
+
+.portal-provider-mark { width: 20px; height: 20px; flex-shrink: 0; }
+
+.portal-login-foot
+{
+    margin: var(--rca-space-5) 0 0;
+    font-size: var(--rca-fs-small);
+    color: var(--rca-ink-soft);
+}
+
+.portal-login-foot a { color: var(--rca-blue); font-weight: var(--rca-fw-semibold); }
+
+/* --- messages ------------------------------------------------------------- */
+
+.portal-alert
+{
+    margin: 0 0 var(--rca-space-5);
+    padding: var(--rca-space-3) var(--rca-space-4);
+    border-radius: var(--rca-radius-md);
+    background-color: var(--rca-danger-bg);
+    color: var(--rca-danger);
+    font-size: var(--rca-fs-small);
+    line-height: 1.5;
+}
+
+.portal-soon
+{
+    margin-bottom: var(--rca-space-5);
+    padding: var(--rca-space-4);
+    border: 1px dashed var(--rca-border-strong);
+    border-radius: var(--rca-radius-md);
+    background-color: var(--rca-surface-subtle);
+    font-size: var(--rca-fs-small);
+    line-height: 1.6;
+    color: var(--rca-ink-soft);
+}
+
+.portal-soon p { margin: 0; }
+.portal-soon-title
+{
+    margin-bottom: var(--rca-space-2) !important;
+    font-weight: var(--rca-fw-semibold);
+    color: var(--rca-navy);
+}
+
+.portal-offline
+{
+    margin: 0 auto var(--rca-space-5);
+    padding: var(--rca-space-3) var(--rca-space-4);
+    border-radius: var(--rca-radius-md);
+    background-color: var(--rca-navy);
+    color: var(--rca-ink-invert);
+    font-size: var(--rca-fs-small);
+    text-align: center;
+}
+
+/* --- generic state screen ------------------------------------------------- */
+
+.portal-state { display: flex; align-items: center; justify-content: center; }
+
+.portal-state-card
+{
+    width: 100%;
+    max-width: 420px;
+    padding: var(--rca-space-6);
+    border: 1px solid var(--rca-border);
+    border-radius: var(--rca-radius-lg, 12px);
+    background-color: var(--rca-surface);
+    text-align: center;
+}
+
+.portal-state-card p
+{
+    margin: var(--rca-space-3) 0 var(--rca-space-5);
+    color: var(--rca-ink-soft);
+    line-height: 1.6;
+}
+
+/* --- home ----------------------------------------------------------------- */
+
+/* Room for the tab bar, plus the phone's home indicator. */
+.portal-home { padding-bottom: calc(72px + env(safe-area-inset-bottom, 0px)); }
+
+.portal-top
+{
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--rca-space-4);
+    margin-bottom: var(--rca-space-6);
+}
+
+.portal-avatar
+{
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: var(--rca-control-h);
+    height: var(--rca-control-h);
+    flex-shrink: 0;
+    border-radius: 50%;
+    background-color: var(--rca-navy);
+    color: var(--rca-ink-invert);
+    font-size: var(--rca-fs-lead);
+    font-weight: var(--rca-fw-semibold);
+}
+
+.portal-section { margin-bottom: var(--rca-space-6); }
+
+.portal-card
+{
+    padding: var(--rca-space-5);
+    border: 1px solid var(--rca-border);
+    border-radius: var(--rca-radius-lg, 12px);
+    background-color: var(--rca-surface);
+}
+
+.portal-card--quiet { border-style: dashed; background-color: transparent; }
+
+.portal-card-title
+{
+    margin: 0;
+    font-size: var(--rca-fs-body);
+    font-weight: var(--rca-fw-semibold);
+    color: var(--rca-navy);
+}
+
+.portal-card-sub
+{
+    margin: var(--rca-space-2) 0 0;
+    font-size: var(--rca-fs-small);
+    line-height: 1.6;
+    color: var(--rca-ink-soft);
+    overflow-wrap: anywhere;
+}
+
+/* --- tab bar -------------------------------------------------------------- */
+
+.portal-tabs
+{
+    position: fixed;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    /* Navbar.css styles the bare element selector `nav` with `position: fixed;
+       top: 0`, and this bar is a <nav>. Without an explicit `top: auto` it
+       inherits that and pins itself to the top of the screen. #107 scopes
+       those selectors to .site-nav; this stays as a guard either way. */
+    top: auto;
+    /* Above the floating WhatsApp/call buttons, which sit at 999. */
+    z-index: 1000;
+    display: flex;
+    max-width: none;
+    padding-bottom: env(safe-area-inset-bottom, 0px);
+    border-top: 1px solid var(--rca-border);
+    background-color: var(--rca-surface);
+}
+
+.portal-tab
+{
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 2px;
+    min-height: 56px;
+    font-size: var(--rca-fs-caption);
+    color: var(--rca-ink-soft);
+}
+
+.portal-tab--active { color: var(--rca-navy); font-weight: var(--rca-fw-semibold); }
+.portal-tab[aria-disabled="true"] { color: var(--rca-disabled-ink); }
+
+/* --- skeletons ------------------------------------------------------------ */
+
+.portal-skeleton { display: flex; flex-direction: column; gap: var(--rca-space-4); }
+
+.sk
+{
+    border-radius: var(--rca-radius-md);
+    background-color: var(--rca-border);
+    /* Deliberately slow and low-contrast: a fast shimmer on a slow connection
+       reads as a stuck animation. */
+    animation: portal-pulse 1.6s ease-in-out infinite;
+}
+
+.sk-line { height: 14px; }
+.sk-line--sm { width: 35%; }
+.sk-line--lg { width: 65%; height: 28px; }
+.sk-card { height: 104px; }
+
+@keyframes portal-pulse
+{
+    0%, 100% { opacity: 1; }
+    50% { opacity: 0.55; }
+}
+
+@media (prefers-reduced-motion: reduce)
+{
+    .sk { animation: none; }
+}
+
+/* --- wider screens -------------------------------------------------------- */
+
+@media (min-width: 768px)
+{
+    .portal { padding-left: var(--rca-gutter); padding-right: var(--rca-gutter); }
+
+    /* The tab bar is phone chrome. With room for it, the account section on
+       the page is the way out, and a bar pinned to the bottom of a laptop
+       window is just in the way. */
+    .portal-tabs { display: none; }
+    .portal-home { padding-bottom: var(--rca-space-8); }
+}

--- a/src/components/portal/PortalCourse.jsx
+++ b/src/components/portal/PortalCourse.jsx
@@ -1,0 +1,135 @@
+import { useEffect, useState } from "react";
+import { Link, useParams } from "react-router-dom";
+import ArrowBackRoundedIcon from "@mui/icons-material/ArrowBackRounded";
+import PortalSkeleton from "./PortalSkeleton";
+import { formatDuration } from "./coursesCache";
+import "./Portal.css";
+
+/**
+ * /portal/courses/:slug — one course and its lessons (#137).
+ *
+ * Notes are the readable half of a lesson and cost a few kilobytes; video is
+ * the expensive half and is not this ticket. Each lesson expands in place
+ * rather than pushing the student to a per-lesson route, so reading a course
+ * end to end on a phone is one screen and no further requests.
+ */
+function PortalCourse() {
+  const { slug } = useParams();
+  const [state, setState] = useState({ status: "loading", course: null });
+  const [openId, setOpenId] = useState(null);
+
+  useEffect(() => {
+    let live = true;
+    (async () => {
+      try {
+        const res = await fetch(`/api/portal/courses/${encodeURIComponent(slug)}`, {
+          credentials: "same-origin",
+        });
+        if (!live) return;
+        if (res.status === 404) return setState({ status: "not_found", course: null });
+        if (!res.ok) return setState({ status: "error", course: null });
+        const body = await res.json().catch(() => ({}));
+        setState({ status: "ready", course: body.course || null });
+      } catch {
+        // Not cached: a course body is large and a student reads it once. The
+        // list on /portal is what has to survive offline, not every lesson.
+        if (live) setState({ status: "offline", course: null });
+      }
+    })();
+    return () => {
+      live = false;
+    };
+  }, [slug]);
+
+  if (state.status === "loading") return <PortalSkeleton />;
+
+  if (state.status !== "ready" || !state.course) {
+    const copy = {
+      // 404 is also the answer for a course this student is not enrolled in,
+      // so the wording covers both without guessing which it was.
+      not_found: ["Course not found", "This course does not exist, or you are not enrolled in it."],
+      offline: ["You are offline", "Open this course again once you have a connection."],
+      error: ["We could not load this course", "This is on our side. Please try again shortly."],
+    }[state.status] || ["Something went wrong", "Please try again."];
+
+    return (
+      <main className="portal portal-state">
+        <div className="portal-state-card" role="status">
+          <h1>{copy[0]}</h1>
+          <p>{copy[1]}</p>
+          <Link className="portal-btn" to="/portal">
+            Back to my courses
+          </Link>
+        </div>
+      </main>
+    );
+  }
+
+  const { course } = state;
+  const lessons = course.lessons || [];
+
+  return (
+    <main className="portal portal-course-page">
+      <Link className="portal-back" to="/portal">
+        <ArrowBackRoundedIcon fontSize="small" />
+        My courses
+      </Link>
+
+      <header className="portal-top">
+        <div>
+          <p className="portal-eyebrow">Course</p>
+          <h1>{course.title}</h1>
+        </div>
+      </header>
+      {course.summary && <p className="portal-course-summary">{course.summary}</p>}
+
+      <section className="portal-section" aria-labelledby="lessons">
+        <h2 id="lessons">{lessons.length === 1 ? "1 lesson" : `${lessons.length} lessons`}</h2>
+
+        {!lessons.length && (
+          <div className="portal-card portal-card--quiet">
+            <p className="portal-card-title">No lessons published yet</p>
+            <p className="portal-card-sub">Your trainer adds them as the batch progresses.</p>
+          </div>
+        )}
+
+        <ol className="portal-lessons">
+          {lessons.map((l) => {
+            const open = openId === l.id;
+            return (
+              <li key={l.id} className="portal-lesson">
+                <button
+                  type="button"
+                  className="portal-lesson-head"
+                  aria-expanded={open}
+                  onClick={() => setOpenId(open ? null : l.id)}
+                >
+                  <span className="portal-lesson-no" aria-hidden="true">
+                    {l.position}
+                  </span>
+                  <span className="portal-lesson-title">{l.title}</span>
+                  <span className="portal-lesson-meta">{formatDuration(l.duration_seconds)}</span>
+                </button>
+                {open && (
+                  <div className="portal-lesson-body">
+                    {l.notes ? (
+                      <p className="portal-lesson-notes">{l.notes}</p>
+                    ) : (
+                      <p className="portal-card-sub">No notes for this lesson yet.</p>
+                    )}
+                    {/* Video is deliberately absent until the storage decision
+                        on #43 is made. A dead play button would be worse than
+                        an honest line of text. */}
+                    <p className="portal-card-sub">Video for this lesson is coming soon.</p>
+                  </div>
+                )}
+              </li>
+            );
+          })}
+        </ol>
+      </section>
+    </main>
+  );
+}
+
+export default PortalCourse;

--- a/src/components/portal/PortalHome.jsx
+++ b/src/components/portal/PortalHome.jsx
@@ -1,0 +1,132 @@
+import PropTypes from "prop-types";
+import { useEffect, useState } from "react";
+import HomeRoundedIcon from "@mui/icons-material/HomeRounded";
+import MenuBookRoundedIcon from "@mui/icons-material/MenuBookRounded";
+import PersonRoundedIcon from "@mui/icons-material/PersonRounded";
+import "./Portal.css";
+
+/**
+ * /portal — the first screen a signed-in student sees (#111).
+ *
+ * Shell only; real course data is Phase 2 (#43). Everything here is data-light
+ * on purpose: no photographs, no icon font, three inline SVGs for the chrome,
+ * and nothing that needs a second request to render.
+ */
+
+function greeting(now = new Date()) {
+  const h = now.getHours();
+  if (h < 12) return "Good morning";
+  if (h < 17) return "Good afternoon";
+  return "Good evening";
+}
+
+/**
+ * The offline banner (#111).
+ *
+ * `navigator.onLine` is only ever trustworthy when it says *false*, so this is
+ * used to show the banner and never to hide an error. The cached shell still
+ * renders underneath — the ticket's requirement is a clear banner rather than
+ * a blank page.
+ */
+function useOnline() {
+  const [online, setOnline] = useState(
+    typeof navigator === "undefined" ? true : navigator.onLine !== false,
+  );
+  useEffect(() => {
+    const up = () => setOnline(true);
+    const down = () => setOnline(false);
+    window.addEventListener("online", up);
+    window.addEventListener("offline", down);
+    return () => {
+      window.removeEventListener("online", up);
+      window.removeEventListener("offline", down);
+    };
+  }, []);
+  return online;
+}
+
+function PortalHome({ user, logout }) {
+  const online = useOnline();
+  const firstName = String(user?.name || "").split(/\s+/)[0] || "there";
+
+  return (
+    <div className="portal portal-home">
+      {!online && (
+        <p className="portal-offline" role="status">
+          You are offline. This is the last version we saved.
+        </p>
+      )}
+
+      <header className="portal-top">
+        <div>
+          <p className="portal-eyebrow">{greeting()}</p>
+          <h1>{firstName}</h1>
+        </div>
+        {/* Initials rather than the provider's avatar URL: one less request,
+            and it renders identically with the network off. */}
+        <span className="portal-avatar" aria-hidden="true">
+          {(firstName[0] || "?").toUpperCase()}
+        </span>
+      </header>
+
+      <section className="portal-section" aria-labelledby="next-class">
+        <h2 id="next-class">Next class</h2>
+        <div className="portal-card portal-card--quiet">
+          <p className="portal-card-title">No class scheduled yet</p>
+          <p className="portal-card-sub">
+            Your batch timetable appears here once your course is assigned.
+          </p>
+        </div>
+      </section>
+
+      <section className="portal-section" aria-labelledby="my-courses">
+        <h2 id="my-courses">My courses</h2>
+        <div className="portal-card portal-card--quiet">
+          <p className="portal-card-title">Nothing here yet</p>
+          <p className="portal-card-sub">
+            Lessons you can stream or download arrive in the next release.
+          </p>
+        </div>
+      </section>
+
+      <section className="portal-section" aria-labelledby="account">
+        <h2 id="account">Account</h2>
+        <div className="portal-card">
+          <p className="portal-card-title">{user?.name || "Student"}</p>
+          {user?.email && <p className="portal-card-sub">{user.email}</p>}
+          <button type="button" className="portal-btn portal-btn--ghost" onClick={logout}>
+            Log out
+          </button>
+        </div>
+      </section>
+
+      {/* App chrome sized for a phone. One item per destination that exists;
+          the other two are marked as not yet available rather than being dead
+          controls that do nothing when tapped. */}
+      <nav className="portal-tabs" aria-label="Portal">
+        <span className="portal-tab portal-tab--active" aria-current="page">
+          <HomeRoundedIcon fontSize="small" />
+          Home
+        </span>
+        <span className="portal-tab" aria-disabled="true">
+          <MenuBookRoundedIcon fontSize="small" />
+          Courses
+        </span>
+        <span className="portal-tab" aria-disabled="true">
+          <PersonRoundedIcon fontSize="small" />
+          Profile
+        </span>
+      </nav>
+    </div>
+  );
+}
+
+PortalHome.propTypes = {
+  user: PropTypes.shape({
+    name: PropTypes.string,
+    email: PropTypes.string,
+  }),
+  logout: PropTypes.func.isRequired,
+};
+
+export default PortalHome;

--- a/src/components/portal/PortalHome.jsx
+++ b/src/components/portal/PortalHome.jsx
@@ -3,14 +3,16 @@ import { useEffect, useState } from "react";
 import HomeRoundedIcon from "@mui/icons-material/HomeRounded";
 import MenuBookRoundedIcon from "@mui/icons-material/MenuBookRounded";
 import PersonRoundedIcon from "@mui/icons-material/PersonRounded";
+import CourseList from "./CourseList";
+import { useCourses } from "./useCourses";
 import "./Portal.css";
 
 /**
  * /portal — the first screen a signed-in student sees (#111).
  *
- * Shell only; real course data is Phase 2 (#43). Everything here is data-light
- * on purpose: no photographs, no icon font, three inline SVGs for the chrome,
- * and nothing that needs a second request to render.
+ * The chrome is data-light on purpose: no photographs, no icon font, and
+ * nothing that needs a second request to render. "My courses" is the one
+ * section that fetches, and it paints its saved copy first (#137).
  */
 
 function greeting(now = new Date()) {
@@ -47,6 +49,7 @@ function useOnline() {
 
 function PortalHome({ user, logout }) {
   const online = useOnline();
+  const { status, courses, cached, reload } = useCourses(user?.id);
   const firstName = String(user?.name || "").split(/\s+/)[0] || "there";
 
   return (
@@ -81,12 +84,7 @@ function PortalHome({ user, logout }) {
 
       <section className="portal-section" aria-labelledby="my-courses">
         <h2 id="my-courses">My courses</h2>
-        <div className="portal-card portal-card--quiet">
-          <p className="portal-card-title">Nothing here yet</p>
-          <p className="portal-card-sub">
-            Lessons you can stream or download arrive in the next release.
-          </p>
-        </div>
+        <CourseList status={status} courses={courses} cached={cached} reload={reload} />
       </section>
 
       <section className="portal-section" aria-labelledby="account">
@@ -123,6 +121,7 @@ function PortalHome({ user, logout }) {
 
 PortalHome.propTypes = {
   user: PropTypes.shape({
+    id: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
     name: PropTypes.string,
     email: PropTypes.string,
   }),

--- a/src/components/portal/PortalLogin.jsx
+++ b/src/components/portal/PortalLogin.jsx
@@ -1,0 +1,116 @@
+import PropTypes from "prop-types";
+import { useLocation, Navigate, Link } from "react-router-dom";
+import { usePortalSession } from "./usePortalSession";
+import PortalSkeleton from "./PortalSkeleton";
+import "./Portal.css";
+
+/**
+ * /portal/login (#110).
+ *
+ * Reuses the site's brand and tokens — no new design language, per the ticket.
+ *
+ * Inert until configured: `providers` comes from /auth/me, which reports which
+ * providers actually have a client id and secret. With none, the screen says
+ * "coming soon" instead of rendering buttons that would send a student to a
+ * provider error page.
+ */
+
+const PROVIDER_LABEL = { google: "Google", microsoft: "Microsoft" };
+
+// The provider tells us why in a query string; nothing from it reaches the DOM.
+const ERRORS = {
+  cancelled: "Sign-in was cancelled. You can try again.",
+  bad_state: "That sign-in link expired. Please try again.",
+  token_exchange: "We could not complete sign-in with that provider. Please try again.",
+  bad_token: "We could not verify that sign-in. Please try again.",
+  storage: "We could not save your account just now. Please try again shortly.",
+  not_configured: "Student sign-in is not switched on yet.",
+};
+
+function ProviderMark({ name }) {
+  if (name === "google") {
+    return (
+      <svg viewBox="0 0 24 24" aria-hidden="true" className="portal-provider-mark">
+        <path fill="#4285F4" d="M23.5 12.3c0-.8-.1-1.6-.2-2.3H12v4.5h6.4a5.5 5.5 0 0 1-2.4 3.6v3h3.9c2.3-2.1 3.6-5.2 3.6-8.8z" />
+        <path fill="#34A853" d="M12 24c3.2 0 6-1.1 8-2.9l-3.9-3c-1.1.7-2.5 1.2-4.1 1.2-3.1 0-5.8-2.1-6.7-5H1.3v3.1A12 12 0 0 0 12 24z" />
+        <path fill="#FBBC05" d="M5.3 14.3a7.2 7.2 0 0 1 0-4.6V6.6H1.3a12 12 0 0 0 0 10.8l4-3.1z" />
+        <path fill="#EA4335" d="M12 4.8c1.8 0 3.3.6 4.6 1.8l3.4-3.4A12 12 0 0 0 1.3 6.6l4 3.1c.9-2.9 3.6-4.9 6.7-4.9z" />
+      </svg>
+    );
+  }
+  return (
+    <svg viewBox="0 0 24 24" aria-hidden="true" className="portal-provider-mark">
+      <path fill="#F25022" d="M2 2h9.5v9.5H2z" />
+      <path fill="#7FBA00" d="M12.5 2H22v9.5h-9.5z" />
+      <path fill="#00A4EF" d="M2 12.5h9.5V22H2z" />
+      <path fill="#FFB900" d="M12.5 12.5H22V22h-9.5z" />
+    </svg>
+  );
+}
+
+ProviderMark.propTypes = { name: PropTypes.string.isRequired };
+
+function PortalLogin() {
+  const { status, providers } = usePortalSession();
+  const location = useLocation();
+  const params = new URLSearchParams(location.search);
+  const errorKey = params.get("error");
+  const error = errorKey ? ERRORS[errorKey] || ERRORS.token_exchange : null;
+
+  if (status === "loading") return <PortalSkeleton />;
+  if (status === "authenticated") return <Navigate to="/portal" replace />;
+
+  const next = (location.state && location.state.from) || "/portal";
+  const offline = status === "offline";
+
+  return (
+    <main className="portal portal-login">
+      <div className="portal-login-card">
+        <p className="portal-eyebrow">Student portal</p>
+        <h1>Sign in to keep learning</h1>
+        <p className="portal-login-sub">
+          Use the Google or Microsoft account you enrolled with.
+        </p>
+
+        {error && (
+          <p className="portal-alert" role="alert">
+            {error}
+          </p>
+        )}
+
+        {offline && (
+          <p className="portal-alert" role="alert">
+            We could not reach the academy. Check your connection and try again.
+          </p>
+        )}
+
+        {!offline && providers.length === 0 && (
+          <div className="portal-soon" role="status">
+            <p className="portal-soon-title">Coming soon</p>
+            <p>
+              Student sign-in is not switched on yet. Your classes carry on as
+              normal in the meantime.
+            </p>
+          </div>
+        )}
+
+        {providers.map((p) => (
+          <a
+            key={p}
+            className="portal-provider"
+            href={`/auth/${p}/start?next=${encodeURIComponent(next)}`}
+          >
+            <ProviderMark name={p} />
+            <span>Sign in with {PROVIDER_LABEL[p] || p}</span>
+          </a>
+        ))}
+
+        <p className="portal-login-foot">
+          Not a student yet? <Link to="/">See our courses</Link>
+        </p>
+      </div>
+    </main>
+  );
+}
+
+export default PortalLogin;

--- a/src/components/portal/PortalRoute.jsx
+++ b/src/components/portal/PortalRoute.jsx
@@ -1,0 +1,46 @@
+import PropTypes from "prop-types";
+import { Navigate, useLocation } from "react-router-dom";
+import { usePortalSession } from "./usePortalSession";
+import PortalSkeleton from "./PortalSkeleton";
+import "./Portal.css";
+
+/**
+ * Guards everything under /portal (#110).
+ *
+ * Renders a skeleton rather than a spinner while /auth/me is in flight, and
+ * treats a failed request as "offline", not as "signed out" — bouncing a
+ * student to a login screen they cannot reach the network to complete would be
+ * the worst possible answer on a metered connection.
+ */
+function PortalRoute({ children }) {
+  const { status, user, reload, logout } = usePortalSession();
+  const location = useLocation();
+
+  if (status === "loading") return <PortalSkeleton />;
+
+  if (status === "offline") {
+    return (
+      <main className="portal portal-state">
+        <div className="portal-state-card" role="status">
+          <h1>You are offline</h1>
+          <p>We could not reach the academy. Your connection may have dropped.</p>
+          <button type="button" className="portal-btn" onClick={reload}>
+            Try again
+          </button>
+        </div>
+      </main>
+    );
+  }
+
+  if (status === "anonymous") {
+    // `state` carries where they were headed, so signing in returns them there
+    // rather than dumping everyone on the home screen.
+    return <Navigate to="/portal/login" replace state={{ from: location.pathname }} />;
+  }
+
+  return typeof children === "function" ? children({ user, logout }) : children;
+}
+
+PortalRoute.propTypes = { children: PropTypes.oneOfType([PropTypes.node, PropTypes.func]) };
+
+export default PortalRoute;

--- a/src/components/portal/PortalSkeleton.jsx
+++ b/src/components/portal/PortalSkeleton.jsx
@@ -1,0 +1,24 @@
+import "./Portal.css";
+
+/**
+ * Skeletons, not a spinner (#111).
+ *
+ * On a slow metered connection the wait is long enough that a spinner reads as
+ * "stuck". A shape that matches what is about to arrive reads as "loading",
+ * and it does not shift the layout when the real content lands.
+ */
+function PortalSkeleton() {
+  return (
+    <main className="portal" aria-busy="true" aria-live="polite">
+      <span className="portal-sr">Loading your portal</span>
+      <div className="portal-skeleton">
+        <div className="sk sk-line sk-line--sm" />
+        <div className="sk sk-line sk-line--lg" />
+        <div className="sk sk-card" />
+        <div className="sk sk-card" />
+      </div>
+    </main>
+  );
+}
+
+export default PortalSkeleton;

--- a/src/components/portal/coursesCache.js
+++ b/src/components/portal/coursesCache.js
@@ -1,0 +1,80 @@
+/**
+ * The saved copy of a student's course list (#137).
+ *
+ * A rural connection drops mid-session more often than it refuses outright, so
+ * the portal keeps the last good course list and renders it when the network
+ * is gone. Kept as plain functions rather than hook internals so the cache
+ * rules are unit-testable, the way batchDateUtils is.
+ */
+
+export const CACHE_KEY = "rca_portal_courses";
+
+// Long enough to survive a commute with no signal, short enough that a stale
+// list is never mistaken for the truth. The UI always labels a cached render.
+export const MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000;
+
+/**
+ * The cache is per student. Without the id in the key, a shared phone would
+ * show one sibling the other's courses for as long as the entry lived.
+ */
+export function cacheKey(userId) {
+  return `${CACHE_KEY}:${userId ?? "anon"}`;
+}
+
+export function readCache(userId, storage = safeStorage(), now = Date.now()) {
+  if (!storage) return null;
+  try {
+    const raw = storage.getItem(cacheKey(userId));
+    if (!raw) return null;
+    const parsed = JSON.parse(raw);
+    // A hand-edited or half-written entry must not crash the screen it was
+    // meant to rescue.
+    if (!parsed || !Array.isArray(parsed.courses) || typeof parsed.savedAt !== "number") return null;
+    if (now - parsed.savedAt > MAX_AGE_MS) return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+export function writeCache(userId, courses, storage = safeStorage(), now = Date.now()) {
+  if (!storage || !Array.isArray(courses)) return false;
+  try {
+    storage.setItem(cacheKey(userId), JSON.stringify({ courses, savedAt: now }));
+    return true;
+  } catch {
+    // Private mode, or the quota is full. Losing the cache is not worth losing
+    // the screen over.
+    return false;
+  }
+}
+
+export function clearCache(userId, storage = safeStorage()) {
+  try {
+    storage?.removeItem(cacheKey(userId));
+  } catch {
+    /* nothing useful to do */
+  }
+}
+
+function safeStorage() {
+  try {
+    return typeof window === "undefined" ? null : window.localStorage;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * "2h 05m", "45m", "—". Lessons are minutes-to-hours long, so an h:mm:ss clock
+ * would be three units of precision nobody reads.
+ */
+export function formatDuration(seconds) {
+  const total = Number(seconds);
+  if (!Number.isFinite(total) || total <= 0) return "—";
+  const mins = Math.round(total / 60);
+  if (mins < 60) return `${mins}m`;
+  const h = Math.floor(mins / 60);
+  const m = mins % 60;
+  return m === 0 ? `${h}h` : `${h}h ${String(m).padStart(2, "0")}m`;
+}

--- a/src/components/portal/coursesCache.test.js
+++ b/src/components/portal/coursesCache.test.js
@@ -1,0 +1,122 @@
+import { describe, it, expect } from "vitest";
+import {
+  cacheKey,
+  readCache,
+  writeCache,
+  clearCache,
+  formatDuration,
+  MAX_AGE_MS,
+} from "./coursesCache";
+
+// A localStorage stand-in. `fail` makes every call throw, which is what a
+// browser in private mode or over quota actually does.
+function memStore(seed = {}, fail = false) {
+  const map = new Map(Object.entries(seed));
+  const boom = () => {
+    throw new Error("storage unavailable");
+  };
+  return {
+    getItem: (k) => (fail ? boom() : (map.has(k) ? map.get(k) : null)),
+    setItem: (k, v) => (fail ? boom() : void map.set(k, v)),
+    removeItem: (k) => (fail ? boom() : void map.delete(k)),
+    map,
+  };
+}
+const entry = (courses, savedAt) => JSON.stringify({ courses, savedAt });
+
+describe("cacheKey", () => {
+  it("is scoped per student, so a shared phone never leaks a sibling's courses", () => {
+    expect(cacheKey(1)).not.toBe(cacheKey(2));
+  });
+
+  it("has a stable fallback when there is no user id", () => {
+    expect(cacheKey(undefined)).toBe(cacheKey(null));
+  });
+});
+
+describe("readCache", () => {
+  const now = 1_000_000_000;
+
+  it("returns a fresh entry", () => {
+    const store = memStore({ [cacheKey(1)]: entry([{ id: 9 }], now - 1000) });
+    expect(readCache(1, store, now).courses).toEqual([{ id: 9 }]);
+  });
+
+  it("returns null when nothing is saved", () => {
+    expect(readCache(1, memStore(), now)).toBeNull();
+  });
+
+  it("drops an entry past its max age rather than showing a stale list", () => {
+    const store = memStore({ [cacheKey(1)]: entry([{ id: 9 }], now - MAX_AGE_MS - 1) });
+    expect(readCache(1, store, now)).toBeNull();
+  });
+
+  it("keeps an entry exactly at the boundary", () => {
+    const store = memStore({ [cacheKey(1)]: entry([{ id: 9 }], now - MAX_AGE_MS) });
+    expect(readCache(1, store, now)).not.toBeNull();
+  });
+
+  it("survives corrupt JSON instead of crashing the screen it exists to rescue", () => {
+    expect(readCache(1, memStore({ [cacheKey(1)]: "{not json" }), now)).toBeNull();
+  });
+
+  it("rejects a well-formed entry with the wrong shape", () => {
+    const store = memStore({ [cacheKey(1)]: JSON.stringify({ courses: "nope", savedAt: now }) });
+    expect(readCache(1, store, now)).toBeNull();
+  });
+
+  it("rejects an entry with no timestamp, which could never be aged out", () => {
+    const store = memStore({ [cacheKey(1)]: JSON.stringify({ courses: [] }) });
+    expect(readCache(1, store, now)).toBeNull();
+  });
+
+  it("returns null when storage itself throws", () => {
+    expect(readCache(1, memStore({}, true), now)).toBeNull();
+  });
+
+  it("does not read another student's entry", () => {
+    const store = memStore({ [cacheKey(2)]: entry([{ id: 9 }], now) });
+    expect(readCache(1, store, now)).toBeNull();
+  });
+});
+
+describe("writeCache", () => {
+  it("round-trips through readCache", () => {
+    const store = memStore();
+    expect(writeCache(1, [{ id: 4 }], store, 500)).toBe(true);
+    expect(readCache(1, store, 600).courses).toEqual([{ id: 4 }]);
+  });
+
+  it("refuses a non-array rather than saving something unreadable", () => {
+    expect(writeCache(1, null, memStore())).toBe(false);
+  });
+
+  it("reports failure instead of throwing when storage is unavailable", () => {
+    expect(writeCache(1, [], memStore({}, true))).toBe(false);
+  });
+
+  it("swallows a failing removeItem", () => {
+    expect(() => clearCache(1, memStore({}, true))).not.toThrow();
+  });
+});
+
+describe("formatDuration", () => {
+  it("renders minutes under an hour", () => {
+    expect(formatDuration(45 * 60)).toBe("45m");
+  });
+
+  it("renders whole hours without a stray 00m", () => {
+    expect(formatDuration(2 * 3600)).toBe("2h");
+  });
+
+  it("pads the minutes so a lesson list stays aligned", () => {
+    expect(formatDuration(2 * 3600 + 5 * 60)).toBe("2h 05m");
+  });
+
+  it("gives a dash for missing, zero or nonsense values", () => {
+    expect(formatDuration(null)).toBe("—");
+    expect(formatDuration(0)).toBe("—");
+    expect(formatDuration(-30)).toBe("—");
+    expect(formatDuration("abc")).toBe("—");
+  });
+});

--- a/src/components/portal/useCourses.js
+++ b/src/components/portal/useCourses.js
@@ -1,0 +1,55 @@
+import { useCallback, useEffect, useState } from "react";
+import { readCache, writeCache } from "./coursesCache";
+
+/**
+ * The student's course list, from GET /api/portal/courses (#137).
+ *
+ * Mirrors usePortalSession's shape: `status` is the whole state machine, and a
+ * failed request is "offline", never "you have no courses".
+ *   loading | ready | offline | error
+ *
+ * `cached` is true when what is on screen came from the saved copy rather than
+ * the network, so the screen can say so instead of quietly showing old data.
+ */
+export function useCourses(userId) {
+  const [status, setStatus] = useState("loading");
+  const [courses, setCourses] = useState([]);
+  const [cached, setCached] = useState(false);
+
+  const load = useCallback(async () => {
+    // Paint the saved copy first. On a slow connection this is the difference
+    // between a blank screen for eight seconds and a usable one immediately.
+    const saved = readCache(userId);
+    if (saved) {
+      setCourses(saved.courses);
+      setCached(true);
+      setStatus("ready");
+    } else {
+      setStatus("loading");
+    }
+
+    try {
+      const res = await fetch("/api/portal/courses", { credentials: "same-origin" });
+      if (!res.ok) {
+        // 503 means the academy's side is down. If a saved copy is already on
+        // screen it stays there; there is nothing better to show.
+        if (!saved) setStatus("error");
+        return;
+      }
+      const body = await res.json().catch(() => ({}));
+      const list = Array.isArray(body.courses) ? body.courses : [];
+      setCourses(list);
+      setCached(false);
+      setStatus("ready");
+      writeCache(userId, list);
+    } catch {
+      if (!saved) setStatus("offline");
+    }
+  }, [userId]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  return { status, courses, cached, reload: load };
+}

--- a/src/components/portal/usePortalSession.js
+++ b/src/components/portal/usePortalSession.js
@@ -1,0 +1,56 @@
+import { useCallback, useEffect, useState } from "react";
+
+/**
+ * The portal's session, read from GET /auth/me (#110).
+ *
+ * `status` is the whole state machine, so no screen has to infer "still
+ * loading" from an absent user:
+ *   loading        — the first /auth/me is in flight
+ *   authenticated  — signed in; `user` is set
+ *   anonymous      — not signed in; `providers` says what can be offered
+ *   offline        — the request itself failed, which on a metered rural
+ *                    connection is the common case rather than the edge one,
+ *                    and is not the same thing as being signed out (#111)
+ */
+export function usePortalSession() {
+  const [status, setStatus] = useState("loading");
+  const [user, setUser] = useState(null);
+  const [providers, setProviders] = useState([]);
+
+  const load = useCallback(async () => {
+    try {
+      const res = await fetch("/auth/me", { credentials: "same-origin" });
+      const body = await res.json().catch(() => ({}));
+      setProviders(Array.isArray(body.providers) ? body.providers : []);
+      if (res.ok && body.authenticated) {
+        setUser(body.user || null);
+        setStatus("authenticated");
+      } else {
+        setUser(null);
+        setStatus("anonymous");
+      }
+    } catch {
+      // A network failure is not a sign-out. Saying "please sign in" here
+      // would send a student round a login loop they cannot complete.
+      setUser(null);
+      setStatus("offline");
+    }
+  }, []);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const logout = useCallback(async () => {
+    try {
+      await fetch("/auth/logout", { method: "POST", credentials: "same-origin" });
+    } catch {
+      // Ignore: the cookie may already be gone, and the screen below still
+      // needs to return the student to the login page either way.
+    }
+    setUser(null);
+    setStatus("anonymous");
+  }, []);
+
+  return { status, user, providers, reload: load, logout };
+}

--- a/tests/portal.auth.test.js
+++ b/tests/portal.auth.test.js
@@ -1,0 +1,205 @@
+import { describe, it, expect } from "vitest";
+import { onRequestGet as startGet } from "../functions/auth/[provider]/start.js";
+import { onRequestGet as meGet } from "../functions/auth/me.js";
+import { onRequestPost as logoutPost } from "../functions/auth/logout.js";
+import { signSession } from "../shared/auth.js";
+import { configuredProviders, isConfigured, redirectUri, codeChallenge, randomString } from "../shared/oidc.js";
+
+const SECRET = "test-secret-value";
+const CONFIGURED = {
+  SESSION_SECRET: SECRET,
+  GOOGLE_CLIENT_ID: "g-id",
+  GOOGLE_CLIENT_SECRET: "g-secret",
+  MS_CLIENT_ID: "m-id",
+  MS_CLIENT_SECRET: "m-secret",
+};
+
+const req = (url, headers = {}) => new Request(url, { headers });
+const cookieHeader = (token) => ({ cookie: `rca_session=${token}` });
+const setCookies = (res) =>
+  (typeof res.headers.getSetCookie === "function"
+    ? res.headers.getSetCookie()
+    : [res.headers.get("set-cookie")]
+  ).filter(Boolean);
+
+describe("provider configuration", () => {
+  it("reports nothing configured when the secrets are absent", () => {
+    expect(configuredProviders({})).toEqual([]);
+    expect(isConfigured("google", {})).toBe(false);
+  });
+
+  it("still reports nothing without a SESSION_SECRET to sign with", () => {
+    expect(configuredProviders({ GOOGLE_CLIENT_ID: "a", GOOGLE_CLIENT_SECRET: "b" })).toEqual([]);
+  });
+
+  it("lists both providers once every secret is present", () => {
+    expect(configuredProviders(CONFIGURED).sort()).toEqual(["google", "microsoft"]);
+  });
+
+  it("never treats an unknown provider as configured", () => {
+    expect(isConfigured("facebook", CONFIGURED)).toBe(false);
+  });
+});
+
+describe("GET /auth/:provider/start", () => {
+  it("is inert until configured — 503, not a redirect to a provider error", async () => {
+    const res = await startGet({ request: req("https://x.test/auth/google/start"), env: {}, params: { provider: "google" } });
+    expect(res.status).toBe(503);
+    expect((await res.json()).error).toBe("not_configured");
+  });
+
+  it("redirects to the provider with PKCE and a state", async () => {
+    const res = await startGet({
+      request: req("https://x.test/auth/google/start"),
+      env: CONFIGURED,
+      params: { provider: "google" },
+    });
+    expect(res.status).toBe(302);
+    const url = new URL(res.headers.get("location"));
+    expect(url.origin + url.pathname).toBe("https://accounts.google.com/o/oauth2/v2/auth");
+    expect(url.searchParams.get("client_id")).toBe("g-id");
+    expect(url.searchParams.get("response_type")).toBe("code");
+    expect(url.searchParams.get("code_challenge_method")).toBe("S256");
+    expect(url.searchParams.get("code_challenge")).toBeTruthy();
+    expect(url.searchParams.get("state")).toBeTruthy();
+    expect(url.searchParams.get("redirect_uri")).toBe("https://x.test/auth/google/callback");
+  });
+
+  it("stores the state and verifier in HttpOnly cookies", async () => {
+    const res = await startGet({
+      request: req("https://x.test/auth/google/start"),
+      env: CONFIGURED,
+      params: { provider: "google" },
+    });
+    const cookies = setCookies(res).join("\n");
+    expect(cookies).toMatch(/rca_oauth_state=/);
+    expect(cookies).toMatch(/rca_oauth_verifier=/);
+    expect(cookies).toMatch(/HttpOnly/);
+    expect(cookies).toMatch(/Secure/);
+  });
+
+  it("refuses to carry an off-site `next` through the login round trip", async () => {
+    const res = await startGet({
+      request: req("https://x.test/auth/google/start?next=https://evil.test/steal"),
+      env: CONFIGURED,
+      params: { provider: "google" },
+    });
+    const next = setCookies(res).find((c) => c.startsWith("rca_oauth_next="));
+    expect(decodeURIComponent(next.split(";")[0].split("=")[1])).toBe("/portal");
+  });
+
+  it("refuses a protocol-relative `next` too", async () => {
+    const res = await startGet({
+      request: req("https://x.test/auth/google/start?next=//evil.test"),
+      env: CONFIGURED,
+      params: { provider: "google" },
+    });
+    const next = setCookies(res).find((c) => c.startsWith("rca_oauth_next="));
+    expect(decodeURIComponent(next.split(";")[0].split("=")[1])).toBe("/portal");
+  });
+
+  it("keeps a same-site `next`", async () => {
+    const res = await startGet({
+      request: req("https://x.test/auth/google/start?next=%2Fportal%2Fcourses"),
+      env: CONFIGURED,
+      params: { provider: "google" },
+    });
+    const next = setCookies(res).find((c) => c.startsWith("rca_oauth_next="));
+    expect(decodeURIComponent(next.split(";")[0].split("=")[1])).toBe("/portal/courses");
+  });
+
+  it("points Microsoft at the tenant when one is set", async () => {
+    const res = await startGet({
+      request: req("https://x.test/auth/microsoft/start"),
+      env: { ...CONFIGURED, MS_TENANT: "contoso" },
+      params: { provider: "microsoft" },
+    });
+    expect(res.headers.get("location")).toContain("/contoso/oauth2/v2.0/authorize");
+  });
+});
+
+describe("GET /auth/me", () => {
+  it("401s with no session, and says which providers can be offered", async () => {
+    const res = await meGet({ request: req("https://x.test/auth/me"), env: CONFIGURED });
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.authenticated).toBe(false);
+    expect(body.providers.sort()).toEqual(["google", "microsoft"]);
+  });
+
+  it("reports an empty provider list when nothing is configured", async () => {
+    const res = await meGet({ request: req("https://x.test/auth/me"), env: {} });
+    expect((await res.json()).providers).toEqual([]);
+  });
+
+  it("returns the user for a valid session", async () => {
+    const token = await signSession({ uid: 7, email: "s@x.test", name: "Asha R", role: "student" }, SECRET);
+    const res = await meGet({ request: req("https://x.test/auth/me", cookieHeader(token)), env: CONFIGURED });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.authenticated).toBe(true);
+    expect(body.user).toMatchObject({ id: 7, email: "s@x.test", name: "Asha R", role: "student" });
+  });
+
+  it("rejects a session signed with a different secret", async () => {
+    const token = await signSession({ uid: 7 }, "some-other-secret");
+    const res = await meGet({ request: req("https://x.test/auth/me", cookieHeader(token)), env: CONFIGURED });
+    expect(res.status).toBe(401);
+  });
+
+  it("rejects a tampered payload", async () => {
+    const token = await signSession({ uid: 7, role: "student" }, SECRET);
+    const [h, , s] = token.split(".");
+    const forged = btoa(JSON.stringify({ uid: 1, role: "admin", exp: 9999999999 }))
+      .replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+    const res = await meGet({
+      request: req("https://x.test/auth/me", cookieHeader(`${h}.${forged}.${s}`)),
+      env: CONFIGURED,
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it("rejects an expired session", async () => {
+    const token = await signSession({ uid: 7 }, SECRET, -10);
+    const res = await meGet({ request: req("https://x.test/auth/me", cookieHeader(token)), env: CONFIGURED });
+    expect(res.status).toBe(401);
+  });
+
+  it("is never cached — it carries who you are", async () => {
+    const res = await meGet({ request: req("https://x.test/auth/me"), env: CONFIGURED });
+    expect(res.headers.get("cache-control")).toBe("no-store");
+  });
+});
+
+describe("POST /auth/logout", () => {
+  it("clears the session cookie", async () => {
+    const res = await logoutPost();
+    expect(res.status).toBe(200);
+    const cookie = res.headers.get("set-cookie");
+    expect(cookie).toMatch(/rca_session=;/);
+    expect(cookie).toMatch(/Max-Age=0/);
+    expect(cookie).toMatch(/HttpOnly/);
+  });
+});
+
+describe("PKCE helpers", () => {
+  it("produces a URL-safe challenge of the right shape", async () => {
+    const c = await codeChallenge("verifier-value");
+    expect(c).toMatch(/^[A-Za-z0-9_-]{43}$/);
+  });
+
+  it("derives the challenge from the verifier, deterministically", async () => {
+    expect(await codeChallenge("a")).toBe(await codeChallenge("a"));
+    expect(await codeChallenge("a")).not.toBe(await codeChallenge("b"));
+  });
+
+  it("does not repeat a random string", () => {
+    const seen = new Set(Array.from({ length: 50 }, () => randomString(16)));
+    expect(seen.size).toBe(50);
+  });
+
+  it("builds the redirect URI from the request origin", () => {
+    expect(redirectUri(req("https://restcoderacademy.in/auth/google/start"), "google"))
+      .toBe("https://restcoderacademy.in/auth/google/callback");
+  });
+});

--- a/tests/portal.courses.test.js
+++ b/tests/portal.courses.test.js
@@ -1,0 +1,161 @@
+import { describe, it, expect } from "vitest";
+import { onRequestGet as listGet } from "../functions/api/portal/courses.js";
+import { onRequestGet as detailGet } from "../functions/api/portal/courses/[slug].js";
+import { listEnrolledCourses, getEnrolledCourse } from "../shared/courses.js";
+import { signSession } from "../shared/auth.js";
+
+const SECRET = "test-secret-value";
+
+// A fake D1 that records the SQL it was handed and replays canned rows. The
+// point is to assert the query shape and the route's behaviour around it, not
+// to reimplement SQLite: `plan` maps a matcher to the rows that query returns.
+function fakeDB(plan, log = []) {
+  return {
+    log,
+    prepare(sql) {
+      const stmt = {
+        sql,
+        args: [],
+        bind(...args) {
+          stmt.args = args;
+          return stmt;
+        },
+        async all() {
+          log.push({ sql, args: stmt.args });
+          return { results: resolve(plan, sql, stmt.args) ?? [] };
+        },
+        async first() {
+          log.push({ sql, args: stmt.args });
+          const rows = resolve(plan, sql, stmt.args);
+          return rows && rows.length ? rows[0] : null;
+        },
+      };
+      return stmt;
+    },
+  };
+}
+function resolve(plan, sql, args) {
+  for (const [needle, rows] of plan) {
+    if (sql.includes(needle)) return typeof rows === "function" ? rows(args) : rows;
+  }
+  return [];
+}
+const throwingDB = () => ({
+  prepare() {
+    return { bind: () => ({ all: async () => { throw new Error("d1 down"); }, first: async () => { throw new Error("d1 down"); } }) };
+  },
+});
+
+const session = (uid = 7) => signSession({ uid, email: "s@example.com", name: "S", role: "student" }, SECRET);
+const req = (url, token) =>
+  new Request(url, { headers: token ? { cookie: `rca_session=${token}` } : {} });
+
+describe("GET /api/portal/courses", () => {
+  it("401s without a session, and reads no course data", async () => {
+    const log = [];
+    const res = await listGet({ request: req("https://x/api/portal/courses"), env: { SESSION_SECRET: SECRET, DB: fakeDB([], log) } });
+    expect(res.status).toBe(401);
+    expect(log).toHaveLength(0);
+  });
+
+  it("401s on a tampered cookie", async () => {
+    const token = (await session()) + "x";
+    const res = await listGet({ request: req("https://x/api/portal/courses", token), env: { SESSION_SECRET: SECRET, DB: fakeDB([]) } });
+    expect(res.status).toBe(401);
+  });
+
+  it("returns the student's enrolled courses", async () => {
+    const db = fakeDB([["FROM enrolments_users", [{ id: 1, slug: "fde", title: "Full Dev", lesson_count: 3 }]]]);
+    const res = await listGet({ request: req("https://x/api/portal/courses", await session()), env: { SESSION_SECRET: SECRET, DB: db } });
+    expect(res.status).toBe(200);
+    expect((await res.json()).courses).toEqual([{ id: 1, slug: "fde", title: "Full Dev", lesson_count: 3 }]);
+  });
+
+  it("scopes the query to the caller's own user id", async () => {
+    const log = [];
+    const db = fakeDB([["FROM enrolments_users", []]], log);
+    await listGet({ request: req("https://x/api/portal/courses", await session(42)), env: { SESSION_SECRET: SECRET, DB: db } });
+    expect(log[0].args).toEqual([42]);
+    expect(log[0].sql).toContain("eu.user_id = ?1");
+  });
+
+  it("never caches a per-student response", async () => {
+    const res = await listGet({ request: req("https://x/api/portal/courses", await session()), env: { SESSION_SECRET: SECRET, DB: fakeDB([]) } });
+    expect(res.headers.get("cache-control")).toBe("no-store");
+  });
+
+  it("503s rather than reporting an empty course list when D1 is missing", async () => {
+    const res = await listGet({ request: req("https://x/api/portal/courses", await session()), env: { SESSION_SECRET: SECRET } });
+    expect(res.status).toBe(503);
+  });
+
+  it("503s when the query throws", async () => {
+    const res = await listGet({ request: req("https://x/api/portal/courses", await session()), env: { SESSION_SECRET: SECRET, DB: throwingDB() } });
+    expect(res.status).toBe(503);
+  });
+});
+
+describe("GET /api/portal/courses/:slug", () => {
+  const enrolled = [
+    ["FROM enrolments_users", [{ id: 5, slug: "fde", title: "Full Dev" }]],
+    ["FROM lessons", [{ id: 1, position: 1, title: "Intro", notes: "# hi" }]],
+  ];
+
+  it("401s without a session", async () => {
+    const res = await detailGet({ request: req("https://x/api/portal/courses/fde"), env: { SESSION_SECRET: SECRET, DB: fakeDB(enrolled) }, params: { slug: "fde" } });
+    expect(res.status).toBe(401);
+  });
+
+  it("returns the course with its lessons in order", async () => {
+    const res = await detailGet({ request: req("https://x/api/portal/courses/fde", await session()), env: { SESSION_SECRET: SECRET, DB: fakeDB(enrolled) }, params: { slug: "fde" } });
+    expect(res.status).toBe(200);
+    const { course } = await res.json();
+    expect(course.slug).toBe("fde");
+    expect(course.lessons).toHaveLength(1);
+  });
+
+  it("404s for a course the student is not enrolled in, and reads no lessons", async () => {
+    const log = [];
+    const db = fakeDB([["FROM enrolments_users", []], ["FROM lessons", [{ id: 1 }]]], log);
+    const res = await detailGet({ request: req("https://x/api/portal/courses/secret", await session()), env: { SESSION_SECRET: SECRET, DB: db }, params: { slug: "secret" } });
+    expect(res.status).toBe(404);
+    expect(log.some((q) => q.sql.includes("FROM lessons"))).toBe(false);
+  });
+
+  it("gives an unenrolled student the same 404 as a nonexistent slug", async () => {
+    const db = fakeDB([["FROM enrolments_users", []]]);
+    const a = await detailGet({ request: req("https://x/a", await session()), env: { SESSION_SECRET: SECRET, DB: db }, params: { slug: "real-but-not-mine" } });
+    const b = await detailGet({ request: req("https://x/b", await session()), env: { SESSION_SECRET: SECRET, DB: db }, params: { slug: "no-such-course" } });
+    expect(a.status).toBe(b.status);
+    expect(await a.json()).toEqual(await b.json());
+  });
+
+  it("404s on an empty slug", async () => {
+    const res = await detailGet({ request: req("https://x/api/portal/courses/", await session()), env: { SESSION_SECRET: SECRET, DB: fakeDB(enrolled) }, params: {} });
+    expect(res.status).toBe(404);
+  });
+});
+
+describe("course queries", () => {
+  it("withholds an unpublished course even from an enrolled student", async () => {
+    const log = [];
+    await listEnrolledCourses(fakeDB([], log), 1);
+    expect(log[0].sql).toContain("c.published = 1");
+  });
+
+  it("counts only published lessons", async () => {
+    const log = [];
+    await listEnrolledCourses(fakeDB([], log), 1);
+    expect(log[0].sql).toContain("l.published = 1");
+  });
+
+  it("returns null for a course the student is not enrolled in", async () => {
+    expect(await getEnrolledCourse(fakeDB([["FROM enrolments_users", []]]), 1, "fde")).toBeNull();
+  });
+
+  it("orders lessons by position", async () => {
+    const log = [];
+    await getEnrolledCourse(fakeDB([["FROM enrolments_users", [{ id: 5, slug: "fde" }]], ["FROM lessons", []]], log), 1, "fde");
+    expect(log[1].sql).toContain("ORDER BY position ASC");
+  });
+});


### PR DESCRIPTION
**Supersedes #139** — which was auto-closed by GitHub when I merged #138 with \`--delete-branch\`, and #139's base branch (\`feat/portal-courses-api-136\`) disappeared with it. My error, apologies @Abhigna1975 — should have caught the "stacked on #138" note in your PR body before deleting the base. Recreating here against main so the work isn't lost.

The head branch \`feat/portal-course-home-137\` and all its commits are intact.

---

_Original PR body (from #139):_

Part of #43. Closes #137.

The student-facing half of Phase 2, stacked on #138 (the APIs it calls). **#138 is now merged in main**, so the "review those first" note there is satisfied.

### What a student sees

- \`/portal\` "My courses" is now their real enrolments, replacing the Phase 1 placeholder.
- \`/portal/courses/:slug\` is one course with its lessons in order; each lesson expands in place to show its notes.

### Built for the connection these students have

- **The saved copy paints first.** The course list renders from \`localStorage\` before the request goes out, so a slow network costs a stale label ("Showing your saved copy") rather than a blank screen. The cache is keyed per user id, because a shared phone would otherwise show one sibling the other's courses, and it ages out after 7 days so it is never mistaken for the truth.
- **A failed request is "you are offline", never "you have no courses."** Telling an enrolled student they have nothing is the one answer that is worse than an error, so the empty state and the network state are kept distinct.
- Skeletons rather than spinners, no photographs, no extra web font, and the list renders from a single request.
- Every tappable row is at least 48px; lesson numbers and durations use tabular figures so lesson 9 to 10 does not shift the title.

### Two deliberate omissions

- **No video player.** #43 has not settled where lesson video lives, so each lesson says so in a line of text rather than offering a play button that does nothing. Needs its own ticket once the storage call is made.
- **Notes render as text, not parsed markdown.** No parser shipped to the client and no untrusted HTML, which seemed the right default until someone actually needs formatting.

### Tests

24 new tests, 142 passing overall. This repo has no jsdom or testing-library and does not test components, so the cache rules and duration formatting live in \`coursesCache.js\` and are tested in node the way \`batchDateUtils\` is: per user keying, expiry including the exact boundary, corrupt and wrong-shape entries, storage that throws, and the formatter's edge values. The components stay thin enough to read.

\`npm run build\` passes.

> **Still open for @nikshepkulli:** lesson video storage. #43 says Supabase, but Phase 1 and #138 are all-Cloudflare D1. R2 would keep it on one stack.