### PR TITLE
feat(placements): emit Instagram post URLs as Person `sameAs` in JSON-LD

### DIFF
--- a/src/components/Pages/PlacementsPage.jsx
+++ b/src/components/Pages/PlacementsPage.jsx
@@ -63,7 +63,18 @@ function PlacementsPage() {
               ...(p.journey ? { description: p.journey } : {}),
             }
           : undefined,
-        ...(p.linkedin ? { sameAs: [p.linkedin] } : {}),
+        // `sameAs` links the Person entity to authoritative external URLs
+        // that identify the same real person. LinkedIn is the classic
+        // fit; @restcoderacademy's placement announcement Reels are the
+        // second — the post is a first-party record of the placement with
+        // the student's face, salary and role in RCA's own captioned
+        // graphic, which SGE and AI Overviews follow when asked to
+        // verify "where a graduate ended up". Emit both when we have them;
+        // omit the whole field if neither is set, so the schema stays
+        // valid rather than carrying an empty array.
+        ...((p.linkedin || p.instagram_url)
+          ? { sameAs: [p.linkedin, p.instagram_url].filter(Boolean) }
+          : {}),
       })),
       {
         "@type": "ItemList",


### PR DESCRIPTION
## What

The /placements JSON-LD generator only put `linkedin` into `sameAs`. All ten IG-embed records from #175 have `instagram_url` but no `linkedin`, so all ten Person entries shipped with **no `sameAs`** at all — the exact schema signal AI answer engines use to verify a Person across domains.

## Why it matters

SGE, AI Overviews and Perplexity read `sameAs` to link a Person named on our page to authoritative records elsewhere. A `@restcoderacademy` placement Reel is a first-party record with the student's face, the salary and RCA's own captioned graphic — stronger verification than anything we could self-host.

## The change

Five lines in `PlacementsPage.jsx`:

```diff
-        ...(p.linkedin ? { sameAs: [p.linkedin] } : {}),
+        ...((p.linkedin || p.instagram_url)
+          ? { sameAs: [p.linkedin, p.instagram_url].filter(Boolean) }
+          : {}),
```

- Emits the LinkedIn URL when set.
- Emits the Instagram URL when set.
- Filters out falsies so a Person with only `instagram_url` gets `sameAs: [\"…instagram…\"]`, not `[null, \"…\"]`.
- Omits `sameAs` entirely when neither is set — the schema stays valid, no empty arrays.

## Verified

```
$ npm run prerender
prerender: 17/17 routes written.

$ python3 …parse dist/placements.html…
Person entries total: 10
Person entries with sameAs: 10
  Manideepika              → ['https://www.instagram.com/reel/DdBgLQntnNb/']
  Selvaraj Nandhini        → ['https://www.instagram.com/reel/Dc_A6hYteGI/']
  Kota Akshay Rathna Kumar → ['https://www.instagram.com/p/Dc5o-Uatcxz/']
```

## Forward compatibility

When new placements are added via the admin portal (#158), setting `instagram_url` on the D1 row automatically enriches the schema graph the same way — no further code change needed for future entries. Same is true for `linkedin` when a graduate hands one over.

## No downside

- Zero visible changes to the page.
- No CSS, no component structure, no data.
- Existing e2e specs untouched.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_014PnGG9Moyg9MTGr3j3vmHy

🤖 Generated with [Claude Code](https://claude.com/claude-code)