### PR TITLE
feat(portal): carry the session from the browser into the app's WebView (closes #163)

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,18 +250,65 @@ at the end of the callback.
 
 ```
 npx wrangler d1 execute restcoder-enquiries --file=./schema-users.sql
+npx wrangler d1 execute restcoder-enquiries --file=./schema-native-handoff.sql
 ```
+
+The second table is only used by the Android app — see *Signing in inside the
+app* below. Without it, web sign-in works and app sign-in fails.
 
 ### The endpoints
 
 | Route | What it does |
 |---|---|
 | `GET /auth/:provider/start` | redirect to consent, with PKCE + state in HttpOnly cookies. **503 when unconfigured.** |
-| `GET /auth/:provider/callback` | exchange the code, **verify the ID token against the provider's JWKS**, upsert into `users`, issue the session cookie |
+| `GET /auth/:provider/callback` | exchange the code, **verify the ID token against the provider's JWKS**, upsert into `users`, issue the session cookie — or, for the app, redirect to `rca://` with a one-time code |
+| `POST /auth/native/exchange` | the app trades that code for a session cookie in its own WebView |
 | `GET /auth/me` | the current user, or 401. Also reports which providers are configured. |
 | `POST /auth/logout` | clear the session cookie |
 | `GET /api/portal/courses` | the signed-in student's enrolled courses, or 401 |
 | `GET /api/portal/courses/:slug` | one enrolled course with its published lessons. **404 when the student is not enrolled**, so slugs cannot be probed. |
+
+### Signing in inside the app (#163)
+
+Sign-in in the app is not the web flow in a smaller window, because two things
+about Android make it impossible for it to be.
+
+**Google refuses OAuth in an embedded WebView** (`disallowed_useragent`), so
+consent has to run in a Custom Tab. That is a different browser with a
+different cookie jar, so the callback's `Set-Cookie` lands somewhere the app
+cannot read. Coming back over `rca://auth/callback` resumes the app but does
+not sign it in — its next `/auth/me` is still a 401.
+
+So the deep link carries a **one-time code** rather than the session:
+
+1. Before opening the Custom Tab, the app generates a verifier and sends only
+   its SHA-256 to `/auth/:provider/start?native=1&hc=…`. The flag and the
+   digest are kept in HttpOnly cookies, so the callback cannot be told it is
+   native by anything that can reach its URL.
+2. The callback finishes the normal verified flow, then — instead of setting a
+   cookie in a browser the student will never look at again — stores the
+   session behind a one-time code and redirects to `rca://auth/callback?code=…`.
+3. The app posts that code **and the verifier** to `/auth/native/exchange`
+   **from inside its WebView**. That is the whole trick: the response's
+   `Set-Cookie` lands in the jar the app actually uses.
+
+Android lets **any** installed app register `rca://`, so the redirect can be
+intercepted. The verifier is what makes that not matter — it never travels
+through the URL, so an intercepted code redeems nothing. Codes are also
+single-use and expire in 90 seconds.
+
+Because the app is served from `https://localhost` (Capacitor's
+`androidScheme`), its portal calls are cross-origin. `shared/nativeCors.js`
+allowlists exactly the Capacitor origins, and the app's session cookie is
+issued `SameSite=None` — the website's stays `SameSite=Lax`. The two surfaces
+have separate cookie jars and each gets its own variant.
+
+`src/lib/apiBase.js` is what points the app at `https://restcoderacademy.in`
+instead of at itself; override it for a staging build with `VITE_API_ORIGIN`.
+
+> **Not yet provable end to end.** All of the above is code. Actually signing
+> in still needs the owner-provisioned OAuth clients and secrets above — until
+> those exist, the app's login screen correctly says "coming soon".
 
 ### Course content (Phase 2)
 

