### PR TITLE
fix(clients): normalise wordmark heights so the row stops reading as jumbled

### DIFF
--- a/e2e/clients.spec.js
+++ b/e2e/clients.spec.js
@@ -37,3 +37,43 @@ test("logos keep their aspect ratio instead of being cropped to a circle", async
   const logo = page.locator("#Clients .card-content img").first();
   await expect(logo).toHaveCSS("object-fit", "contain");
 });
+
+test("every visible logo renders at a consistent size", async ({ page }) => {
+  // Nikshep on 2026-09-09: the row read as "jumbled" because each wordmark
+  // rendered at its intrinsic aspect ratio — Mindtree at 47px, Accenture and
+  // Wipro at 197px, others in between — producing a very uneven visual
+  // rhythm across the tile row. The fix caps every image at max-height 70px,
+  // which normalises visual weight. Guard the outcome, not the specific
+  // number: every logo in the visible window should render within a small
+  // envelope of every other one.
+  await page.setViewportSize({ width: 1440, height: 900 });
+  await page.goto("/");
+
+  // Only measure logos whose top-left is roughly inside the viewport; slick's
+  // clones and off-screen slides can be at extreme negative x and their
+  // heights are irrelevant to what a visitor sees.
+  const visibleHeights = await page.evaluate(() => {
+    return [...document.querySelectorAll("#Clients .card-content img")]
+      .map((img) => {
+        const r = img.getBoundingClientRect();
+        return { h: Math.round(r.height), x: Math.round(r.left) };
+      })
+      .filter((r) => r.x >= -50 && r.x < window.innerWidth + 50 && r.h > 0)
+      .map((r) => r.h);
+  });
+
+  expect(visibleHeights.length, "at least four logos visible").toBeGreaterThanOrEqual(4);
+  const maxH = Math.max(...visibleHeights);
+  const minH = Math.min(...visibleHeights);
+  // Envelope: no logo should render more than 25px taller than any other in
+  // the visible window. That's tight enough to catch a Mindtree-vs-Accenture
+  // regression (150px difference on live before the fix) but loose enough to
+  // allow the natural aspect-ratio variance within the 70px cap.
+  expect(
+    maxH - minH,
+    `logo heights varied by ${maxH - minH}px (min ${minH}, max ${maxH}) — jumble regressed`,
+  ).toBeLessThanOrEqual(25);
+  // Also cap absolute size — 70px is the CSS value; anything much larger
+  // means the CSS regression escaped.
+  expect(maxH, "no logo should render taller than the CSS cap").toBeLessThanOrEqual(80);
+});

--- a/src/components/organism/clients/Clients.css
+++ b/src/components/organism/clients/Clients.css
@@ -55,14 +55,30 @@
   display: flex;
   justify-content: center;
   align-items: center;
+  /* Give the image's `max-height: 100%` a real containing block to resolve
+     against. Without this the card-content shrink-wraps around the img
+     and 100% falls back to auto, so each logo renders at whatever its
+     intrinsic aspect ratio dictates — Mindtree at 47px, Accenture at
+     197px, etc., which reads as visually jumbled at a glance. Filling the
+     full card gives every logo the same envelope to sit inside. */
+  width: 100%;
+  height: 100%;
 }
 
 /* Wordmarks are rectangular. The old rule cropped them to a circle with
    border-radius: 50% and stretched them to fill, which cut the ends off
-   longer logos (Tech Mahindra, Capgemini). Contain keeps each mark whole. */
+   longer logos (Tech Mahindra, Capgemini). Contain keeps each mark whole.
+   The explicit pixel max-height + max-width normalises visual weight
+   across a set of logos whose intrinsic aspect ratios range from square
+   (Accenture, Wipro) to very wide-and-short (Mindtree, Capgemini). The
+   tile is 10rem = 160px tall, so 70px caps the tallest logo at roughly
+   half the tile — plenty of breathing room, and every wordmark reads at
+   comparable size regardless of source. */
 .clients .card-content img {
-  max-width: 100%;
-  max-height: 100%;
+  max-width: 75%;
+  max-height: 70px;
+  width: auto;
+  height: auto;
   object-fit: contain;
 }
 


### PR DESCRIPTION
## What Nikshep saw

The \"Our students work at\" row rendered as jumble — each logo tile was the same width, but each wordmark inside sat at its own intrinsic height. Live inspection at 1440×900:

| Wordmark | Displayed height |
|---|---|
| Accenture | 197 px |
| Capgemini | 110 px |
| Mindtree | 47 px |
| Wipro | 197 px |
| Tech Mahindra | 197 px |
| HCL Technologies | 158 px |
| SKAD | 77 px |
| Infosys | 158 px |
| Integra | 140 px |

That's a 150 px spread across the visible row — reads as inconsistent at a glance, especially with the square-ish logos (Accenture, Wipro) filling their tiles while the wide-and-short ones (Mindtree, Capgemini) look tiny.

## Root cause

The img rule said \`max-height: 100%\` on \`.card-content\`, but \`.card-content\` had no explicit height — it shrink-wrapped around the img — so \`100%\` fell back to auto, and every logo rendered at whatever its natural aspect ratio dictated when scaled to fit the 197 px tile width.

## Fix

Two blocks in \`Clients.css\`:

- Card-content now fills the tile (\`width: 100%; height: 100%\`), so \`%\` sizing on the image resolves properly against a real containing block.
- Image cap: \`max-width: 75%; max-height: 70px; width: auto; height: auto; object-fit: contain\`. Every wordmark sits inside the same 70 px envelope, centred, aspect-preserved.

## Test

Adds one spec to \`e2e/clients.spec.js\`:

> **every visible logo renders at a consistent size**

- Measures \`.card-content img\` in the visible carousel window.
- Asserts \`max - min ≤ 25 px\` across all visible logos.
- Asserts \`max ≤ 80 px\` absolute cap.
- Guards against a future rule that would let a single logo blow past the row rhythm again.

The existing three \`clients.spec.js\` tests are untouched.

## Verified

\`24/24 e2e specs pass in 19.1s\` locally.

## No visible-content changes

Copy stays \"Our students work at,\" tile borders unchanged, no logo added or removed, no schema affected. Only the visual normalisation.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_014PnGG9Moyg9MTGr3j3vmHy

🤖 Generated with [Claude Code](https://claude.com/claude-code)