### PR TITLE
fix(portal): harden the OIDC verification path (closes #159, closes #160, closes #161, closes #162)

### DIFF
--- a/functions/auth/[provider]/callback.js
+++ b/functions/auth/[provider]/callback.js
@@ -4,7 +4,7 @@ import { signSession, sessionCookie, readCookie } from "../../../shared/auth.js"
 import { isConfigured, providerConfig, redirectUri, verifyIdToken } from "../../../shared/oidc.js";
 
 const clearTx = (headers) => {
-  for (const n of ["rca_oauth_state", "rca_oauth_verifier", "rca_oauth_next"]) {
+  for (const n of ["rca_oauth_state", "rca_oauth_verifier", "rca_oauth_nonce", "rca_oauth_next"]) {
     headers.append("set-cookie", `${n}=; HttpOnly; Secure; SameSite=Lax; Path=/auth; Max-Age=0`);
   }
 };
@@ -57,7 +57,12 @@ export async function onRequestGet(context) {
   }
   if (!tokens.id_token) return fail("token_exchange");
 
-  const claims = await verifyIdToken(tokens.id_token, cfg);
+  // The nonce cookie is set by our own start endpoint, so a request that
+  // arrives without one did not begin here (#159).
+  const expectedNonce = readCookie(request, "rca_oauth_nonce");
+  if (!expectedNonce) return fail("bad_state");
+
+  const claims = await verifyIdToken(tokens.id_token, cfg, fetch, expectedNonce);
   if (!claims) return fail("bad_token");
 
   if (!env.DB) return fail("storage");

--- a/functions/auth/[provider]/start.js
+++ b/functions/auth/[provider]/start.js
@@ -27,6 +27,10 @@ export async function onRequestGet(context) {
   const state = randomString(16);
   const verifier = randomString(32);
   const challenge = await codeChallenge(verifier);
+  // Binds the ID token to this browser (#159). PKCE already blocks replay of
+  // the code; the nonce is what stops a token minted elsewhere being swapped
+  // in at the callback.
+  const nonce = randomString(16);
 
   // Where to land inside the app afterwards. Only a same-site path is kept —
   // an absolute URL here would make this an open redirect.
@@ -41,6 +45,7 @@ export async function onRequestGet(context) {
   url.searchParams.set("state", state);
   url.searchParams.set("code_challenge", challenge);
   url.searchParams.set("code_challenge_method", "S256");
+  url.searchParams.set("nonce", nonce);
   // Ask for an account chooser rather than silently reusing whichever account
   // the phone happens to be signed into.
   url.searchParams.set("prompt", "select_account");
@@ -48,6 +53,7 @@ export async function onRequestGet(context) {
   const headers = new Headers({ location: url.toString() });
   headers.append("set-cookie", txCookie("rca_oauth_state", state));
   headers.append("set-cookie", txCookie("rca_oauth_verifier", verifier));
+  headers.append("set-cookie", txCookie("rca_oauth_nonce", nonce));
   headers.append("set-cookie", txCookie("rca_oauth_next", encodeURIComponent(next)));
   return new Response(null, { status: 302, headers });
 }

--- a/shared/auth.js
+++ b/shared/auth.js
@@ -40,6 +40,20 @@ export async function verifySession(token, secret) {
   const parts = token.split(".");
   if (parts.length !== 3) return null;
   const [header, body, sig] = parts;
+
+  // Pin the algorithm before doing anything with the token (#161). We are the
+  // only signer today and HMAC output is length-fixed, so this is unreachable
+  // as things stand. It stops being decorative the moment a second caller
+  // hands this helper an asymmetrically-signed token — that is the shape of
+  // alg-confusion, where a header of {"alg":"RS256"} gets verified against a
+  // public key being used as an HMAC secret.
+  try {
+    const hdr = JSON.parse(dec.decode(b64urlToBytes(header)));
+    if (!hdr || hdr.alg !== "HS256") return null;
+  } catch {
+    return null;
+  }
+
   const key = await hmacKey(secret);
   let ok = false;
   try {

--- a/shared/oidc.js
+++ b/shared/oidc.js
@@ -48,6 +48,8 @@ export function providerConfig(name, env) {
     scope: p.scope,
     clientId: p.clientId(env),
     clientSecret: p.clientSecret(env),
+    // Needed to enforce the issuer when a tenant is pinned (#160).
+    tenant: (env && env.MS_TENANT) || null,
   };
 }
 
@@ -128,19 +130,74 @@ function bytesFromB64url(s) {
  * callback could post a self-made token and be issued a session. Fails closed —
  * every error path returns null rather than a partially trusted payload.
  */
-export async function verifyIdToken(idToken, cfg, fetchImpl = fetch) {
+// --- JWKS cache -------------------------------------------------------------
+// Both providers serve their signing keys with a long Cache-Control (~24h) and
+// rotate slowly. Fetching them on every login put a round trip to Google on the
+// hot path of the callback, and with no abort signal a stall there hung the
+// login until Cloudflare's wall-clock cap rather than failing it (#162).
+//
+// Module scope, so the cache lives as long as the isolate — shared across
+// requests it happens to serve, gone on eviction. That is the right lifetime
+// here: it is a public document, and the worst case of a cold isolate is the
+// fetch we were doing anyway.
+const JWKS_TIMEOUT_MS = 5000;
+const JWKS_FALLBACK_TTL_MS = 60 * 60 * 1000; // 1h if the response says nothing
+const jwksCache = new Map(); // url -> { keys, expires }
+
+function maxAgeFrom(res) {
+  const cc = res.headers.get("cache-control") || "";
+  const m = cc.match(/max-age=(\d+)/i);
+  if (!m) return JWKS_FALLBACK_TTL_MS;
+  // Clamp: a provider sending max-age=0 should not mean "never cache and hit
+  // the network every login", and one sending a year should not outlive a key
+  // rotation we would otherwise pick up.
+  const secs = Math.min(Math.max(Number(m[1]), 300), 24 * 60 * 60);
+  return secs * 1000;
+}
+
+async function fetchJwks(url, fetchImpl) {
+  const res = await fetchImpl(url, { signal: AbortSignal.timeout(JWKS_TIMEOUT_MS) });
+  if (!res.ok) return null;
+  const body = await res.json();
+  const keys = body && Array.isArray(body.keys) ? body.keys : null;
+  if (!keys) return null;
+  jwksCache.set(url, { keys, expires: Date.now() + maxAgeFrom(res) });
+  return keys;
+}
+
+/**
+ * The signing keys for `url`, cached.
+ *
+ * `wantKid` is what makes this safe across a key rotation: if the cached set
+ * does not contain the kid the token was signed with, the cache is stale by
+ * definition, so it refetches once rather than rejecting a token that is
+ * actually valid. Without that, a rotation would fail every login until the
+ * isolate happened to be evicted.
+ */
+async function getJwks(url, wantKid, fetchImpl) {
+  const hit = jwksCache.get(url);
+  const fresh = hit && hit.expires > Date.now();
+  if (fresh && hit.keys.some((k) => k.kid === wantKid)) return hit.keys;
+
+  try {
+    const keys = await fetchJwks(url, fetchImpl);
+    if (keys) return keys;
+  } catch {
+    // Timed out or the network failed. Fall through.
+  }
+  // A cached set that is merely expired still beats nothing — the alternative
+  // is refusing every login while the provider is unreachable.
+  return hit ? hit.keys : null;
+}
+
+export async function verifyIdToken(idToken, cfg, fetchImpl = fetch, expectedNonce = null) {
   const jwt = parseJwt(idToken);
   if (!jwt || jwt.header.alg !== "RS256" || !jwt.header.kid) return null;
 
-  let keys;
-  try {
-    const res = await fetchImpl(cfg.jwks);
-    if (!res.ok) return null;
-    keys = (await res.json()).keys;
-  } catch {
-    return null;
-  }
-  const jwk = (keys || []).find((k) => k.kid === jwt.header.kid);
+  const keys = await getJwks(cfg.jwks, jwt.header.kid, fetchImpl);
+  if (!keys) return null;
+
+  const jwk = keys.find((k) => k.kid === jwt.header.kid);
   if (!jwk) return null;
 
   let ok = false;
@@ -174,7 +231,37 @@ export async function verifyIdToken(idToken, cfg, fetchImpl = fetch) {
   if (!aud.includes(cfg.clientId)) return null;
 
   if (cfg.issuers && !cfg.issuers.includes(p.iss)) return null;
-  if (!cfg.issuers && !/^https:\/\/login\.microsoftonline\.com\//.test(String(p.iss))) return null;
+  if (!cfg.issuers && !isTrustedMicrosoftIssuer(String(p.iss), cfg.tenant)) return null;
+
+  // The nonce ties this ID token to the browser that started the flow (#159).
+  // code+PKCE over a server-side exchange already blocks replay; this closes
+  // token substitution — an ID token that leaked into a log or through a
+  // TLS-terminating proxy being injected here. Absent when expected is a
+  // failure, not a pass: a provider that drops the nonce is one we cannot bind.
+  if (expectedNonce && p.nonce !== expectedNonce) return null;
 
   return p;
+}
+
+const GUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/**
+ * Microsoft's issuer under `common` carries the *signing tenant's* id, which is
+ * not known ahead of time — hence the shape check rather than a fixed string.
+ *
+ * Once a tenant is pinned, that shape check is too loose: a token minted by a
+ * different Entra tenant, with a matching `client_id`, passes it (#160).
+ *
+ * The catch is that `MS_TENANT` may legitimately be a GUID, a verified domain
+ * (`contoso.onmicrosoft.com`), or one of `common` / `organizations` /
+ * `consumers` — while `iss` always carries the tenant **GUID**. So a domain
+ * value cannot be matched against the issuer without a discovery round trip,
+ * and pattern-matching it would reject every valid login. We therefore tighten
+ * only when the pin is a GUID, which is the case where we can be certain, and
+ * leave the rest on the host check.
+ */
+export function isTrustedMicrosoftIssuer(iss, tenant) {
+  if (!/^https:\/\/login\.microsoftonline\.com\//.test(iss)) return false;
+  if (!tenant || !GUID.test(tenant)) return true;
+  return new RegExp(`^https://login\\.microsoftonline\\.com/${tenant}/`, "i").test(iss);
 }

--- a/tests/portal.oidc-hardening.test.js
+++ b/tests/portal.oidc-hardening.test.js
@@ -1,0 +1,235 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { onRequestGet as startGet } from "../functions/auth/[provider]/start.js";
+import { signSession, verifySession } from "../shared/auth.js";
+import { providerConfig, verifyIdToken, isTrustedMicrosoftIssuer } from "../shared/oidc.js";
+
+const SECRET = "test-secret-value";
+const CONFIGURED = {
+  SESSION_SECRET: SECRET,
+  GOOGLE_CLIENT_ID: "g-id",
+  GOOGLE_CLIENT_SECRET: "g-secret",
+  MS_CLIENT_ID: "m-id",
+  MS_CLIENT_SECRET: "m-secret",
+};
+const req = (url, headers = {}) => new Request(url, { headers });
+const setCookies = (res) =>
+  (typeof res.headers.getSetCookie === "function"
+    ? res.headers.getSetCookie()
+    : [res.headers.get("set-cookie")]
+  ).filter(Boolean);
+
+// --- a real RS256 signer, so the ID-token tests exercise the actual path ----
+const enc = new TextEncoder();
+const b64url = (bytes) =>
+  btoa(String.fromCharCode(...new Uint8Array(bytes))).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+const b64urlJson = (o) => b64url(enc.encode(JSON.stringify(o)));
+
+let KEY, JWK;
+const KID = "test-key-1";
+
+beforeAll(async () => {
+  KEY = await crypto.subtle.generateKey(
+    { name: "RSASSA-PKCS1-v1_5", modulusLength: 2048, publicExponent: new Uint8Array([1, 0, 1]), hash: "SHA-256" },
+    true,
+    ["sign", "verify"],
+  );
+  JWK = { ...(await crypto.subtle.exportKey("jwk", KEY.publicKey)), kid: KID, alg: "RS256" };
+  delete JWK.key_ops;
+  delete JWK.ext;
+});
+
+async function idToken(payload, { kid = KID } = {}) {
+  const head = b64urlJson({ alg: "RS256", typ: "JWT", kid });
+  const body = b64urlJson(payload);
+  const sig = await crypto.subtle.sign("RSASSA-PKCS1-v1_5", KEY.privateKey, enc.encode(`${head}.${body}`));
+  return `${head}.${body}.${b64url(sig)}`;
+}
+
+const googleCfg = () => providerConfig("google", CONFIGURED);
+const claims = (over = {}) => ({
+  sub: "user-1",
+  aud: "g-id",
+  iss: "https://accounts.google.com",
+  exp: Math.floor(Date.now() / 1000) + 600,
+  ...over,
+});
+
+// A fetch stub that counts calls, so caching is observable.
+function jwksStub(keys = [JWK], { cacheControl = "max-age=86400", ok = true } = {}) {
+  const fn = async () => {
+    fn.calls++;
+    return new Response(JSON.stringify({ keys }), {
+      status: ok ? 200 : 500,
+      headers: { "content-type": "application/json", "cache-control": cacheControl },
+    });
+  };
+  fn.calls = 0;
+  return fn;
+}
+
+describe("#161 — the session helper pins its algorithm", () => {
+  // Swapping the header while keeping the original signature proves nothing:
+  // the HMAC covers the header, so the signature check rejects it whether or
+  // not the alg is inspected. To isolate the new check the token has to be
+  // *validly* signed over the swapped header — which is exactly what an
+  // attacker holds in a real alg-confusion, where the "secret" is a public key
+  // they already know.
+  async function hs256(headerObj, payload) {
+    const head = b64urlJson(headerObj);
+    const body = b64urlJson({ ...payload, exp: Math.floor(Date.now() / 1000) + 60 });
+    const key = await crypto.subtle.importKey(
+      "raw", enc.encode(SECRET), { name: "HMAC", hash: "SHA-256" }, false, ["sign"],
+    );
+    const sig = await crypto.subtle.sign("HMAC", key, enc.encode(`${head}.${body}`));
+    return `${head}.${body}.${b64url(sig)}`;
+  }
+
+  it("still accepts a session it signed itself", async () => {
+    const t = await signSession({ uid: 1 }, SECRET);
+    expect(await verifySession(t, SECRET)).toMatchObject({ uid: 1 });
+  });
+
+  it("accepts a correctly-signed HS256 token built by hand — the control", async () => {
+    // Establishes that the helper produces something the verifier would
+    // otherwise accept, so the next two fail on the alg and nothing else.
+    expect(await verifySession(await hs256({ alg: "HS256", typ: "JWT" }, { uid: 1 }), SECRET))
+      .toMatchObject({ uid: 1 });
+  });
+
+  it("rejects a validly-signed token that claims RS256", async () => {
+    expect(await verifySession(await hs256({ alg: "RS256", typ: "JWT" }, { uid: 1 }), SECRET)).toBeNull();
+  });
+
+  it("rejects a validly-signed token that claims alg: none", async () => {
+    expect(await verifySession(await hs256({ alg: "none", typ: "JWT" }, { uid: 1 }), SECRET)).toBeNull();
+  });
+
+  it("rejects a header that is not JSON at all", async () => {
+    const t = await signSession({ uid: 1 }, SECRET);
+    const [, body, sig] = t.split(".");
+    expect(await verifySession(`bm90LWpzb24.${body}.${sig}`, SECRET)).toBeNull();
+  });
+});
+
+describe("#160 — the Microsoft issuer is held to the pinned tenant", () => {
+  const GUID = "11111111-2222-3333-4444-555555555555";
+  const OTHER = "99999999-2222-3333-4444-555555555555";
+  const iss = (t) => `https://login.microsoftonline.com/${t}/v2.0`;
+
+  it("accepts any tenant when none is pinned", () => {
+    expect(isTrustedMicrosoftIssuer(iss(GUID), null)).toBe(true);
+    expect(isTrustedMicrosoftIssuer(iss(GUID), "common")).toBe(true);
+  });
+
+  it("accepts the pinned tenant", () => {
+    expect(isTrustedMicrosoftIssuer(iss(GUID), GUID)).toBe(true);
+  });
+
+  it("rejects a different tenant once one is pinned — the actual bug", () => {
+    expect(isTrustedMicrosoftIssuer(iss(OTHER), GUID)).toBe(false);
+  });
+
+  it("never accepts a host that is not Microsoft's", () => {
+    expect(isTrustedMicrosoftIssuer(`https://evil.example/${GUID}/v2.0`, GUID)).toBe(false);
+    expect(isTrustedMicrosoftIssuer(`https://evil.example/${GUID}/v2.0`, null)).toBe(false);
+  });
+
+  it("does not lock out a domain-shaped pin, whose GUID we cannot know", () => {
+    // `iss` always carries the tenant GUID, so matching a domain against it
+    // would reject every valid login. Documented behaviour, not an oversight.
+    expect(isTrustedMicrosoftIssuer(iss(GUID), "contoso.onmicrosoft.com")).toBe(true);
+  });
+
+  it("carries the tenant onto the provider config", () => {
+    expect(providerConfig("microsoft", { ...CONFIGURED, MS_TENANT: "abc" }).tenant).toBe("abc");
+  });
+});
+
+describe("#162 — JWKS is fetched with a timeout and cached", () => {
+  it("passes an abort signal, so a stalled provider fails instead of hanging", async () => {
+    let seen = null;
+    const spy = async (url, init) => {
+      seen = init;
+      return new Response(JSON.stringify({ keys: [JWK] }), {
+        headers: { "content-type": "application/json" },
+      });
+    };
+    await verifyIdToken(await idToken(claims()), googleCfg(), spy);
+    expect(seen && seen.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it("serves a second verification from cache", async () => {
+    const cfg = { ...googleCfg(), jwks: "https://example.test/jwks-cache" };
+    const f = jwksStub();
+    expect(await verifyIdToken(await idToken(claims()), cfg, f)).toMatchObject({ sub: "user-1" });
+    expect(await verifyIdToken(await idToken(claims()), cfg, f)).toMatchObject({ sub: "user-1" });
+    expect(f.calls).toBe(1);
+  });
+
+  it("refetches when the token's kid is not in the cached set — key rotation", async () => {
+    const cfg = { ...googleCfg(), jwks: "https://example.test/jwks-rotate" };
+    const stale = jwksStub([{ ...JWK, kid: "old-key" }]);
+    await verifyIdToken(await idToken(claims(), { kid: "old-key" }), cfg, stale);
+    expect(stale.calls).toBe(1);
+
+    // Same URL, but now signed with a kid the cache has never seen.
+    const rotated = jwksStub([JWK]);
+    expect(await verifyIdToken(await idToken(claims()), cfg, rotated)).toMatchObject({ sub: "user-1" });
+    expect(rotated.calls).toBe(1);
+  });
+
+  it("falls back to an expired cache rather than refusing every login", async () => {
+    const cfg = { ...googleCfg(), jwks: "https://example.test/jwks-stale" };
+    await verifyIdToken(await idToken(claims()), cfg, jwksStub([JWK], { cacheControl: "max-age=0" }));
+
+    const dead = async () => {
+      throw new Error("network down");
+    };
+    expect(await verifyIdToken(await idToken(claims()), cfg, dead)).toMatchObject({ sub: "user-1" });
+  });
+
+  it("returns null when there is no cache and the fetch fails", async () => {
+    const cfg = { ...googleCfg(), jwks: "https://example.test/jwks-never" };
+    const dead = async () => {
+      throw new Error("network down");
+    };
+    expect(await verifyIdToken(await idToken(claims()), cfg, dead)).toBeNull();
+  });
+});
+
+describe("#159 — the OIDC flow carries a nonce", () => {
+  it("sends a nonce to the provider and remembers it in an HttpOnly cookie", async () => {
+    const res = await startGet({
+      request: req("https://restcoderacademy.in/auth/google/start"),
+      env: CONFIGURED,
+      params: { provider: "google" },
+    });
+    const sent = new URL(res.headers.get("location")).searchParams.get("nonce");
+    expect(sent).toBeTruthy();
+
+    const jar = setCookies(res).find((c) => c.startsWith("rca_oauth_nonce="));
+    expect(jar).toContain("HttpOnly");
+    expect(jar).toContain("SameSite=Lax");
+    expect(jar.split(";")[0].split("=")[1]).toBe(sent);
+  });
+
+  it("accepts an ID token carrying the expected nonce", async () => {
+    const t = await idToken(claims({ nonce: "n-123" }));
+    expect(await verifyIdToken(t, googleCfg(), jwksStub(), "n-123")).toMatchObject({ sub: "user-1" });
+  });
+
+  it("rejects a token minted for a different flow", async () => {
+    const t = await idToken(claims({ nonce: "someone-elses" }));
+    expect(await verifyIdToken(t, googleCfg(), jwksStub(), "n-123")).toBeNull();
+  });
+
+  it("rejects a token with no nonce when one was expected", async () => {
+    const t = await idToken(claims());
+    expect(await verifyIdToken(t, googleCfg(), jwksStub(), "n-123")).toBeNull();
+  });
+
+  it("still verifies when no nonce is expected, so nothing else breaks", async () => {
+    const t = await idToken(claims());
+    expect(await verifyIdToken(t, googleCfg(), jwksStub())).toMatchObject({ sub: "user-1" });
+  });
+});


### PR DESCRIPTION
The four follow-ups deferred from the review on #127. All of them live in code that has since landed on `main`, all four are unassigned, and none needed anyone else to unblock them.

Grouped into one PR because three touch the same twenty lines of `shared/oidc.js` — reviewing them apart would mean reading that file four times.

## #159 — nonce

`start.js` mints one alongside the state, sends it to the provider, and keeps it in an HttpOnly cookie. `callback.js` requires that cookie and hands the value to `verifyIdToken`, which rejects a mismatch.

code+PKCE over a server-side exchange already blocks replay of the *code*. The nonce closes token substitution — an ID token that leaked into a log or through a TLS-terminating proxy being injected at the callback. A token carrying **no** nonce when one is expected fails: a provider that drops it is one we cannot bind the flow to.

## #160 — tenant enforcement

The issuer check accepted anything under `login.microsoftonline.com/`, so with `MS_TENANT` pinned, a token from a *different* Entra tenant with a matching `client_id` passed.

**The fix suggested in the ticket would have broken logins**, and this is the part worth a close look. `MS_TENANT` may legitimately be a GUID, a verified domain (`contoso.onmicrosoft.com`), or `common`/`organizations`/`consumers` — but `iss` always carries the tenant **GUID**. Regex-matching a domain value against the issuer would reject every valid sign-in.

So `isTrustedMicrosoftIssuer` tightens only when the pin is a GUID — the case we can be certain about — and leaves a domain pin on the host check, with a comment saying why. Anything not under Microsoft's host is refused either way.

## #161 — algorithm pinning

`verifySession` parses the header and requires `HS256` before touching the token.

To be clear about severity: **this is not a live vulnerability.** An attacker cannot produce a validly-signed token without the secret, and the ticket says as much. It is defence in depth for the moment a second caller hands this helper an asymmetrically-signed token — which #163 is about to create.

## #162 — JWKS timeout and cache

The fetch had no abort signal, so a stalled provider hung the callback until Cloudflare's wall-clock cap — a login that hangs rather than fails. Now `AbortSignal.timeout(5000)`, plus a module-scope cache honouring the response's `max-age`, clamped to 5 minutes .. 24 hours so neither `max-age=0` nor a year is taken literally.

Two details that matter more than the caching:

- **A cached set without the token's `kid` is stale by definition, so it refetches.** Without that, a provider key rotation would fail every login until the isolate happened to be evicted.
- **If the refetch fails, an expired cache is still used.** Refusing every login because the provider is briefly unreachable is worse than trusting public keys a few hours past their max-age.

## Tests

21 new, in `tests/portal.oidc-hardening.test.js`. They generate a real RSA keypair and sign real RS256 ID tokens, so the verification path is genuinely exercised rather than stubbed. Suite goes **177 → 198**.

**14 of the 21 fail on `main`** — I ran them there rather than assuming.

The #161 tests are built the awkward way on purpose. Swapping a header and keeping the original signature proves nothing: the HMAC covers the header, so the signature check rejects it with or without the fix, and that test passes either way. They sign the swapped header correctly with the secret instead — which is what an attacker holds in a real alg-confusion — so they actually fail on `main`. There is a control test alongside them establishing that the helper produces something the verifier would otherwise accept.

Build clean, lint clean on every touched file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KYe7CfXDuLYS79EhzXbPx2