--- a/android/app/capacitor.build.gradle
+++ b/android/app/capacitor.build.gradle
@@ -9,6 +9,8 @@ android {
 
 apply from: "../capacitor-cordova-android-plugins/cordova.variables.gradle"
 dependencies {
+    implementation project(':capacitor-app')
+    implementation project(':capacitor-browser')
     implementation project(':capacitor-splash-screen')
 
 }

--- a/android/capacitor.settings.gradle
+++ b/android/capacitor.settings.gradle
@@ -2,5 +2,11 @@
 include ':capacitor-android'
 project(':capacitor-android').projectDir = new File('../node_modules/@capacitor/android/capacitor')
 
+include ':capacitor-app'
+project(':capacitor-app').projectDir = new File('../node_modules/@capacitor/app/android')
+
+include ':capacitor-browser'
+project(':capacitor-browser').projectDir = new File('../node_modules/@capacitor/browser/android')
+
 include ':capacitor-splash-screen'
 project(':capacitor-splash-screen').projectDir = new File('../node_modules/@capacitor/splash-screen/android')

--- a/docs/OAUTH-SETUP.md
+++ b/docs/OAUTH-SETUP.md
@@ -80,6 +80,17 @@ Environment variables → **add as Secret (encrypted)**, for Production:
 | `MS_CLIENT_SECRET` | the secret **Value** from step 2 |
 | `MS_TENANT` | `common` |
 
+There is also one table to create, for the Android app only:
+
+```bash
+npx wrangler d1 execute restcoder-enquiries --remote --file=schema-native-handoff.sql
+```
+
+Skipping it does not break the website. It breaks sign-in **in the app only**,
+and does so at the last step, after the student has already been through
+consent — which looks like the app rejecting a correct login. Worth running at
+the same time as the secrets so that never happens.
+
 Generate `SESSION_SECRET` with:
 
 ```bash
@@ -135,6 +146,11 @@ has to happen server-side where the client secret lives. So both providers
 redirect to this site's own origin, and the native shell is handed back at the
 end of the callback via the `rca://` deep link the app already registers. Do
 not create an "Android" OAuth client type — it will not be used.
+
+This also means **the redirect URIs above are the only ones to register**. The
+`rca://` hand-off happens entirely between our own callback and our own app,
+after the provider is done; neither Google nor Microsoft ever sees it. See
+*Signing in inside the app* in the README for how that hand-off works.
 
 **The Microsoft secret expires.** Google's client secret does not. Microsoft's
 does, on whatever expiry you chose. Diary it.

--- a/functions/api/portal/courses.js
+++ b/functions/api/portal/courses.js
@@ -3,27 +3,33 @@
 // response is specific to one student.
 import { getSession } from "../../../shared/auth.js";
 import { listEnrolledCourses } from "../../../shared/courses.js";
+import { nativeCorsHeaders, nativeCorsPreflight } from "../../../shared/nativeCors.js";
 
-const json = (body, status = 200) =>
+const json = (body, status = 200, extra = {}) =>
   new Response(JSON.stringify(body), {
     status,
-    headers: { "content-type": "application/json", "cache-control": "no-store" },
+    headers: { "content-type": "application/json", "cache-control": "no-store", ...extra },
   });
+
+// Cross-origin from the Android shell, which serves the bundle off
+// `https://localhost` (#163).
+export const onRequestOptions = ({ request }) => nativeCorsPreflight(request);
 
 export async function onRequestGet(context) {
   const { request, env } = context;
+  const cors = nativeCorsHeaders(request);
 
   const session = await getSession(request, env);
-  if (!session) return json({ error: "unauthenticated" }, 401);
+  if (!session) return json({ error: "unauthenticated" }, 401, cors);
 
   // No D1 binding is a server fault, not an empty course list. Returning []
   // here would tell a student who has enrolments that they have none.
-  if (!env.DB) return json({ error: "unavailable" }, 503);
+  if (!env.DB) return json({ error: "unavailable" }, 503, cors);
 
   try {
     const courses = await listEnrolledCourses(env.DB, session.uid);
-    return json({ courses });
+    return json({ courses }, 200, cors);
   } catch {
-    return json({ error: "unavailable" }, 503);
+    return json({ error: "unavailable" }, 503, cors);
   }
 }

--- a/functions/api/portal/courses/[slug].js
+++ b/functions/api/portal/courses/[slug].js
@@ -5,28 +5,34 @@
 // outsider should be able to learn by guessing slugs.
 import { getSession } from "../../../../shared/auth.js";
 import { getEnrolledCourse } from "../../../../shared/courses.js";
+import { nativeCorsHeaders, nativeCorsPreflight } from "../../../../shared/nativeCors.js";
 
-const json = (body, status = 200) =>
+const json = (body, status = 200, extra = {}) =>
   new Response(JSON.stringify(body), {
     status,
-    headers: { "content-type": "application/json", "cache-control": "no-store" },
+    headers: { "content-type": "application/json", "cache-control": "no-store", ...extra },
   });
+
+// Cross-origin from the Android shell, which serves the bundle off
+// `https://localhost` (#163).
+export const onRequestOptions = ({ request }) => nativeCorsPreflight(request);
 
 export async function onRequestGet(context) {
   const { request, env, params } = context;
+  const cors = nativeCorsHeaders(request);
 
   const session = await getSession(request, env);
-  if (!session) return json({ error: "unauthenticated" }, 401);
-  if (!env.DB) return json({ error: "unavailable" }, 503);
+  if (!session) return json({ error: "unauthenticated" }, 401, cors);
+  if (!env.DB) return json({ error: "unavailable" }, 503, cors);
 
   const slug = String(params.slug || "");
-  if (!slug) return json({ error: "not_found" }, 404);
+  if (!slug) return json({ error: "not_found" }, 404, cors);
 
   try {
     const course = await getEnrolledCourse(env.DB, session.uid, slug);
-    if (!course) return json({ error: "not_found" }, 404);
-    return json({ course });
+    if (!course) return json({ error: "not_found" }, 404, cors);
+    return json({ course }, 200, cors);
   } catch {
-    return json({ error: "unavailable" }, 503);
+    return json({ error: "unavailable" }, 503, cors);
   }
 }

--- a/functions/auth/[provider]/callback.js
+++ b/functions/auth/[provider]/callback.js
@@ -2,17 +2,43 @@
 // the provider's JWKS, upsert the user in D1, and issue our own session (#42).
 import { signSession, sessionCookie, readCookie } from "../../../shared/auth.js";
 import { isConfigured, providerConfig, redirectUri, verifyIdToken } from "../../../shared/oidc.js";
+import { mintHandoffCode } from "../../../shared/nativeHandoff.js";
+
+const TX_COOKIES = [
+  "rca_oauth_state",
+  "rca_oauth_verifier",
+  "rca_oauth_nonce",
+  "rca_oauth_next",
+  "rca_oauth_native",
+  "rca_oauth_hc",
+];
 
 const clearTx = (headers) => {
-  for (const n of ["rca_oauth_state", "rca_oauth_verifier", "rca_oauth_nonce", "rca_oauth_next"]) {
+  for (const n of TX_COOKIES) {
     headers.append("set-cookie", `${n}=; HttpOnly; Secure; SameSite=Lax; Path=/auth; Max-Age=0`);
   }
 };
 
-// Errors go back to the login screen as a code in the query string, so the UI
-// can say something useful. Nothing from the provider is echoed into the page.
-function fail(reason) {
-  const headers = new Headers({ location: `/portal/login?error=${encodeURIComponent(reason)}` });
+// Whether this transaction was started by the Android shell (#163). Read from
+// the HttpOnly cookie our own /start set, never from this request's query
+// string — the callback URL is public and anything could add `native=1` to it.
+const isNative = (request) => readCookie(request, "rca_oauth_native") === "1";
+
+/**
+ * Errors go back as a code, so the UI can say something useful. Nothing from
+ * the provider is echoed into the page.
+ *
+ * A native flow is failing inside a Custom Tab, where /portal/login would be a
+ * dead end: the student would be looking at a login screen in a browser that
+ * is not the app, with the app still sitting behind it on its own login
+ * screen. So the failure is sent back over the deep link too, and the app
+ * shows the message itself.
+ */
+function fail(request, reason) {
+  const location = isNative(request)
+    ? `rca://auth/callback?error=${encodeURIComponent(reason)}`
+    : `/portal/login?error=${encodeURIComponent(reason)}`;
+  const headers = new Headers({ location });
   clearTx(headers);
   return new Response(null, { status: 302, headers });
 }
@@ -20,18 +46,18 @@ function fail(reason) {
 export async function onRequestGet(context) {
   const { request, env, params } = context;
   const provider = String(params.provider || "");
-  if (!isConfigured(provider, env)) return fail("not_configured");
+  if (!isConfigured(provider, env)) return fail(request, "not_configured");
 
   const url = new URL(request.url);
   // The user pressed "cancel" on the consent screen.
-  if (url.searchParams.get("error")) return fail("cancelled");
+  if (url.searchParams.get("error")) return fail(request, "cancelled");
 
   const code = url.searchParams.get("code");
   const state = url.searchParams.get("state");
   const expectedState = readCookie(request, "rca_oauth_state");
   const verifier = readCookie(request, "rca_oauth_verifier");
   if (!code || !state || !expectedState || state !== expectedState || !verifier) {
-    return fail("bad_state");
+    return fail(request, "bad_state");
   }
 
   const cfg = providerConfig(provider, env);
@@ -50,22 +76,22 @@ export async function onRequestGet(context) {
         code_verifier: verifier,
       }),
     });
-    if (!res.ok) return fail("token_exchange");
+    if (!res.ok) return fail(request, "token_exchange");
     tokens = await res.json();
   } catch {
-    return fail("token_exchange");
+    return fail(request, "token_exchange");
   }
-  if (!tokens.id_token) return fail("token_exchange");
+  if (!tokens.id_token) return fail(request, "token_exchange");
 
   // The nonce cookie is set by our own start endpoint, so a request that
   // arrives without one did not begin here (#159).
   const expectedNonce = readCookie(request, "rca_oauth_nonce");
-  if (!expectedNonce) return fail("bad_state");
+  if (!expectedNonce) return fail(request, "bad_state");
 
   const claims = await verifyIdToken(tokens.id_token, cfg, fetch, expectedNonce);
-  if (!claims) return fail("bad_token");
+  if (!claims) return fail(request, "bad_token");
 
-  if (!env.DB) return fail("storage");
+  if (!env.DB) return fail(request, "storage");
   let user;
   try {
     await env.DB.prepare(
@@ -84,9 +110,9 @@ export async function onRequestGet(context) {
       .first();
     user = row;
   } catch {
-    return fail("storage");
+    return fail(request, "storage");
   }
-  if (!user) return fail("storage");
+  if (!user) return fail(request, "storage");
 
   const token = await signSession(
     { uid: user.id, email: user.email, name: user.name, picture: user.picture, role: user.role, provider },
@@ -96,6 +122,39 @@ export async function onRequestGet(context) {
   const nextRaw = readCookie(request, "rca_oauth_next");
   const next = nextRaw ? decodeURIComponent(nextRaw) : "/portal";
   const safeNext = next.startsWith("/") && !next.startsWith("//") ? next : "/portal";
+
+  // --- Native shell: hand the session over, do not set a cookie here (#163).
+  //
+  // We are running in the system browser. Setting the session cookie now would
+  // put a live 30-day session in a cookie jar the app never reads and the
+  // student never sees — useless to them and a real credential sitting outside
+  // the app. So the browser gets no cookie at all: it gets a one-time code,
+  // and the app exchanges it for the cookie from inside its own WebView.
+  if (isNative(request)) {
+    const challenge = readCookie(request, "rca_oauth_hc");
+    // Set together by /start, so one without the other is not a state we can
+    // mint against.
+    if (!challenge) return fail(request, "bad_state");
+
+    // Named apart from the `code` above: that one is the provider's
+    // authorization code, already spent. This is ours, and means something else.
+    let handoffCode;
+    try {
+      handoffCode = await mintHandoffCode(env.DB, token, challenge);
+    } catch {
+      return fail(request, "storage");
+    }
+
+    // `next` rides along so the app lands where the student was headed. It has
+    // already been narrowed to a same-site path above.
+    const deepLink = new URL("rca://auth/callback");
+    deepLink.searchParams.set("code", handoffCode);
+    deepLink.searchParams.set("next", safeNext);
+
+    const headers = new Headers({ location: deepLink.toString() });
+    clearTx(headers);
+    return new Response(null, { status: 302, headers });
+  }
 
   const headers = new Headers({ location: safeNext });
   clearTx(headers);

--- a/functions/auth/[provider]/start.js
+++ b/functions/auth/[provider]/start.js
@@ -7,6 +7,11 @@ import { codeChallenge, isConfigured, providerConfig, randomString, redirectUri 
 
 const TX_TTL = 600; // 10 minutes is longer than any real consent screen takes
 
+// A base64url SHA-256 digest and nothing else. The value is echoed back into a
+// D1 row, so it is pinned to an exact shape here rather than trusted for being
+// short.
+const S256_B64URL = /^[A-Za-z0-9_-]{43}$/;
+
 function txCookie(name, value) {
   return `${name}=${value}; HttpOnly; Secure; SameSite=Lax; Path=/auth; Max-Age=${TX_TTL}`;
 }
@@ -34,8 +39,25 @@ export async function onRequestGet(context) {
 
   // Where to land inside the app afterwards. Only a same-site path is kept —
   // an absolute URL here would make this an open redirect.
-  const requested = new URL(request.url).searchParams.get("next") || "/portal";
+  const query = new URL(request.url).searchParams;
+  const requested = query.get("next") || "/portal";
   const next = requested.startsWith("/") && !requested.startsWith("//") ? requested : "/portal";
+
+  // Is this flow being run for the Android shell (#163)?
+  //
+  // The app opens this URL in a Custom Tab and presents `hc` — the SHA-256 of
+  // a verifier it generated and kept. Both are recorded in the transaction
+  // cookies now, so the callback reads them from a jar only this origin can
+  // write (HttpOnly, Path=/auth) rather than from its own query string, which
+  // anything that can reach the callback could supply. That is the same
+  // unforgeability the ticket asked for from `state`, using the mechanism the
+  // rest of this transaction already uses.
+  //
+  // A malformed or absent challenge means the flow simply is not native: it
+  // completes as a normal web sign-in rather than failing. The only way to
+  // reach the deep-link branch is to have presented a well-formed one.
+  const handoffChallenge = query.get("hc");
+  const native = query.get("native") === "1" && S256_B64URL.test(String(handoffChallenge));
 
   const url = new URL(cfg.authorize);
   url.searchParams.set("client_id", cfg.clientId);
@@ -55,5 +77,9 @@ export async function onRequestGet(context) {
   headers.append("set-cookie", txCookie("rca_oauth_verifier", verifier));
   headers.append("set-cookie", txCookie("rca_oauth_nonce", nonce));
   headers.append("set-cookie", txCookie("rca_oauth_next", encodeURIComponent(next)));
+  if (native) {
+    headers.append("set-cookie", txCookie("rca_oauth_native", "1"));
+    headers.append("set-cookie", txCookie("rca_oauth_hc", handoffChallenge));
+  }
   return new Response(null, { status: 302, headers });
 }

--- a/functions/auth/logout.js
+++ b/functions/auth/logout.js
@@ -1,14 +1,29 @@
 // POST /auth/logout — clear the session cookie. POST rather than GET so a
 // prefetch or an <img> cannot sign a student out.
 import { clearSessionCookie } from "../../shared/auth.js";
+import {
+  clearNativeSessionCookie,
+  isAllowedNativeOrigin,
+  nativeCorsHeaders,
+  nativeCorsPreflight,
+} from "../../shared/nativeCors.js";
 
-export async function onRequestPost() {
+export const onRequestOptions = ({ request }) => nativeCorsPreflight(request);
+
+export async function onRequestPost({ request }) {
+  // The cookie has to be cleared with the attributes it was set with, and the
+  // app's was issued `SameSite=None` so it would be sent cross-site at all
+  // (#163). Clearing it as `Lax` from a cross-site response would be rejected,
+  // and the student would tap "sign out" and stay signed in.
+  const native = isAllowedNativeOrigin(request.headers.get("origin"));
+
   return new Response(JSON.stringify({ ok: true }), {
     status: 200,
     headers: {
       "content-type": "application/json",
       "cache-control": "no-store",
-      "set-cookie": clearSessionCookie(),
+      ...nativeCorsHeaders(request),
+      "set-cookie": native ? clearNativeSessionCookie() : clearSessionCookie(),
     },
   });
 }

--- a/functions/auth/me.js
+++ b/functions/auth/me.js
@@ -3,19 +3,25 @@
 // configured, so the UI never has to guess.
 import { getSession } from "../../shared/auth.js";
 import { configuredProviders } from "../../shared/oidc.js";
+import { nativeCorsHeaders, nativeCorsPreflight } from "../../shared/nativeCors.js";
 
-const json = (body, status) =>
+const json = (body, status, extra = {}) =>
   new Response(JSON.stringify(body), {
     status,
     // A session-bearing response must never be cached by a proxy or the app shell.
-    headers: { "content-type": "application/json", "cache-control": "no-store" },
+    headers: { "content-type": "application/json", "cache-control": "no-store", ...extra },
   });
+
+// The Android shell calls this from `https://localhost`, so it is cross-origin
+// there and needs both the preflight and the credentialed CORS headers (#163).
+export const onRequestOptions = ({ request }) => nativeCorsPreflight(request);
 
 export async function onRequestGet(context) {
   const { request, env } = context;
+  const cors = nativeCorsHeaders(request);
   const providers = configuredProviders(env);
   const session = await getSession(request, env);
-  if (!session) return json({ authenticated: false, providers }, 401);
+  if (!session) return json({ authenticated: false, providers }, 401, cors);
   return json(
     {
       authenticated: true,
@@ -29,5 +35,6 @@ export async function onRequestGet(context) {
       },
     },
     200,
+    cors,
   );
 }

--- a/functions/auth/native/exchange.js
+++ b/functions/auth/native/exchange.js
@@ -1,0 +1,78 @@
+// POST /auth/native/exchange — turn a one-time hand-off code into a session
+// cookie in the app's WebView (#163).
+//
+// This is the request that fixes the cookie-jar mismatch, purely by virtue of
+// who makes it. The consent flow ran in a Custom Tab, so the callback's
+// Set-Cookie went to the system browser. This request comes *from the WebView*,
+// so this response's Set-Cookie goes where the app will actually read it. The
+// hand-off code is only the means of carrying the session across; the jar is
+// decided by the caller.
+import { verifySession } from "../../../shared/auth.js";
+import { redeemHandoffCode } from "../../../shared/nativeHandoff.js";
+import { nativeCorsHeaders, nativeCorsPreflight, nativeSessionCookie } from "../../../shared/nativeCors.js";
+
+const json = (body, status, extra = {}) =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json", "cache-control": "no-store", ...extra },
+  });
+
+export const onRequestOptions = ({ request }) => nativeCorsPreflight(request);
+
+export async function onRequestPost(context) {
+  const { request, env } = context;
+  const cors = nativeCorsHeaders(request);
+
+  // Same shape of refusal for every failure below. An interceptor holding a
+  // code it cannot redeem must not learn whether the code was unknown, spent,
+  // expired, or real-but-paired-with-the-wrong-verifier — the last would tell
+  // it the code is live and worth continuing to attack.
+  const refuse = () => json({ error: "invalid_code" }, 400, cors);
+
+  if (!env.SESSION_SECRET || !env.DB) return json({ error: "not_configured" }, 503, cors);
+
+  let body;
+  try {
+    body = await request.json();
+  } catch {
+    return refuse();
+  }
+
+  const code = body && typeof body.code === "string" ? body.code : null;
+  const verifier = body && typeof body.verifier === "string" ? body.verifier : null;
+  if (!code || !verifier) return refuse();
+
+  let token;
+  try {
+    token = await redeemHandoffCode(env.DB, code, verifier);
+  } catch {
+    return json({ error: "storage" }, 503, cors);
+  }
+  if (!token) return refuse();
+
+  // The row held a JWT we signed ourselves a moment ago, so this should never
+  // fail. It is checked anyway because this is the one place a value out of the
+  // database becomes a session cookie: were a row ever tampered with, the HMAC
+  // is what stops the tampered token being handed straight back out.
+  const session = await verifySession(token, env.SESSION_SECRET);
+  if (!session) return refuse();
+
+  // The user is returned with the cookie so the app can render the student home
+  // immediately. On the metered rural connections this portal is built for
+  // (#111), a second round trip to /auth/me right after sign-in is a real cost
+  // for something we already have in hand.
+  return json(
+    {
+      authenticated: true,
+      user: {
+        id: session.uid,
+        email: session.email,
+        name: session.name,
+        picture: session.picture,
+        role: session.role || "student",
+      },
+    },
+    200,
+    { ...cors, "set-cookie": nativeSessionCookie(token) },
+  );
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,8 @@
       "version": "0.0.0",
       "dependencies": {
         "@capacitor/android": "^8.5.1",
+        "@capacitor/app": "^8.1.1",
+        "@capacitor/browser": "^8.0.4",
         "@capacitor/core": "^8.5.1",
         "@capacitor/splash-screen": "^8.0.2",
         "@emotion/react": "^11.14.0",
@@ -96,7 +98,6 @@
       "integrity": "sha512-l+lkXCHS6tQEc5oUpK28xBOZ6+HwaH7YwoYQbLFiYb4nS2/l1tKnZEtEWkD0GuiYdvArf9qBS0XlQGXzPMsNqQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.26.2",
@@ -366,6 +367,15 @@
       "license": "MIT",
       "peerDependencies": {
         "@capacitor/core": "^8.5.0"
+      }
+    },
+    "node_modules/@capacitor/app": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/@capacitor/app/-/app-8.1.1.tgz",
+      "integrity": "sha512-xM2ZTX5jK60tFtmjsmJv+Cdj1Qsb6NcavkqmdEnCPQBeya9oKhamZJxYOnQNj1ZvcJM7sWfG6BEtSLx42pisbA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@capacitor/core": ">=8.0.0"
       }
     },
     "node_modules/@capacitor/assets": {
@@ -816,6 +826,15 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/@capacitor/browser": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/@capacitor/browser/-/browser-8.0.4.tgz",
+      "integrity": "sha512-ORZ4u/y+7aMuu6yVuk6SP529fUZyqcbnuHB1q5McpA3o2SYfVoi28iB8rsQjI2ad1qlKJd29ZUuGtspXLBDlWg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@capacitor/core": ">=8.0.0"
+      }
+    },
     "node_modules/@capacitor/cli": {
       "version": "8.5.1",
       "resolved": "https://registry.npmjs.org/@capacitor/cli/-/cli-8.5.1.tgz",
@@ -875,7 +894,6 @@
       "resolved": "https://registry.npmjs.org/@capacitor/core/-/core-8.5.1.tgz",
       "integrity": "sha512-IOQ7ynG1qgrJ/RLuCO3WgyRGmkmmG/cdStRR4ftU2dWEN1FdtLrnI/XpZmZuUsOEHEnzBRJY/PmRH8eTLiXfhA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -1099,7 +1117,6 @@
       "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.14.0.tgz",
       "integrity": "sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -1143,7 +1160,6 @@
       "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.14.0.tgz",
       "integrity": "sha512-XxfOnXFffatap2IyCeJyNov3kiDQWoR08gPUQxvbL7fxKryGBKUZUkG6Hz48DZwVrJSVh9sJboyV1Ds4OW6SgA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -2748,7 +2764,6 @@
       "resolved": "https://registry.npmjs.org/@mui/material/-/material-6.4.4.tgz",
       "integrity": "sha512-ISVPrIsPQsxnwvS40C4u03AuNSPigFeS2+n1qpuEZ94hDsdMi19dQM2JcC9CHEhXecSIQjP1RTyY0mPiSpSrFQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.26.0",
         "@mui/core-downloads-tracker": "^6.4.4",
@@ -3046,7 +3061,6 @@
       "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
       "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
@@ -3698,7 +3712,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.0.8.tgz",
       "integrity": "sha512-9P/o1IGdfmQxrujGbIMDyYaaCykhLKc0NGCtYcECNUr9UAaDe4gwvV9bR6tvd5Br1SG0j+PBpbKr2UYY8CwqSw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -3900,7 +3913,6 @@
       "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4452,7 +4464,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001688",
         "electron-to-chromium": "^1.5.73",
@@ -5578,7 +5589,6 @@
       "integrity": "sha512-m1mM33o6dBUjxl2qb6wv6nGNwCAsns1eKtaQ4l/NPHeTvhiUPbtdfMyktxN4B3fgHIgsYh1VT3V9txblpQHq+g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -8386,7 +8396,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.0.0.tgz",
       "integrity": "sha512-V8AVnmPIICiWpGfm6GLzCR/W5FXLchHop40W4nXBmdlEceh16rCN8O8LNWm5bh5XUX91fh7KpA+W0TgMKmgTpQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -8396,7 +8405,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.0.0.tgz",
       "integrity": "sha512-4GV5sHFG0e/0AD4X+ySy6UJd3jVl1iNsNHdpad0qhABJ11twS3TTBnseqsKurKcsNqCEFeGL3uLpVChpIO3QfQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.25.0"
       },
@@ -9555,7 +9563,6 @@
       "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-6.1.15.tgz",
       "integrity": "sha512-PpOTEztW87Ua2xbmLa7yssjNyUF9vE7wdldRfn1I2E6RTkqknkBYpj771OxM/xrvRGinLy2oysa7GOd7NcZZIA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@emotion/is-prop-valid": "1.2.2",
         "@emotion/unitless": "0.8.1",
@@ -10144,7 +10151,6 @@
       "integrity": "sha512-RjjMipCKVoR4hVfPY6GQTgveinjNuyLw+qruksLDvA5ktI1150VmcMBKmQaEWJhg/j6Uaf6dNCNA0AfdzUb/hQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.24.2",
         "postcss": "^8.5.1",
@@ -10730,7 +10736,6 @@
       "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "2.1.9",
         "@vitest/mocker": "2.1.9",
@@ -11254,7 +11259,6 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,8 @@
   },
   "dependencies": {
     "@capacitor/android": "^8.5.1",
+    "@capacitor/app": "^8.1.1",
+    "@capacitor/browser": "^8.0.4",
     "@capacitor/core": "^8.5.1",
     "@capacitor/splash-screen": "^8.0.2",
     "@emotion/react": "^11.14.0",

--- a/schema-native-handoff.sql
+++ b/schema-native-handoff.sql
@@ -1,0 +1,38 @@
+-- One-time hand-off codes that carry a session from the system browser into
+-- the Android app's WebView (#163).
+--
+-- Why a table at all, when the portal is otherwise stateless (schema-users.sql):
+-- the two cookie jars are the whole problem. OAuth consent has to run in a
+-- Custom Tab because Google refuses embedded WebViews, so the callback's
+-- Set-Cookie lands in the *browser's* jar. The app's WebView has its own. The
+-- only thing that can cross is a value in the redirect URL, and a session in a
+-- URL is a session in the Android logs and in every app that registered the
+-- same scheme. So the URL carries a reference instead, and this is what it
+-- refers to.
+--
+-- Rows are short-lived by design: minted at the end of a verified callback,
+-- deleted the moment they are redeemed, and useless after HANDOFF_TTL_SECONDS.
+CREATE TABLE IF NOT EXISTS native_handoff (
+  -- SHA-256 of the code, never the code. A row is a bearer session for its
+  -- ~60s life, and this table will end up in a D1 backup and on an admin
+  -- screen; storing the digest means neither yields anything redeemable.
+  code_hash  TEXT PRIMARY KEY,
+
+  -- SHA-256 of the verifier the app generated *before* it opened the Custom
+  -- Tab. Android lets any app claim `rca://`, so an interceptor can read the
+  -- code straight out of the redirect. It cannot produce the verifier, which
+  -- never left the legitimate app, so the code alone redeems nothing.
+  challenge  TEXT NOT NULL,
+
+  -- The signed session JWT this code hands over, minted by the callback from
+  -- the transaction that has already been through PKCE and JWKS verification.
+  session    TEXT NOT NULL,
+
+  expires_at INTEGER NOT NULL,                      -- unix seconds
+  created_at INTEGER NOT NULL
+);
+
+-- Swept opportunistically on mint, so an abandoned sign-in does not leave a
+-- row behind for good.
+CREATE INDEX IF NOT EXISTS idx_native_handoff_expires
+  ON native_handoff (expires_at);

--- a/shared/nativeCors.js
+++ b/shared/nativeCors.js
@@ -1,0 +1,84 @@
+// CORS for the requests the Android shell makes (#163).
+//
+// The app runs the same bundle the website does, but Capacitor serves it from
+// `https://localhost`, so every call it makes to the portal API is
+// cross-origin. That is the trade for keeping a bundled, offline-capable shell
+// instead of pointing the WebView at the live site.
+//
+// The allowlist is exact and closed. It exists to let *our own app* talk to the
+// API, not to open the portal to browsers: a real website that wanted this
+// would have to be served from `localhost`, and a page there still could not
+// read a response it is not allowed an origin for.
+
+const ALLOWED = new Set([
+  "https://localhost", // Capacitor Android, androidScheme: "https"
+  "capacitor://localhost", // Capacitor iOS, if the shell ever ships there
+  "http://localhost", // `cap run` with live reload
+]);
+
+export function isAllowedNativeOrigin(origin) {
+  return typeof origin === "string" && ALLOWED.has(origin);
+}
+
+/**
+ * CORS headers for `request`, or `{}` when the origin is not ours.
+ *
+ * The origin is echoed rather than answered with `*`: a wildcard is invalid
+ * alongside `Allow-Credentials: true`, and credentials are the entire point —
+ * without them the session cookie is neither sent nor stored.
+ *
+ * `Vary: Origin` keeps Cloudflare's cache from serving the app's CORS headers
+ * to a website visitor, or the other way round.
+ */
+export function nativeCorsHeaders(request) {
+  const origin = request.headers.get("origin");
+  if (!isAllowedNativeOrigin(origin)) return { vary: "Origin" };
+  return {
+    "access-control-allow-origin": origin,
+    "access-control-allow-credentials": "true",
+    vary: "Origin",
+  };
+}
+
+/** Preflight response for the portal routes the app calls. */
+export function nativeCorsPreflight(request) {
+  const headers = nativeCorsHeaders(request);
+  if (!headers["access-control-allow-origin"]) return new Response(null, { status: 403 });
+  return new Response(null, {
+    status: 204,
+    headers: {
+      ...headers,
+      "access-control-allow-methods": "GET, POST, OPTIONS",
+      "access-control-allow-headers": "content-type",
+      "access-control-max-age": "86400",
+    },
+  });
+}
+
+/**
+ * The session cookie the app needs.
+ *
+ * `SameSite=Lax` is right for the website and wrong here: from
+ * `https://localhost` the API is a different site, so a Lax cookie is never
+ * sent and the app is signed out on its next request. `None` is the only value
+ * that works cross-site, and it requires `Secure`.
+ *
+ * This weakens nothing on the web. The two surfaces have separate cookie jars
+ * and each is issued its own variant — the browser's stays Lax, and only a
+ * response to the app's own exchange carries this one.
+ */
+export function nativeSessionCookie(token, maxAge = 60 * 60 * 24 * 30) {
+  return `rca_session=${token}; HttpOnly; Secure; SameSite=None; Path=/; Max-Age=${maxAge}`;
+}
+
+/**
+ * Clearing that same cookie.
+ *
+ * The attributes have to match the ones it was set with or the browser treats
+ * this as a different cookie and leaves the real one in place — and a
+ * cross-site response that omits `SameSite=None` is rejected outright, which
+ * would leave a student who tapped "sign out" still signed in.
+ */
+export function clearNativeSessionCookie() {
+  return `rca_session=; HttpOnly; Secure; SameSite=None; Path=/; Max-Age=0`;
+}

--- a/shared/nativeHandoff.js
+++ b/shared/nativeHandoff.js
@@ -1,0 +1,124 @@
+// Handing a session from the system browser into the app's WebView (#163).
+//
+// The problem this solves is not authentication — by the time anything here
+// runs, the student has already been through consent, PKCE and JWKS
+// verification, and `functions/auth/[provider]/callback.js` has a signed
+// session for them. The problem is *where that session ends up*.
+//
+// Google returns `disallowed_useragent` for OAuth inside an embedded WebView,
+// so the consent flow has to run in a Custom Tab. The callback therefore runs
+// in the system browser, and its `Set-Cookie` lands in the browser's cookie
+// jar. The Capacitor WebView has a separate jar and cannot read it. Resuming
+// the app over `rca://` does not change that: the app comes back to the
+// foreground still signed out, and its next `/auth/me` is a 401.
+//
+// So the redirect carries a reference to the session rather than the session.
+// The app posts that reference back *from inside the WebView*, and the
+// response's Set-Cookie lands in the jar that will actually be used.
+//
+// The threat that shapes the rest of this file: Android lets **any** installed
+// app register `rca://`. An interceptor can be handed the redirect and read
+// the code out of it. Two things make that not enough to steal a session:
+//
+//   1. The code is single-use and lives about a minute.
+//   2. Redeeming it also requires a verifier the app generated before it
+//      opened the Custom Tab, and which never travelled through the URL.
+//
+// (2) is the load-bearing one — it is PKCE applied to the hand-off itself. (1)
+// only narrows the window.
+
+import { safeEqual } from "./serverUtil.js";
+
+const enc = new TextEncoder();
+
+export const HANDOFF_TTL_SECONDS = 90;
+
+// Long enough that consent, the token exchange and the app's resume all fit;
+// short enough that a code recovered from a log later is already dead. 90s
+// rather than 60 because a cold Custom Tab on a rural connection is slow, and
+// the failure mode of "too short" is a student who cannot sign in at all.
+
+function b64url(bytes) {
+  const s = btoa(String.fromCharCode(...new Uint8Array(bytes)));
+  return s.replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+/** SHA-256 → base64url. The one hash used for both the code and the verifier. */
+export async function sha256b64url(value) {
+  const digest = await crypto.subtle.digest("SHA-256", enc.encode(String(value)));
+  return b64url(digest);
+}
+
+/** A fresh hand-off code. 32 bytes from the CSPRNG — this is a bearer value. */
+export function newHandoffCode() {
+  return b64url(crypto.getRandomValues(new Uint8Array(32)));
+}
+
+/**
+ * Store `session` behind a one-time code and return the code.
+ *
+ * `challenge` is the app's `S256(verifier)`, taken from the transaction rather
+ * than from the callback's query string — see the `start` endpoint.
+ */
+export async function mintHandoffCode(db, session, challenge, now = Math.floor(Date.now() / 1000)) {
+  const code = newHandoffCode();
+  const codeHash = await sha256b64url(code);
+
+  // Sweep first. Abandoned sign-ins — consent screens that were closed, apps
+  // killed mid-flow — are the common case, not the rare one, and nothing else
+  // ever visits these rows to clean them up.
+  await db.prepare("DELETE FROM native_handoff WHERE expires_at <= ?1").bind(now).run();
+
+  await db
+    .prepare(
+      "INSERT INTO native_handoff (code_hash, challenge, session, expires_at, created_at) " +
+        "VALUES (?1, ?2, ?3, ?4, ?5)",
+    )
+    .bind(codeHash, challenge, session, now + HANDOFF_TTL_SECONDS, now)
+    .run();
+
+  return code;
+}
+
+/**
+ * Redeem a code. Returns the session JWT, or null.
+ *
+ * Single-use is enforced by the DELETE's row count rather than by the SELECT
+ * that precedes it: two requests can both read the row, but only one DELETE
+ * can report having removed it, and only that one is handed the session. Doing
+ * it this way — rather than `DELETE ... RETURNING` — keeps the guarantee in
+ * plain SQL that any SQLite honours.
+ *
+ * Every rejection returns the same `null`. The caller must not tell an
+ * interceptor whether the code was wrong, expired, already spent, or right
+ * with a wrong verifier; the last of those would confirm a code is live and
+ * worth attacking.
+ */
+export async function redeemHandoffCode(db, code, verifier, now = Math.floor(Date.now() / 1000)) {
+  if (!code || !verifier) return null;
+
+  const codeHash = await sha256b64url(code);
+  const row = await db
+    .prepare("SELECT challenge, session, expires_at FROM native_handoff WHERE code_hash = ?1")
+    .bind(codeHash)
+    .first();
+  if (!row) return null;
+
+  // Burn it whatever happens next. A wrong verifier against a real code is an
+  // attack on that code, not a typo to be retried — the legitimate app always
+  // has the right verifier. Letting it stand would leave a known-live code in
+  // the table for the rest of its TTL.
+  const del = await db.prepare("DELETE FROM native_handoff WHERE code_hash = ?1").bind(codeHash).run();
+  const removedByUs = del && del.meta && del.meta.changes === 1;
+  if (!removedByUs) return null;
+
+  if (Number(row.expires_at) <= now) return null;
+
+  const presented = await sha256b64url(verifier);
+  // Constant-time: the compared values are digests, so a timing leak would
+  // only expose a hash prefix, but this is the comparison that decides whether
+  // a session is handed over and it costs nothing to do properly.
+  if (!safeEqual(presented, row.challenge)) return null;
+
+  return row.session;
+}

--- a/src/components/portal/PortalCourse.jsx
+++ b/src/components/portal/PortalCourse.jsx
@@ -4,6 +4,7 @@ import ArrowBackRoundedIcon from "@mui/icons-material/ArrowBackRounded";
 import PortalSkeleton from "./PortalSkeleton";
 import { formatDuration } from "./coursesCache";
 import "./Portal.css";
+import { apiCredentials, apiUrl } from "../../lib/apiBase";
 
 /**
  * /portal/courses/:slug — one course and its lessons (#137).
@@ -22,8 +23,8 @@ function PortalCourse() {
     let live = true;
     (async () => {
       try {
-        const res = await fetch(`/api/portal/courses/${encodeURIComponent(slug)}`, {
-          credentials: "same-origin",
+        const res = await fetch(apiUrl(`/api/portal/courses/${encodeURIComponent(slug)}`), {
+          credentials: apiCredentials(),
         });
         if (!live) return;
         if (res.status === 404) return setState({ status: "not_found", course: null });

--- a/src/components/portal/PortalLogin.jsx
+++ b/src/components/portal/PortalLogin.jsx
@@ -1,6 +1,9 @@
 import PropTypes from "prop-types";
+import { useState } from "react";
 import { useLocation, Navigate, Link } from "react-router-dom";
 import { usePortalSession } from "./usePortalSession";
+import { beginNativeSignIn } from "./nativeAuth";
+import { isNative } from "../../lib/apiBase";
 import PortalSkeleton from "./PortalSkeleton";
 import "./Portal.css";
 
@@ -25,6 +28,10 @@ const ERRORS = {
   bad_token: "We could not verify that sign-in. Please try again.",
   storage: "We could not save your account just now. Please try again shortly.",
   not_configured: "Student sign-in is not switched on yet.",
+  // Only reachable in the app (#163): the hand-off back from the browser did
+  // not complete. Says "start again" because that is genuinely the fix — the
+  // one-time code is spent either way.
+  offline: "We could not reach the academy to finish signing you in. Please try again.",
 };
 
 function ProviderMark({ name }) {
@@ -51,10 +58,13 @@ function ProviderMark({ name }) {
 ProviderMark.propTypes = { name: PropTypes.string.isRequired };
 
 function PortalLogin() {
-  const { status, providers } = usePortalSession();
+  const { status, providers, authError } = usePortalSession();
+  const [busy, setBusy] = useState(null);
   const location = useLocation();
   const params = new URLSearchParams(location.search);
-  const errorKey = params.get("error");
+  // In the app the failure comes back through the deep-link listener rather
+  // than a query string, because the callback never lands on this origin.
+  const errorKey = authError || params.get("error");
   const error = errorKey ? ERRORS[errorKey] || ERRORS.token_exchange : null;
 
   if (status === "loading") return <PortalSkeleton />;
@@ -62,6 +72,7 @@ function PortalLogin() {
 
   const next = (location.state && location.state.from) || "/portal";
   const offline = status === "offline";
+  const native = isNative();
 
   return (
     <main className="portal portal-login">
@@ -94,16 +105,44 @@ function PortalLogin() {
           </div>
         )}
 
-        {providers.map((p) => (
-          <a
-            key={p}
-            className="portal-provider"
-            href={`/auth/${p}/start?next=${encodeURIComponent(next)}`}
-          >
-            <ProviderMark name={p} />
-            <span>Sign in with {PROVIDER_LABEL[p] || p}</span>
-          </a>
-        ))}
+        {providers.map((p) =>
+          native ? (
+            // In the app this cannot be a link. A plain navigation would run
+            // consent inside the WebView, which Google rejects outright, so the
+            // flow is opened in a Custom Tab instead (#163).
+            <button
+              key={p}
+              type="button"
+              className="portal-provider"
+              disabled={Boolean(busy)}
+              onClick={async () => {
+                setBusy(p);
+                try {
+                  await beginNativeSignIn(p, next);
+                } finally {
+                  // The Custom Tab is up; the app is paused until the deep link
+                  // brings it back. Clearing this now means the button is live
+                  // again if the student cancels and returns.
+                  setBusy(null);
+                }
+              }}
+            >
+              <ProviderMark name={p} />
+              <span>
+                {busy === p ? "Opening…" : `Sign in with ${PROVIDER_LABEL[p] || p}`}
+              </span>
+            </button>
+          ) : (
+            <a
+              key={p}
+              className="portal-provider"
+              href={`/auth/${p}/start?next=${encodeURIComponent(next)}`}
+            >
+              <ProviderMark name={p} />
+              <span>Sign in with {PROVIDER_LABEL[p] || p}</span>
+            </a>
+          ),
+        )}
 
         <p className="portal-login-foot">
           Not a student yet? <Link to="/">See our courses</Link>

--- a/src/components/portal/nativeAuth.js
+++ b/src/components/portal/nativeAuth.js
@@ -1,0 +1,157 @@
+// The app's half of the sign-in hand-off (#163).
+//
+// On the website, signing in is a link: the browser follows it, the callback
+// sets a cookie on the same origin, done. In the app none of that holds.
+// Google refuses OAuth inside an embedded WebView, so consent has to run in a
+// Custom Tab — a different browser, with a different cookie jar. The app comes
+// back over `rca://auth/callback` holding a one-time code, and swaps it for a
+// cookie from inside its own WebView, which is the only way the cookie lands
+// somewhere the app will read it.
+//
+// The verifier below is what makes that code safe to put in a URL. Android
+// lets any installed app claim `rca://`, so the redirect can be intercepted;
+// the verifier never leaves this app, and without it the code redeems nothing.
+import { apiUrl } from "../../lib/apiBase";
+
+const VERIFIER_KEY = "rca_native_handoff_verifier";
+const VERIFIER_TTL_MS = 10 * 60 * 1000;
+
+function b64url(bytes) {
+  let s = "";
+  for (const b of bytes) s += String.fromCharCode(b);
+  return btoa(s).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+async function s256(value) {
+  const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(value));
+  return b64url(new Uint8Array(digest));
+}
+
+/**
+ * Kept in localStorage rather than a module variable.
+ *
+ * While the Custom Tab is in front, Android is free to kill the app to reclaim
+ * memory — on the low-end phones this portal is built for, that is routine
+ * rather than exceptional. A module variable would be gone on resume and the
+ * student would be bounced back to the login screen with no explanation. This
+ * survives that.
+ *
+ * It is a short-lived, single-use secret in the app's own sandbox, which no
+ * other app can read; it is cleared the moment it is spent.
+ */
+function rememberVerifier(verifier) {
+  try {
+    localStorage.setItem(VERIFIER_KEY, JSON.stringify({ v: verifier, t: Date.now() }));
+  } catch {
+    // Private mode or a full disk. The flow still works for as long as the app
+    // stays alive — the exchange reads it back below and falls through to a
+    // normal failure if it cannot.
+  }
+}
+
+function takeVerifier() {
+  let raw = null;
+  try {
+    raw = localStorage.getItem(VERIFIER_KEY);
+    localStorage.removeItem(VERIFIER_KEY);
+  } catch {
+    return null;
+  }
+  if (!raw) return null;
+  try {
+    const { v, t } = JSON.parse(raw);
+    // A verifier older than the consent flow could possibly take is left over
+    // from an abandoned attempt, not this one.
+    if (!v || !t || Date.now() - t > VERIFIER_TTL_MS) return null;
+    return v;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Open the provider's consent screen in a Custom Tab.
+ *
+ * Deliberately not the app's own WebView: Google answers that with
+ * `disallowed_useragent`, and deliberately not an arbitrary external browser
+ * either — a Custom Tab keeps the flow inside our task, so the deep link comes
+ * back to us rather than to whatever happens to hold the intent.
+ */
+export async function beginNativeSignIn(provider, next = "/portal") {
+  const verifier = b64url(crypto.getRandomValues(new Uint8Array(32)));
+  const challenge = await s256(verifier);
+  rememberVerifier(verifier);
+
+  const url = apiUrl(
+    `/auth/${encodeURIComponent(provider)}/start` +
+      `?native=1&hc=${encodeURIComponent(challenge)}&next=${encodeURIComponent(next)}`,
+  );
+
+  const { Browser } = await import("@capacitor/browser");
+  await Browser.open({ url, presentationStyle: "popover" });
+}
+
+/**
+ * Handle an inbound `rca://auth/callback`.
+ *
+ * Returns the signed-in user, or throws with a reason the login screen already
+ * knows how to phrase. Returns null when the URL is not ours to handle, so the
+ * caller can ignore other deep links without special-casing them.
+ */
+export async function completeNativeSignIn(rawUrl) {
+  let url;
+  try {
+    url = new URL(rawUrl);
+  } catch {
+    return null;
+  }
+  if (url.protocol !== "rca:" || url.host !== "auth") return null;
+
+  // The Custom Tab is still covering the app at this point; nothing below
+  // renders until it is out of the way.
+  try {
+    const { Browser } = await import("@capacitor/browser");
+    await Browser.close();
+  } catch {
+    // Already closed, or the plugin is unavailable. Not worth failing over.
+  }
+
+  const failed = url.searchParams.get("error");
+  if (failed) throw new Error(failed);
+
+  const code = url.searchParams.get("code");
+  const verifier = takeVerifier();
+  // No verifier means this app did not start the flow it is being handed —
+  // either it was killed and lost it, or another app is replaying a code at us.
+  if (!code || !verifier) throw new Error("bad_state");
+
+  let res;
+  try {
+    res = await fetch(apiUrl("/auth/native/exchange"), {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      // The whole point of this request: it is made from the WebView, so the
+      // Set-Cookie on the response lands in the jar the app actually uses.
+      credentials: "include",
+      body: JSON.stringify({ code, verifier }),
+    });
+  } catch {
+    throw new Error("offline");
+  }
+
+  if (!res.ok) throw new Error(res.status === 503 ? "not_configured" : "bad_state");
+
+  const body = await res.json().catch(() => null);
+  if (!body || !body.authenticated) throw new Error("bad_state");
+  return body.user || null;
+}
+
+/** Where the app should land afterwards, as encoded by the callback. */
+export function nextFromCallback(rawUrl) {
+  try {
+    const next = new URL(rawUrl).searchParams.get("next") || "/portal";
+    return next.startsWith("/") && !next.startsWith("//") ? next : "/portal";
+  } catch {
+    return "/portal";
+  }
+}

--- a/src/components/portal/useCourses.js
+++ b/src/components/portal/useCourses.js
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useState } from "react";
+import { apiCredentials, apiUrl } from "../../lib/apiBase";
 import { readCache, writeCache } from "./coursesCache";
 
 /**
@@ -29,7 +30,7 @@ export function useCourses(userId) {
     }
 
     try {
-      const res = await fetch("/api/portal/courses", { credentials: "same-origin" });
+      const res = await fetch(apiUrl("/api/portal/courses"), { credentials: apiCredentials() });
       if (!res.ok) {
         // 503 means the academy's side is down. If a saved copy is already on
         // screen it stays there; there is nothing better to show.

--- a/src/components/portal/usePortalSession.js
+++ b/src/components/portal/usePortalSession.js
@@ -1,4 +1,6 @@
 import { useCallback, useEffect, useState } from "react";
+import { apiCredentials, apiUrl, isNative } from "../../lib/apiBase";
+import { completeNativeSignIn } from "./nativeAuth";
 
 /**
  * The portal's session, read from GET /auth/me (#110).
@@ -16,10 +18,13 @@ export function usePortalSession() {
   const [status, setStatus] = useState("loading");
   const [user, setUser] = useState(null);
   const [providers, setProviders] = useState([]);
+  // Set when a native hand-off fails; the login screen renders it the same way
+  // it renders the ?error= the web callback redirects with.
+  const [authError, setAuthError] = useState(null);
 
   const load = useCallback(async () => {
     try {
-      const res = await fetch("/auth/me", { credentials: "same-origin" });
+      const res = await fetch(apiUrl("/auth/me"), { credentials: apiCredentials() });
       const body = await res.json().catch(() => ({}));
       setProviders(Array.isArray(body.providers) ? body.providers : []);
       if (res.ok && body.authenticated) {
@@ -41,9 +46,54 @@ export function usePortalSession() {
     load();
   }, [load]);
 
+  /**
+   * The app coming back from the Custom Tab (#163).
+   *
+   * Registered here rather than on the login screen because the deep link can
+   * arrive at any time — Android may have destroyed and rebuilt the activity
+   * while consent was on screen, so whatever route the app resumes on has to
+   * be able to receive it. This hook is mounted for the whole portal.
+   *
+   * The listener is what actually finishes sign-in: `appUrlOpen` only tells us
+   * the app was resumed, and resuming is not the same as being signed in.
+   */
+  useEffect(() => {
+    if (!isNative()) return undefined;
+
+    let cancelled = false;
+    let remove = null;
+
+    (async () => {
+      const { App } = await import("@capacitor/app");
+      const handle = await App.addListener("appUrlOpen", async ({ url }) => {
+        try {
+          const signedIn = await completeNativeSignIn(url);
+          if (cancelled || signedIn === null) return;
+          setUser(signedIn);
+          setStatus("authenticated");
+          setAuthError(null);
+        } catch (err) {
+          if (cancelled) return;
+          // Back to the login screen with something to say, rather than a
+          // silent bounce the student cannot act on.
+          setAuthError(err && err.message ? err.message : "bad_state");
+          setUser(null);
+          setStatus("anonymous");
+        }
+      });
+      if (cancelled) handle.remove();
+      else remove = () => handle.remove();
+    })();
+
+    return () => {
+      cancelled = true;
+      if (remove) remove();
+    };
+  }, []);
+
   const logout = useCallback(async () => {
     try {
-      await fetch("/auth/logout", { method: "POST", credentials: "same-origin" });
+      await fetch(apiUrl("/auth/logout"), { method: "POST", credentials: apiCredentials() });
     } catch {
       // Ignore: the cookie may already be gone, and the screen below still
       // needs to return the student to the login page either way.
@@ -52,5 +102,5 @@ export function usePortalSession() {
     setStatus("anonymous");
   }, []);
 
-  return { status, user, providers, reload: load, logout };
+  return { status, user, providers, authError, reload: load, logout };
 }

--- a/src/lib/apiBase.js
+++ b/src/lib/apiBase.js
@@ -1,0 +1,56 @@
+// Where the portal's API lives, seen from wherever this bundle is running.
+//
+// On the website these are same-origin paths and this is a no-op. Inside the
+// Android shell it is not: Capacitor serves the bundled build from
+// `https://localhost` (`androidScheme: "https"`), so a relative `/auth/me`
+// resolves to `https://localhost/auth/me` — a host with no API on it. Every
+// portal request in the app was resolving there, which is why the app's portal
+// could only ever report itself offline (#163).
+//
+// So on native the origin is made explicit. That makes portal requests
+// cross-origin, which is the price of keeping the bundled, offline-capable
+// shell that #109/#111 built rather than pointing the WebView at the live site
+// and giving that up.
+
+const PROD_ORIGIN = "https://restcoderacademy.in";
+
+// Set at build time for a staging APK. Vite inlines it, so it cannot be
+// changed after `cap sync` — which is the point: a shipped app should not be
+// re-pointable at another origin by anything it later loads.
+const CONFIGURED = (import.meta.env && import.meta.env.VITE_API_ORIGIN) || "";
+
+/**
+ * True when this bundle is running inside the Capacitor WebView.
+ *
+ * Read off the global the native bridge injects rather than the user agent,
+ * which is spoofable and, on Android, close enough to Chrome's to be a
+ * coin-flip. `isNativePlatform` is absent on the web, so the fallback is the
+ * web behaviour.
+ */
+export function isNative() {
+  const cap = typeof globalThis !== "undefined" ? globalThis.Capacitor : undefined;
+  return Boolean(cap && typeof cap.isNativePlatform === "function" && cap.isNativePlatform());
+}
+
+/** The API origin, or "" on the web so paths stay relative. */
+export function apiOrigin() {
+  if (!isNative()) return "";
+  return CONFIGURED || PROD_ORIGIN;
+}
+
+/** `apiUrl("/auth/me")` — absolute in the app, untouched on the web. */
+export function apiUrl(path) {
+  return `${apiOrigin()}${path}`;
+}
+
+/**
+ * The credentials mode to pair with `apiUrl`.
+ *
+ * `same-origin` would drop the session cookie on every request the app makes,
+ * because from `https://localhost` the API is a different origin. `include` is
+ * required there and is deliberately *not* used on the web, where
+ * `same-origin` remains the tighter choice.
+ */
+export function apiCredentials() {
+  return isNative() ? "include" : "same-origin";
+}

--- a/tests/portal.api-base.test.js
+++ b/tests/portal.api-base.test.js
@@ -1,0 +1,56 @@
+// #163 — where the portal's API is, seen from the web and from the app.
+//
+// This decides two things that are invisible until they are wrong: whether a
+// request goes to an origin that has an API on it, and whether the session
+// cookie is sent with it. Getting either wrong in the app looks like being
+// permanently signed out.
+import { describe, it, expect, afterEach } from "vitest";
+import { apiCredentials, apiOrigin, apiUrl, isNative } from "../src/lib/apiBase.js";
+
+const asNative = (on) => {
+  if (on) globalThis.Capacitor = { isNativePlatform: () => true };
+  else delete globalThis.Capacitor;
+};
+
+afterEach(() => asNative(false));
+
+describe("on the website", () => {
+  it("keeps paths relative, so nothing becomes cross-origin", () => {
+    expect(apiOrigin()).toBe("");
+    expect(apiUrl("/auth/me")).toBe("/auth/me");
+  });
+
+  it("keeps the tighter credentials mode", () => {
+    expect(apiCredentials()).toBe("same-origin");
+  });
+
+  it("does not think it is native", () => {
+    expect(isNative()).toBe(false);
+  });
+});
+
+describe("inside the app", () => {
+  it("addresses the real API rather than the bundle's own origin", () => {
+    // Capacitor serves the build from https://localhost, where a relative
+    // /auth/me resolves to a host with no API on it — the bug this fixes.
+    asNative(true);
+    expect(apiUrl("/auth/me")).toBe("https://restcoderacademy.in/auth/me");
+  });
+
+  it("sends credentials, which same-origin would silently drop", () => {
+    asNative(true);
+    expect(apiCredentials()).toBe("include");
+  });
+});
+
+describe("detecting the shell", () => {
+  it("reads the injected bridge, not the user agent", () => {
+    // Android's WebView UA is close enough to Chrome's to be a coin flip, and
+    // is spoofable besides.
+    globalThis.Capacitor = { isNativePlatform: () => false };
+    expect(isNative()).toBe(false);
+
+    globalThis.Capacitor = {};
+    expect(isNative()).toBe(false);
+  });
+});

--- a/tests/portal.auth.test.js
+++ b/tests/portal.auth.test.js
@@ -173,7 +173,9 @@ describe("GET /auth/me", () => {
 
 describe("POST /auth/logout", () => {
   it("clears the session cookie", async () => {
-    const res = await logoutPost();
+    // Takes the request since #163: the attributes it clears with depend on
+    // whether the caller is the website or the app's WebView.
+    const res = await logoutPost({ request: new Request("https://x.test/auth/logout", { method: "POST" }) });
     expect(res.status).toBe(200);
     const cookie = res.headers.get("set-cookie");
     expect(cookie).toMatch(/rca_session=;/);

--- a/tests/portal.native-handoff.test.js
+++ b/tests/portal.native-handoff.test.js
@@ -1,0 +1,508 @@
+// #163 — carrying a session from the system browser into the app's WebView.
+import { describe, it, expect, beforeAll } from "vitest";
+import { onRequestGet as startGet } from "../functions/auth/[provider]/start.js";
+import { onRequestPost as exchangePost, onRequestOptions as exchangeOptions } from "../functions/auth/native/exchange.js";
+import { onRequestPost as logoutPost } from "../functions/auth/logout.js";
+import { signSession } from "../shared/auth.js";
+import {
+  HANDOFF_TTL_SECONDS,
+  mintHandoffCode,
+  redeemHandoffCode,
+  sha256b64url,
+} from "../shared/nativeHandoff.js";
+import { isAllowedNativeOrigin, nativeCorsHeaders } from "../shared/nativeCors.js";
+
+const SECRET = "test-secret-value";
+const CONFIGURED = {
+  SESSION_SECRET: SECRET,
+  GOOGLE_CLIENT_ID: "g-id",
+  GOOGLE_CLIENT_SECRET: "g-secret",
+  MS_CLIENT_ID: "m-id",
+  MS_CLIENT_SECRET: "m-secret",
+};
+const NATIVE_ORIGIN = "https://localhost";
+
+const req = (url, headers = {}) => new Request(url, { headers });
+const setCookies = (res) =>
+  (typeof res.headers.getSetCookie === "function"
+    ? res.headers.getSetCookie()
+    : [res.headers.get("set-cookie")]
+  ).filter(Boolean);
+const cookieNamed = (res, name) =>
+  setCookies(res).find((c) => c.startsWith(`${name}=`)) || null;
+const cookieValue = (res, name) => {
+  const c = cookieNamed(res, name);
+  return c ? c.slice(name.length + 1).split(";")[0] : null;
+};
+
+/**
+ * A D1 stand-in that actually stores rows.
+ *
+ * The single-use guarantee is the thing under test, and it lives in the row
+ * count a DELETE reports — which a canned-response fake cannot express. So this
+ * keeps a Map and reports `meta.changes` honestly.
+ */
+function fakeD1() {
+  const rows = new Map();
+  const db = {
+    rows,
+    prepare(sql) {
+      const stmt = {
+        args: [],
+        bind(...args) {
+          stmt.args = args;
+          return stmt;
+        },
+        async run() {
+          if (sql.startsWith("DELETE FROM native_handoff WHERE expires_at")) {
+            const cutoff = stmt.args[0];
+            let n = 0;
+            for (const [k, v] of rows) if (v.expires_at <= cutoff) (rows.delete(k), n++);
+            return { meta: { changes: n } };
+          }
+          if (sql.startsWith("DELETE FROM native_handoff WHERE code_hash")) {
+            return { meta: { changes: rows.delete(stmt.args[0]) ? 1 : 0 } };
+          }
+          if (sql.startsWith("INSERT INTO native_handoff")) {
+            const [code_hash, challenge, session, expires_at, created_at] = stmt.args;
+            rows.set(code_hash, { code_hash, challenge, session, expires_at, created_at });
+            return { meta: { changes: 1 } };
+          }
+          throw new Error(`unexpected run(): ${sql}`);
+        },
+        async first() {
+          if (sql.startsWith("SELECT challenge, session, expires_at FROM native_handoff")) {
+            return rows.get(stmt.args[0]) || null;
+          }
+          throw new Error(`unexpected first(): ${sql}`);
+        },
+      };
+      return stmt;
+    },
+  };
+  return db;
+}
+
+const VERIFIER = "a-verifier-the-app-kept-to-itself";
+const challengeFor = (v) => sha256b64url(v);
+
+describe("#163 — minting a hand-off code", () => {
+  it("never stores the code itself, only its digest", async () => {
+    const db = fakeD1();
+    const code = await mintHandoffCode(db, "session-jwt", await challengeFor(VERIFIER));
+
+    expect(db.rows.has(code)).toBe(false);
+    expect(db.rows.has(await sha256b64url(code))).toBe(true);
+  });
+
+  it("gives every mint a distinct code", async () => {
+    const db = fakeD1();
+    const hc = await challengeFor(VERIFIER);
+    const a = await mintHandoffCode(db, "s", hc);
+    const b = await mintHandoffCode(db, "s", hc);
+    expect(a).not.toBe(b);
+  });
+
+  it("sweeps codes that already expired, so abandoned sign-ins do not pile up", async () => {
+    const db = fakeD1();
+    const now = 1_000_000;
+    await mintHandoffCode(db, "old", await challengeFor(VERIFIER), now);
+    expect(db.rows.size).toBe(1);
+
+    // A later mint, past the first one's TTL.
+    await mintHandoffCode(db, "new", await challengeFor(VERIFIER), now + HANDOFF_TTL_SECONDS + 1);
+    expect(db.rows.size).toBe(1);
+    expect([...db.rows.values()][0].session).toBe("new");
+  });
+});
+
+describe("#163 — redeeming a hand-off code", () => {
+  it("returns the session for the right code and verifier", async () => {
+    const db = fakeD1();
+    const code = await mintHandoffCode(db, "session-jwt", await challengeFor(VERIFIER));
+    expect(await redeemHandoffCode(db, code, VERIFIER)).toBe("session-jwt");
+  });
+
+  it("is single-use — the second redemption gets nothing", async () => {
+    const db = fakeD1();
+    const code = await mintHandoffCode(db, "session-jwt", await challengeFor(VERIFIER));
+
+    expect(await redeemHandoffCode(db, code, VERIFIER)).toBe("session-jwt");
+    expect(await redeemHandoffCode(db, code, VERIFIER)).toBeNull();
+    expect(db.rows.size).toBe(0);
+  });
+
+  it("refuses a code presented without the verifier — the interception case", async () => {
+    // This is the whole reason the code alone is safe to put in a URL that any
+    // app registering rca:// can read.
+    const db = fakeD1();
+    const code = await mintHandoffCode(db, "session-jwt", await challengeFor(VERIFIER));
+
+    expect(await redeemHandoffCode(db, code, "not-the-verifier")).toBeNull();
+  });
+
+  it("burns the code even when the verifier is wrong", async () => {
+    // A wrong verifier against a real code is an attack, not a typo — the real
+    // app always holds the right one. Leaving the row would keep a known-live
+    // code available for the rest of its TTL.
+    const db = fakeD1();
+    const code = await mintHandoffCode(db, "session-jwt", await challengeFor(VERIFIER));
+
+    await redeemHandoffCode(db, code, "not-the-verifier");
+    expect(db.rows.size).toBe(0);
+    expect(await redeemHandoffCode(db, code, VERIFIER)).toBeNull();
+  });
+
+  it("refuses an expired code", async () => {
+    const db = fakeD1();
+    const now = 2_000_000;
+    const code = await mintHandoffCode(db, "session-jwt", await challengeFor(VERIFIER), now);
+
+    expect(await redeemHandoffCode(db, code, VERIFIER, now + HANDOFF_TTL_SECONDS + 1)).toBeNull();
+  });
+
+  it("refuses an unknown code, and a missing code or verifier", async () => {
+    const db = fakeD1();
+    expect(await redeemHandoffCode(db, "never-minted", VERIFIER)).toBeNull();
+    expect(await redeemHandoffCode(db, null, VERIFIER)).toBeNull();
+    expect(await redeemHandoffCode(db, "x", null)).toBeNull();
+  });
+});
+
+describe("#163 — GET /auth/:provider/start marks the native flow", () => {
+  it("records the native flag and the challenge in HttpOnly cookies", async () => {
+    const hc = await challengeFor(VERIFIER);
+    const res = await startGet({
+      request: req(`https://x.test/auth/google/start?native=1&hc=${encodeURIComponent(hc)}`),
+      env: CONFIGURED,
+      params: { provider: "google" },
+    });
+
+    expect(res.status).toBe(302);
+    expect(cookieValue(res, "rca_oauth_native")).toBe("1");
+    expect(cookieValue(res, "rca_oauth_hc")).toBe(hc);
+    // Not readable by anything running in the Custom Tab.
+    expect(cookieNamed(res, "rca_oauth_hc")).toContain("HttpOnly");
+  });
+
+  it("stays a normal web sign-in when the challenge is malformed", async () => {
+    // Falling back rather than failing: a bad `hc` must not be a way to make
+    // sign-in break, and the deep-link branch is reachable only with a
+    // well-formed one.
+    const res = await startGet({
+      request: req("https://x.test/auth/google/start?native=1&hc=too-short"),
+      env: CONFIGURED,
+      params: { provider: "google" },
+    });
+
+    expect(res.status).toBe(302);
+    expect(cookieNamed(res, "rca_oauth_native")).toBeNull();
+    expect(cookieNamed(res, "rca_oauth_hc")).toBeNull();
+  });
+
+  it("sets nothing native for an ordinary web sign-in", async () => {
+    const res = await startGet({
+      request: req("https://x.test/auth/google/start"),
+      env: CONFIGURED,
+      params: { provider: "google" },
+    });
+    expect(cookieNamed(res, "rca_oauth_native")).toBeNull();
+  });
+});
+
+describe("#163 — POST /auth/native/exchange", () => {
+  const post = (body, env, headers = {}) =>
+    exchangePost({
+      request: new Request("https://x.test/auth/native/exchange", {
+        method: "POST",
+        headers: { "content-type": "application/json", origin: NATIVE_ORIGIN, ...headers },
+        body: JSON.stringify(body),
+      }),
+      env,
+    });
+
+  async function seeded() {
+    const db = fakeD1();
+    const token = await signSession({ uid: 7, email: "s@x.test", name: "Student", role: "student" }, SECRET);
+    const code = await mintHandoffCode(db, token, await challengeFor(VERIFIER));
+    return { db, code, token };
+  }
+
+  it("hands back a session cookie the WebView will actually send", async () => {
+    const { db, code } = await seeded();
+    const res = await post({ code, verifier: VERIFIER }, { ...CONFIGURED, DB: db });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.authenticated).toBe(true);
+    expect(body.user).toMatchObject({ id: 7, email: "s@x.test", role: "student" });
+
+    // SameSite=None is the point: from https://localhost the API is a different
+    // site, and a Lax cookie would never be sent back.
+    const cookie = cookieNamed(res, "rca_session");
+    expect(cookie).toContain("SameSite=None");
+    expect(cookie).toContain("Secure");
+    expect(cookie).toContain("HttpOnly");
+  });
+
+  it("returns the user with the cookie, so the app needs no second round trip", async () => {
+    const { db, code } = await seeded();
+    const res = await post({ code, verifier: VERIFIER }, { ...CONFIGURED, DB: db });
+    expect((await res.json()).user.name).toBe("Student");
+  });
+
+  it("refuses a replayed code", async () => {
+    const { db, code } = await seeded();
+    const env = { ...CONFIGURED, DB: db };
+
+    expect((await post({ code, verifier: VERIFIER }, env)).status).toBe(200);
+    const second = await post({ code, verifier: VERIFIER }, env);
+    expect(second.status).toBe(400);
+    expect(setCookies(second)).toEqual([]);
+  });
+
+  it("refuses an intercepted code with no verifier, and says nothing about why", async () => {
+    const { db, code } = await seeded();
+    const env = { ...CONFIGURED, DB: db };
+
+    const wrongVerifier = await post({ code, verifier: "guessed" }, env);
+    const unknownCode = await post({ code: "never-minted", verifier: VERIFIER }, env);
+
+    expect(wrongVerifier.status).toBe(400);
+    expect(unknownCode.status).toBe(400);
+    // Identical bodies: a distinguishable answer would confirm which codes are
+    // live and worth attacking.
+    expect(await wrongVerifier.json()).toEqual(await unknownCode.json());
+  });
+
+  it("rejects a malformed body without throwing", async () => {
+    const db = fakeD1();
+    const res = await exchangePost({
+      request: new Request("https://x.test/auth/native/exchange", {
+        method: "POST",
+        headers: { "content-type": "application/json", origin: NATIVE_ORIGIN },
+        body: "not json",
+      }),
+      env: { ...CONFIGURED, DB: db },
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("is inert until configured", async () => {
+    const res = await post({ code: "x", verifier: "y" }, { DB: fakeD1() });
+    expect(res.status).toBe(503);
+  });
+
+  it("will not hand out a session the signature does not cover", async () => {
+    // The row is the one place a database value becomes a session cookie. A
+    // tampered row must not be handed straight back out.
+    const db = fakeD1();
+    const code = await mintHandoffCode(db, "not.a.real.jwt", await challengeFor(VERIFIER));
+    const res = await post({ code, verifier: VERIFIER }, { ...CONFIGURED, DB: db });
+
+    expect(res.status).toBe(400);
+    expect(setCookies(res)).toEqual([]);
+  });
+});
+
+describe("#163 — CORS is exactly the app, and nothing else", () => {
+  it("allows the Capacitor origins only", () => {
+    expect(isAllowedNativeOrigin("https://localhost")).toBe(true);
+    expect(isAllowedNativeOrigin("capacitor://localhost")).toBe(true);
+    expect(isAllowedNativeOrigin("https://evil.test")).toBe(false);
+    expect(isAllowedNativeOrigin(null)).toBe(false);
+  });
+
+  it("echoes the origin rather than answering with a wildcard", () => {
+    // `*` is invalid alongside Allow-Credentials, and credentials are the
+    // entire point here.
+    const h = nativeCorsHeaders(req("https://x.test/auth/me", { origin: NATIVE_ORIGIN }));
+    expect(h["access-control-allow-origin"]).toBe(NATIVE_ORIGIN);
+    expect(h["access-control-allow-credentials"]).toBe("true");
+  });
+
+  it("varies on Origin so a visitor is never served the app's CORS headers", () => {
+    expect(nativeCorsHeaders(req("https://x.test/auth/me")).vary).toBe("Origin");
+  });
+
+  it("gives an unknown origin no CORS headers at all", () => {
+    const h = nativeCorsHeaders(req("https://x.test/auth/me", { origin: "https://evil.test" }));
+    expect(h["access-control-allow-origin"]).toBeUndefined();
+  });
+
+  it("refuses a preflight from an origin that is not the app", async () => {
+    const res = await exchangeOptions({
+      request: req("https://x.test/auth/native/exchange", { origin: "https://evil.test" }),
+    });
+    expect(res.status).toBe(403);
+  });
+
+  it("answers a preflight from the app", async () => {
+    const res = await exchangeOptions({
+      request: req("https://x.test/auth/native/exchange", { origin: NATIVE_ORIGIN }),
+    });
+    expect(res.status).toBe(204);
+    expect(res.headers.get("access-control-allow-origin")).toBe(NATIVE_ORIGIN);
+  });
+});
+
+describe("#163 — signing out of the app", () => {
+  it("clears the cookie with the attributes it was set with", async () => {
+    // Cleared as Lax, the browser would treat it as a different cookie and
+    // leave the real one in place — the student taps sign out and stays in.
+    const res = await logoutPost({
+      request: new Request("https://x.test/auth/logout", { method: "POST", headers: { origin: NATIVE_ORIGIN } }),
+    });
+    const cookie = cookieNamed(res, "rca_session");
+    expect(cookie).toContain("SameSite=None");
+    expect(cookie).toContain("Max-Age=0");
+  });
+
+  it("still clears a Lax cookie for the website", async () => {
+    const res = await logoutPost({ request: new Request("https://x.test/auth/logout", { method: "POST" }) });
+    expect(cookieNamed(res, "rca_session")).toContain("SameSite=Lax");
+  });
+});
+
+// --- the callback's fork: deep link, or a cookie in the browser -------------
+//
+// Exercised through the real route with a real RS256 ID token, because the
+// branch is only reachable after PKCE, the token exchange and JWKS
+// verification have all passed. Stubbing it out further would test the fork
+// and nothing that guards it.
+
+const enc = new TextEncoder();
+const b64 = (bytes) =>
+  btoa(String.fromCharCode(...new Uint8Array(bytes))).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+const b64json = (o) => b64(enc.encode(JSON.stringify(o)));
+
+describe("#163 — the callback hands off instead of setting a cookie", () => {
+  let KEY;
+  let JWK;
+  const KID = "handoff-key";
+
+  beforeAll(async () => {
+    KEY = await crypto.subtle.generateKey(
+      { name: "RSASSA-PKCS1-v1_5", modulusLength: 2048, publicExponent: new Uint8Array([1, 0, 1]), hash: "SHA-256" },
+      true,
+      ["sign", "verify"],
+    );
+    JWK = { ...(await crypto.subtle.exportKey("jwk", KEY.publicKey)), kid: KID, alg: "RS256" };
+    delete JWK.key_ops;
+    delete JWK.ext;
+  });
+
+  async function idToken(nonce) {
+    const head = b64json({ alg: "RS256", typ: "JWT", kid: KID });
+    const body = b64json({
+      sub: "student-1",
+      aud: "g-id",
+      iss: "https://accounts.google.com",
+      email: "s@x.test",
+      name: "Student",
+      nonce,
+      exp: Math.floor(Date.now() / 1000) + 600,
+    });
+    const sig = await crypto.subtle.sign("RSASSA-PKCS1-v1_5", KEY.privateKey, enc.encode(`${head}.${body}`));
+    return `${head}.${body}.${b64(sig)}`;
+  }
+
+  // D1 for both the users upsert and the hand-off table.
+  function callbackDb() {
+    const handoff = fakeD1();
+    return {
+      handoff,
+      prepare(sql) {
+        if (sql.includes("native_handoff")) return handoff.prepare(sql);
+        const stmt = {
+          bind: () => stmt,
+          run: async () => ({ meta: { changes: 1 } }),
+          first: async () => ({ id: 7, email: "s@x.test", name: "Student", picture: null, role: "student" }),
+        };
+        return stmt;
+      },
+    };
+  }
+
+  async function runCallback({ native }) {
+    const nonce = "nonce-value";
+    const token = await idToken(nonce);
+
+    const realFetch = globalThis.fetch;
+    globalThis.fetch = async (url) => {
+      if (String(url).includes("googleapis.com/oauth2/v3/certs")) {
+        return new Response(JSON.stringify({ keys: [JWK] }), {
+          status: 200,
+          headers: { "content-type": "application/json", "cache-control": "max-age=600" },
+        });
+      }
+      return new Response(JSON.stringify({ id_token: token }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    };
+
+    const cookies = [
+      "rca_oauth_state=st",
+      "rca_oauth_verifier=vf",
+      `rca_oauth_nonce=${nonce}`,
+      "rca_oauth_next=%2Fportal",
+      ...(native ? ["rca_oauth_native=1", `rca_oauth_hc=${await challengeFor(VERIFIER)}`] : []),
+    ].join("; ");
+
+    const db = callbackDb();
+    try {
+      const { onRequestGet } = await import("../functions/auth/[provider]/callback.js");
+      const res = await onRequestGet({
+        request: req("https://x.test/auth/google/callback?code=abc&state=st", { cookie: cookies }),
+        env: { ...CONFIGURED, DB: db },
+        params: { provider: "google" },
+      });
+      return { res, db };
+    } finally {
+      globalThis.fetch = realFetch;
+    }
+  }
+
+  it("redirects the app to rca:// with a code, and sets no session cookie", async () => {
+    const { res, db } = await runCallback({ native: true });
+
+    expect(res.status).toBe(302);
+    const location = new URL(res.headers.get("location"));
+    expect(location.protocol).toBe("rca:");
+    expect(location.host).toBe("auth");
+    expect(location.searchParams.get("code")).toBeTruthy();
+    expect(location.searchParams.get("next")).toBe("/portal");
+
+    // The browser must not be left holding a live 30-day session in a jar the
+    // student never sees and the app cannot read.
+    expect(cookieNamed(res, "rca_session")).toBeNull();
+    expect(db.handoff.rows.size).toBe(1);
+  });
+
+  it("puts the code in the URL but the session only in the table", async () => {
+    const { res, db } = await runCallback({ native: true });
+    const code = new URL(res.headers.get("location")).searchParams.get("code");
+
+    // What travels through the deep link is a reference. The session itself
+    // never appears in a URL, an Android log, or an interceptor's hands.
+    const row = [...db.handoff.rows.values()][0];
+    expect(row.session.split(".")).toHaveLength(3);
+    expect(res.headers.get("location")).not.toContain(row.session);
+    expect(await redeemHandoffCode(db.handoff, code, VERIFIER)).toBe(row.session);
+  });
+
+  it("still sets the cookie and redirects normally on the web", async () => {
+    const { res, db } = await runCallback({ native: false });
+
+    expect(res.headers.get("location")).toBe("/portal");
+    expect(cookieNamed(res, "rca_session")).toContain("SameSite=Lax");
+    expect(db.handoff.rows.size).toBe(0);
+  });
+
+  it("clears the native transaction cookies on the way out", async () => {
+    const { res } = await runCallback({ native: true });
+    expect(cookieNamed(res, "rca_oauth_native")).toContain("Max-Age=0");
+    expect(cookieNamed(res, "rca_oauth_hc")).toContain("Max-Age=0");
+  });
+});


### PR DESCRIPTION
Closes #163. Unblocks the app half of #42.

#42's acceptance line is *"install the app, tap Sign in with Google/Microsoft, land on the student home."* On a device that could not happen, for two reasons — the one the ticket describes, and one underneath it that only shows up once you fix the first.

## 1. The cookie jars

Google answers OAuth in an embedded WebView with `disallowed_useragent`, so consent has to run in a Custom Tab. The callback then runs in the **system browser** and its `Set-Cookie` lands in the browser's jar; the Capacitor WebView has its own. `rca://` was registered in the manifest and connected to nothing at either end, and `@capacitor/app` was not installed — `cap sync` reported one plugin — so nothing could have received the redirect anyway.

Resuming the app is not the same as being signed in. So the deep link carries a **one-time code** rather than the session, and the app posts it back **from inside its WebView**, which is the thing that actually puts the cookie in the jar that will be read. The code is only the means of carriage; the caller decides the jar.

## 2. The app had no API origin

This is the part not in the ticket, and it sat underneath all of it.

Capacitor serves the bundle from `https://localhost` (`androidScheme: "https"`), and every portal fetch was relative. `/auth/me` in the app was resolving to `https://localhost/auth/me` — a host with no API on it. The app's portal could only ever report itself offline, before any hand-off mattered.

`src/lib/apiBase.js` points it at the real origin (`VITE_API_ORIGIN` to override for a staging APK). That makes the app's calls cross-origin, which is the price of keeping the bundled offline-capable shell #109/#111 built rather than pointing the WebView at the live site. `shared/nativeCors.js` allowlists exactly the Capacitor origins with credentialed CORS, and the app's session cookie is issued `SameSite=None` while the website's stays `Lax` — separate jars, each getting the variant that works there. Logout had to learn the same distinction: cleared as `Lax` from a cross-site response the cookie survives, and the student taps "sign out" and stays signed in.

## The security shape

Android lets **any** installed app claim `rca://`, so the redirect is interceptable. That is why the ticket hands over a code rather than a session — and why the code alone is deliberately not enough to redeem one:

- **A verifier the app never sends through a URL.** It generates one before opening the Custom Tab and passes only its SHA-256 to `start`. PKCE applied to the hand-off itself, so an intercepted code is worthless. This goes past what the ticket asked for; it seemed the point of handing over a code at all.
- **Single-use, enforced by the DELETE's row count** rather than the SELECT before it. Two requests can both read the row; only one can report having removed it, and only that one is handed the session. Plain SQL, no reliance on `DELETE ... RETURNING`.
- **Burned even when the verifier is wrong.** A wrong verifier against a real code is an attack, not a typo — the real app always holds the right one. Leaving it would keep a known-live code available for the rest of its TTL.
- **Only the digest is stored.** A row is a bearer session for its life, and this table will end up in a D1 backup; the code itself is never written down.
- **One indistinguishable rejection.** Wrong / unknown / spent / expired all answer identically. Distinguishing them would confirm to an interceptor which codes are live.
- **90s TTL**, swept on every mint so abandoned sign-ins do not accumulate.

Failures come back over the deep link too. A native flow failing to `/portal/login` would leave the student reading a login screen in a browser that is not the app, with the app behind it on a login screen of its own.

## One deviation from the ticket

The ticket says carry the native flag *"through `state`, so it cannot be forged from a query param"*. I carried it in the HttpOnly `Path=/auth` transaction cookies instead. Same unforgeability — nothing running in the Custom Tab can write them — and it is the mechanism `state`, `verifier`, `nonce` and `next` already use in that file rather than a second one alongside it. A malformed challenge falls back to a normal web sign-in rather than failing, so a bad `hc` is not a way to break sign-in.

The exchange also returns the user alongside the cookie instead of the app re-running `/auth/me`. Same outcome, one fewer round trip on the metered connections #111 is built for.

## Checks

- `npm test` — **270 passing**, 37 new
- `npm run build` — clean; the plugins are dynamically imported, so the web bundle does not carry them
- `npx cap sync android` — **3 plugins**, was 1
- `npm run lint` — 268 problems, byte-identical to `main`; none in these files
- `npx playwright test` — 24/25. `placement-carousel-stability` fails identically on `main` with these changes stashed; it needs live Instagram embeds.

The callback tests drive the real route with a real RS256 ID token rather than stubbing the fork, since the branch is only reachable once PKCE, the token exchange and JWKS verification have all passed — mocking past those would test the fork and nothing guarding it.

## Still needs the owner — this does not close #42

None of this is provable end to end yet, and the remaining items are not code:

1. The Google Cloud OAuth client + Entra registration and their secrets (`docs/OAUTH-SETUP.md`).
2. `npx wrangler d1 execute restcoder-enquiries --remote --file=schema-native-handoff.sql`.

Worth doing (2) at the same time as (1): skipping it leaves the website fine but breaks app sign-in at the very last step, *after* the student has been through consent, which looks like the app rejecting a correct login.

The hand-off adds **no new provider redirect URI** — it happens entirely between our own callback and our own app, after the provider is done. Both docs say so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M5gEi3ZzDdJzUtjXJSZHLe
