### PR TITLE
fix(prerender): stop waiting on IG embeds so the deploy job stops timing out

### DIFF
--- a/scripts/prerender.mjs
+++ b/scripts/prerender.mjs
@@ -85,11 +85,43 @@ async function main() {
 
   const browser = await chromium.launch();
   const page = await browser.newPage();
+
+  // Instagram embeds on /placements (see placement.js records with
+  // `instagram_url`) load `embed.js` and one iframe per card from
+  // instagram.com/www.cdninstagram.com. Those iframes keep the network
+  // busy long after the SPA has finished rendering — a video prefetch here,
+  // a metrics ping there — so `waitUntil: "networkidle"` was never reaching
+  // idle inside the 30s timeout once the fallback list carried more than
+  // one IG record. Abort every request to IG's origins during the snapshot;
+  // InstagramEmbed's blockquote fallback anchor stays visible, which is
+  // what a crawler should see anyway (a real link to the post, not an
+  // opaque iframe), and the client-side script still runs on the real
+  // page load for actual visitors. Same treatment for cdninstagram.com
+  // (media) and platform-lookaside.fbsbx.com (avatar CDN) so no lingering
+  // media request pins the network open.
+  await page.route("**/*", (route) => {
+    const host = new URL(route.request().url()).hostname;
+    if (
+      host === "www.instagram.com" ||
+      host === "instagram.com" ||
+      host.endsWith(".cdninstagram.com") ||
+      host.endsWith(".fbsbx.com")
+    ) {
+      return route.abort();
+    }
+    return route.continue();
+  });
+
   let ok = 0;
 
   for (const route of routes) {
     const target = base + route.path;
-    await page.goto(target, { waitUntil: "networkidle", timeout: 30000 });
+    // `waitUntil: "load"` fires after the SPA's scripts and stylesheets are
+    // in, without waiting for arbitrarily-lingering third-party requests.
+    // The `waitForSelector` below is what actually confirms the SPA rendered
+    // the route's own content — the network-idle wait was double-insurance
+    // that we no longer need, and which broke with IG embeds on the page.
+    await page.goto(target, { waitUntil: "load", timeout: 30000 });
     await page.waitForSelector(route.waitFor, { timeout: 20000 });
 
     // React 19 hoists per-route <title>/<meta> into a <head> that already holds


### PR DESCRIPTION
## Regression

[This deploy failed](https://github.com/Rest-coder-academy/trca/actions/runs/34328984303) — the Cloudflare Pages job hung on \`/placements\` waiting for \`networkidle\` and never got past it. Root cause: with 10 IG embeds in the fallback list (from #175), IG's iframes keep the network busy indefinitely with video prefetches and metrics pings, so \`networkidle\` never fires inside the 30s timeout.

## Fix

Two changes on the prerender path only. The live SPA is not touched.

1. **\`waitUntil: "load"\` instead of \`"networkidle"\`.** The \`waitForSelector\` after already gates on the SPA having rendered the route's own content (\`main.pl\` for /placements, \`main.cd\` for course pages, etc.). Network-idle was double-insurance that broke the moment we put more than one third-party embed on a page.

2. **Abort every request to \`instagram.com\`, \`*.cdninstagram.com\`, \`*.fbsbx.com\` during the snapshot.** \`InstagramEmbed\`'s blockquote fallback anchor stays visible — a real \"See NAME on Instagram\" link, which is what a crawler should get anyway. The client-side script still runs for actual visitors on real page load, so the embed itself is unchanged in the browser.

## Verified locally

\`\`\`
$ npm run prerender
prerendered /                                      → index.html
prerendered /for-parents                           → for-parents.html
prerendered /placements                            → placements.html         ← was hanging here
prerendered /contact                               → contact.html
prerendered /faq                                   → faq.html
prerendered /blog                                  → blog.html
prerendered /blog/… (6 posts)                      → …
prerendered /about                                 → about.html
prerendered /courses/… (4 courses)                 → …
prerender: 17/17 routes written.
\`\`\`

\`~10s\` total (was hanging at 30s on \`/placements\` before, then aborting the whole job).

## Side benefit

This removes an entire class of flake. Whenever a future PR adds a third-party embed anywhere on any prerendered route — YouTube, LinkedIn, Twitter — \`networkidle\` would have started missing again. Now the SPA renders and we move on.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_014PnGG9Moyg9MTGr3j3vmHy

🤖 Generated with [Claude Code](https://claude.com/claude-code)