### PR TITLE
fix(clients): restore visible gap between adjacent logo tiles

### DIFF
--- a/e2e/clients.spec.js
+++ b/e2e/clients.spec.js
@@ -38,6 +38,36 @@ test("logos keep their aspect ratio instead of being cropped to a circle", async
   await expect(logo).toHaveCSS("object-fit", "contain");
 });
 
+test("adjacent tiles have a visible horizontal gap", async ({ page }) => {
+  // Nikshep on 2026-09-09: the row read as one continuous strip because the
+  // single-sided `margin-left` on `.card` was swallowed by slick's slide-width
+  // math — tiles sat flush border-to-border. Symmetric `margin: 0 8px` +
+  // `width: calc(100% - 16px)` restores a real 16px gap between adjacent tiles.
+  // Guard the outcome: any two neighbouring tiles in the visible window should
+  // have at least 10px of clear space between them.
+  await page.setViewportSize({ width: 1440, height: 900 });
+  await page.goto("/");
+
+  const rects = await page.evaluate(() => {
+    return [...document.querySelectorAll("#Clients .card")]
+      .map((el) => {
+        const r = el.getBoundingClientRect();
+        return { left: Math.round(r.left), right: Math.round(r.right) };
+      })
+      .filter((r) => r.left >= -50 && r.left < window.innerWidth + 50)
+      .sort((a, b) => a.left - b.left);
+  });
+
+  expect(rects.length, "at least three tiles visible for gap checks").toBeGreaterThanOrEqual(3);
+  for (let i = 1; i < rects.length; i++) {
+    const gap = rects[i].left - rects[i - 1].right;
+    expect(
+      gap,
+      `adjacent tiles ${i - 1}→${i} touched (gap=${gap}px, expected ≥10px)`,
+    ).toBeGreaterThanOrEqual(10);
+  }
+});
+
 test("every visible logo renders at a consistent size", async ({ page }) => {
   // Nikshep on 2026-09-09: the row read as "jumbled" because each wordmark
   // rendered at its intrinsic aspect ratio — Mindtree at 47px, Accenture and

--- a/src/components/organism/clients/Clients.css
+++ b/src/components/organism/clients/Clients.css
@@ -41,9 +41,17 @@
   display: flex;
   justify-content: center;
   align-items: center;
-  width: 94%;
+  /* Symmetric horizontal margin creates a visible 16px gap between adjacent
+     tiles (8px + 8px). The original single-sided `margin-left` was swallowed
+     by slick's slide-width math, so tile borders sat flush against each
+     other and the row read as one continuous strip instead of separate
+     tiles. `calc(100% - 16px)` shrinks the tile to fit inside the slide
+     with room for the two 8px margins; `!important` on the width is needed
+     because MUI's own `MuiCard-root` class ships a width rule that would
+     otherwise re-inflate the tile to slide edge. */
+  width: calc(100% - 16px) !important;
   height: 10rem;
-  margin-left: var(--rca-space-2);
+  margin: 0 8px;
   border: 1px solid var(--rca-blue);
   /* radius-lg is the card radius the course cards use; this tile was on
      radius-sm (4px), the chip value, so it read as a different family. */


### PR DESCRIPTION
## What Nikshep saw

Adjacent tiles in the "Our students work at" row sat flush border-to-border. Measured on live at 1440×900: every adjacent pair had a **0 px** gap between them. The 1px blue borders touching each other made the row look like one continuous outlined shape rather than five separate tiles.

## Root cause

Two rules on \`.clients .card\`:
- \`width: 94%\` — left 6% of each slide as gutter, but slick then packed the slides edge-to-edge so the gutter fell inside the next slide, not between the tiles.
- \`margin-left: var(--rca-space-2)\` (one-sided) — swallowed by slick's slide-width math and didn't push the next tile away.

And MUI's own \`MuiCard-root\` ships a width rule that re-inflated the card past any un-\`!important\` value, which is why an earlier attempt with \`width: calc(100% - 16px)\` (no \`!important\`) had zero effect on the computed style.

## Fix

Two lines on \`.clients .card\`:

\`\`\`css
width: calc(100% - 16px) !important;
margin: 0 8px;
\`\`\`

Card is now 16px narrower than the slide with 8px symmetric margins, so adjacent tiles get a real 16px gap between them. \`!important\` on the width is needed only because MUI's own class ships a competing rule; nothing else.

## Test

Adds one spec to \`e2e/clients.spec.js\`:

> **adjacent tiles have a visible horizontal gap**

- Measures \`#Clients .card\` left/right in the visible carousel window.
- Asserts \`gap ≥ 10px\` between every neighbouring pair.
- Guards against a future edit that would let them touch again.

## Verified

\`25/25 e2e specs pass in 20.1s\` locally.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_014PnGG9Moyg9MTGr3j3vmHy

🤖 Generated with [Claude Code](https://claude.com/claude-code)