### PR TITLE
test(e2e): stop the placement specs depending on live Instagram (closes #182)

### DIFF
--- a/e2e/fixtures/instagram.js
+++ b/e2e/fixtures/instagram.js
@@ -1,0 +1,151 @@
+// Instagram, made deterministic for the e2e suite.
+//
+// Every test in placement-ig-embed and placement-carousel-stability used to
+// wait on the real `instagram.com/embed.js` and on real iframes hydrating from
+// IG's CDN. That made the whole E2E job a coin flip: three runs of one commit
+// on 2026-09-09 gave a failure in placement-ig-embed, a failure in a different
+// spec, and a pass, with nothing changed in between. One of those runs also
+// took the wrangler dev server down with it, after which every remaining test
+// failed with ERR_CONNECTION_REFUSED.
+//
+// None of those tests are about Instagram. They are about our CSS surviving
+// Instagram: whether our `min-width: 0 !important` beats IG's `min-width:
+// 326px`, whether the iframe reflows to the card instead of being clipped by
+// `overflow: hidden`, and whether the section's height reservation absorbs
+// hydration. All of that can be asserted against a stub — and asserted
+// *better*, because the stub always applies the hostile behaviour, where the
+// real script only sometimes got far enough to apply it.
+//
+// So the stub is written to be adversarial on purpose. It reproduces the three
+// things IG does that our CSS has to defeat:
+//
+//   1. injects a stylesheet with `.instagram-media { min-width: 326px }`
+//   2. renders an iframe carrying `width="326"` as a presentation attribute
+//   3. grows that iframe's height a beat later, the way IG's postMessage
+//      resize does
+//
+// If someone deletes the override in Placement.css, these tests now fail every
+// time rather than whenever IG happened to be quick.
+
+/** Every host the placement embeds would otherwise reach. */
+const IG_HOSTS = (url) =>
+  url.hostname === "www.instagram.com" ||
+  url.hostname === "instagram.com" ||
+  url.hostname.endsWith(".cdninstagram.com");
+
+// What IG's own stylesheet imposes, and the width attribute it writes. Kept
+// here as named constants because they are the adversarial input: if IG ever
+// moves to 400px, changing these two numbers is the whole update.
+export const IG_MIN_WIDTH = 326;
+export const IG_IFRAME_HEIGHT = 540;
+
+const STUB_SCRIPT = `
+(function () {
+  var MIN_WIDTH = ${IG_MIN_WIDTH};
+  var HEIGHT = ${IG_IFRAME_HEIGHT};
+
+  // (1) IG ships its own stylesheet. This is the rule our Placement.css has
+  // to beat; without it the test would pass against a stub even if the
+  // override were deleted.
+  var style = document.createElement('style');
+  style.setAttribute('data-ig-stub', '1');
+  style.textContent =
+    '.instagram-media { min-width: ' + MIN_WIDTH + 'px; max-width: 540px; }';
+  document.head.appendChild(style);
+
+  function render(bq) {
+    if (bq.getAttribute('data-ig-stub-done')) return;
+    bq.setAttribute('data-ig-stub-done', '1');
+
+    // (2) IG replaces the blockquote with an iframe that keeps the
+    // .instagram-media class and carries width as a presentation attribute.
+    var iframe = document.createElement('iframe');
+    iframe.className = 'instagram-media instagram-media-rendered';
+    iframe.setAttribute('width', String(MIN_WIDTH));
+    iframe.setAttribute('height', String(HEIGHT));
+    iframe.setAttribute('frameborder', '0');
+    iframe.setAttribute('scrolling', 'no');
+    iframe.setAttribute('data-instgrm-payload-id', 'stub');
+    iframe.setAttribute('title', 'Instagram embed (stubbed)');
+    // about:blank never touches the network, so the iframe is instant and
+    // cannot flake. Nothing under test reads its contents.
+    iframe.src = 'about:blank';
+    iframe.style.height = Math.round(HEIGHT / 2) + 'px';
+
+    bq.parentNode.insertBefore(iframe, bq);
+    bq.parentNode.removeChild(bq);
+
+    // (3) IG's embed measures its content and posts a resize back, so the
+    // iframe's final height arrives after layout has already settled once.
+    // That second settle is exactly what the "does not jump" test exists to
+    // catch, so the stub has to do it too.
+    requestAnimationFrame(function () {
+      iframe.style.height = HEIGHT + 'px';
+      iframe.setAttribute('data-ig-stub-settled', '1');
+    });
+  }
+
+  function process() {
+    var list = document.querySelectorAll('blockquote.instagram-media');
+    for (var i = 0; i < list.length; i++) render(list[i]);
+  }
+
+  window.instgrm = { Embeds: { process: process } };
+  process();
+})();
+`;
+
+/**
+ * Serve a stubbed `embed.js` and block every other Instagram request.
+ *
+ * Call before `page.goto`. The component loads the script lazily on
+ * intersection, so nothing happens until the carousel is scrolled to, exactly
+ * as in production.
+ */
+export async function stubInstagram(page) {
+  await page.route(IG_HOSTS, (route) => {
+    if (route.request().url().includes("/embed.js")) {
+      return route.fulfill({
+        status: 200,
+        contentType: "application/javascript",
+        body: STUB_SCRIPT,
+      });
+    }
+    // Anything else the page reaches for (CDN images, the iframe document)
+    // is not under test and must not become a network dependency.
+    return route.abort();
+  });
+}
+
+/**
+ * Block Instagram outright, leaving the blockquote fallback in place.
+ *
+ * This is the cold-cache state a hard reload hits for the first few hundred
+ * milliseconds, and the state the section used to collapse in.
+ */
+export async function blockInstagram(page) {
+  await page.route(IG_HOSTS, (route) => route.abort());
+}
+
+/** Scroll the carousel into view and wait for the placement cards to exist. */
+export async function scrollToPlacements(page) {
+  await page.locator("#Placements").scrollIntoViewIfNeeded();
+  await page.waitForSelector(".placements .card--instagram", { timeout: 15_000 });
+}
+
+/**
+ * Wait until every stubbed embed has rendered *and* taken its post-resize
+ * height, so a measurement cannot land between the two.
+ */
+export async function waitForStubbedEmbeds(page) {
+  await page.waitForFunction(
+    () => {
+      const frames = document.querySelectorAll(
+        ".placements .card--instagram iframe[data-instgrm-payload-id='stub']",
+      );
+      if (frames.length === 0) return false;
+      return [...frames].every((f) => f.getAttribute("data-ig-stub-settled") === "1");
+    },
+    { timeout: 15_000 },
+  );
+}

--- a/e2e/placement-carousel-stability.spec.js
+++ b/e2e/placement-carousel-stability.spec.js
@@ -1,4 +1,10 @@
 import { test, expect } from "@playwright/test";
+import {
+  blockInstagram,
+  scrollToPlacements,
+  stubInstagram,
+  waitForStubbedEmbeds,
+} from "./fixtures/instagram.js";
 
 // Issue caught by Nikshep on 2026-09-09: on the homepage the Placements
 // carousel visually "collapses" on Cmd+Shift+R — the whole section is only
@@ -29,11 +35,10 @@ import { test, expect } from "@playwright/test";
 
 const SECTION_MIN_HEIGHT = 900; // in sync with Placement.css `.placements { min-height: 900px }` at ≥600px viewports
 
-async function scrollToPlacements(page) {
-  await page.locator("#Placements").scrollIntoViewIfNeeded();
-  // Give slick + IG a moment to react without asserting timing.
-  await page.waitForSelector(".placements .card--instagram", { timeout: 15_000 });
-}
+// The card is `width: calc(100% - 8px)` with `margin: 0 4px`, so it sits 4px
+// inside its slide on each side and two adjacent slides put 8px between their
+// cards. See the block in Placement.css that #177 added.
+const CARD_INSET = 4;
 
 test("Placement section reserves vertical space before IG hydrates", async ({ page }) => {
   await page.setViewportSize({ width: 1440, height: 900 });
@@ -41,13 +46,7 @@ test("Placement section reserves vertical space before IG hydrates", async ({ pa
   // the iframe. This is precisely the state a fresh cold-cache Cmd+Shift+R
   // hits for the first few hundred ms, and it's the state where the section
   // was collapsing on live.
-  await page.route(
-    (url) =>
-      url.hostname === "www.instagram.com" ||
-      url.hostname === "instagram.com" ||
-      url.hostname.endsWith(".cdninstagram.com"),
-    (route) => route.abort(),
-  );
+  await blockInstagram(page);
   await page.goto("/");
   await scrollToPlacements(page);
 
@@ -64,38 +63,43 @@ test("Placement section reserves vertical space before IG hydrates", async ({ pa
 });
 
 test("Placement section does not jump when IG embeds hydrate", async ({ page }) => {
+  // The two states are measured in two separate loads rather than before and
+  // after within one.
+  //
+  // Taking "before" from a live page was the single flakiest thing in this
+  // suite: it landed at an arbitrary point in IG's async hydration, so it was
+  // sometimes the pre-hydrate height and sometimes the post-hydrate one. When
+  // it landed early and IG was slow, this test reported an 8359px jump
+  // (900→9259) on a commit that had touched none of this. Two loads make each
+  // state exact.
+  const heightWith = async (setup) => {
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await setup(page);
+    await page.goto("/");
+    await scrollToPlacements(page);
+    return page
+      .locator("#Placements")
+      .evaluate((el) => Math.round(el.getBoundingClientRect().height));
+  };
+
+  // Never hydrates: the fallback anchors only, which is the cold-cache state.
+  const heightBefore = await heightWith(blockInstagram);
+
+  await page.unrouteAll();
+
+  // Fully hydrated, including the post-resize settle.
   await page.setViewportSize({ width: 1440, height: 900 });
+  await stubInstagram(page);
   await page.goto("/");
   await scrollToPlacements(page);
+  await waitForStubbedEmbeds(page);
+  const heightAfter = await page
+    .locator("#Placements")
+    .evaluate((el) => Math.round(el.getBoundingClientRect().height));
 
-  // Height with the fallback still visible (embed script may or may not have
-  // resolved yet — this is the "before" state whatever that is).
-  const heightBefore = await page.locator("#Placements").evaluate(
-    (el) => Math.round(el.getBoundingClientRect().height),
-  );
-
-  // Wait for at least one hydrated IG iframe so we know we're past the
-  // pre-hydrate state. If IG is being blocked (some network conditions),
-  // fall through: the `heightAfter` will still equal heightBefore, and the
-  // invariant is trivially satisfied by min-height alone.
-  await page
-    .waitForFunction(
-      () => document.querySelectorAll(".placements .card--instagram iframe").length > 0,
-      { timeout: 15_000 },
-    )
-    .catch(() => {});
-  // Give IG's `embed.js` its postMessage resize round-trip so the iframe is
-  // at its final rendered height.
-  await page.waitForTimeout(2000);
-
-  const heightAfter = await page.locator("#Placements").evaluate(
-    (el) => Math.round(el.getBoundingClientRect().height),
-  );
-
-  // The section may still grow a little as IG's iframe stretches to its
-  // final aspect ratio, but never more than one card's worth of jump — a
-  // ~100px envelope is the visible-motion threshold; anything larger is a
-  // collapse-and-reform.
+  // The section may still grow a little as the iframe stretches to its final
+  // height, but never more than one card's worth of jump — a ~100px envelope
+  // is the visible-motion threshold; anything larger is a collapse-and-reform.
   const jump = Math.abs(heightAfter - heightBefore);
   expect(
     jump,
@@ -104,36 +108,101 @@ test("Placement section does not jump when IG embeds hydrate", async ({ page }) 
 });
 
 test("Adjacent IG cards on desktop have a visible horizontal gap", async ({ page }) => {
+  // Measured as the card's inset within its own slide, not as the distance
+  // between two IG cards.
+  //
+  // The previous version selected `.slick-active .card--instagram` plus the
+  // un-cloned ones and required two of them. There is only ever **one**
+  // un-cloned IG card on this page — the rest of that count came from slick's
+  // own clones — so the test was measuring a card against copies of itself,
+  // and whether it found two at all depended on where the carousel happened
+  // to have settled. It failed locally with a count of one while passing in
+  // CI on the same commit.
+  //
+  // The inset is the actual invariant #177 introduced, it is what produces
+  // the 8px between neighbours, and it holds no matter how many placements
+  // come back with an instagram_url.
   await page.setViewportSize({ width: 1440, height: 900 });
+  await stubInstagram(page);
   await page.goto("/");
   await scrollToPlacements(page);
-  await page.waitForTimeout(500);
+  await waitForStubbedEmbeds(page);
 
-  const rects = await page.evaluate(() => {
-    return [
-      ...document.querySelectorAll(
-        ".placements .slick-active .card--instagram, .placements .slick-slide:not(.slick-cloned) .card--instagram",
-      ),
-    ]
-      .slice(0, 4)
-      .map((el) => {
-        const r = el.getBoundingClientRect();
-        return { left: Math.round(r.left), right: Math.round(r.right) };
-      })
-      .sort((a, b) => a.left - b.left);
+  const geom = await page.evaluate(() => {
+    const card = document.querySelector(
+      ".placements .slick-slide:not(.slick-cloned) .card--instagram",
+    );
+    const slide = card && card.closest(".slick-slide");
+    if (!card || !slide) return null;
+    const c = card.getBoundingClientRect();
+    const s = slide.getBoundingClientRect();
+    return {
+      leftInset: Math.round(c.left - s.left),
+      rightInset: Math.round(s.right - c.right),
+      cardWidth: Math.round(c.width),
+      slideWidth: Math.round(s.width),
+    };
   });
 
-  // Need at least two cards side-by-side to measure a gap.
-  expect(rects.length, "at least two IG cards visible for a gap check").toBeGreaterThanOrEqual(2);
+  expect(geom, "an un-cloned IG card inside a slick slide").not.toBeNull();
 
-  for (let i = 1; i < rects.length; i++) {
-    const gap = rects[i].left - rects[i - 1].right;
-    // 8px is the target (4px symmetric margin on each side). Accept 6-16px
-    // to allow for sub-pixel rounding and future minor tuning of the margin.
-    expect(
-      gap,
-      `Adjacent IG cards touched at index ${i} (gap=${gap}px, expected 6-16px)`,
-    ).toBeGreaterThanOrEqual(6);
-    expect(gap).toBeLessThanOrEqual(16);
+  // Symmetric, so the gap does not lean to one side the way the original
+  // `margin-left: 8px` did.
+  expect(
+    geom.leftInset,
+    `IG card is inset ${geom.leftInset}px on the left, expected ${CARD_INSET}px`,
+  ).toBe(CARD_INSET);
+  expect(
+    geom.rightInset,
+    `IG card is inset ${geom.rightInset}px on the right, expected ${CARD_INSET}px`,
+  ).toBe(CARD_INSET);
+
+  // Which is to say the card is exactly 8px narrower than its slide, so two
+  // adjacent slides put 8px between their cards.
+  expect(geom.slideWidth - geom.cardWidth).toBe(CARD_INSET * 2);
+});
+
+test("adjacent placement cards do not touch", async ({ page }) => {
+  // The end-to-end version of the check above, across whatever cards the
+  // carousel actually renders. Any `.card`, not only the IG variant, since
+  // the row is mixed and the complaint was about the row.
+  await page.setViewportSize({ width: 1440, height: 900 });
+  await stubInstagram(page);
+  await page.goto("/");
+  await scrollToPlacements(page);
+  await waitForStubbedEmbeds(page);
+
+  const gaps = await page.evaluate(() => {
+    // Clones excluded deliberately. Slick duplicates the whole set on both
+    // sides of the track for its infinite mode, and those copies sit far off
+    // screen — the boundary between the clone group and the real one measures
+    // ~301px, which is slick's track arithmetic rather than anything a viewer
+    // can see. Only the un-cloned slides are on screen.
+    const cards = [
+      ...document.querySelectorAll(".placements .slick-slide:not(.slick-cloned) .card"),
+    ]
+      .map((el) => el.getBoundingClientRect())
+      .filter((r) => r.width > 0)
+      .sort((a, b) => a.left - b.left);
+    const out = [];
+    for (let i = 1; i < cards.length; i++) {
+      // Only compare cards sitting on the same row.
+      if (Math.abs(cards[i].top - cards[i - 1].top) > 2) continue;
+      out.push(Math.round(cards[i].left - cards[i - 1].right));
+    }
+    return out;
+  });
+
+  expect(gaps.length, "at least one adjacent pair on a row").toBeGreaterThan(0);
+  for (const gap of gaps) {
+    // The band is wider than the IG card's own 8px because the two variants
+    // are deliberately different widths: the standard card is `94%` with a
+    // `margin-left`, giving ~17px, while the IG variant is
+    // `calc(100% - 8px)` so the embed gets every pixel it can (the reasoning
+    // is in Placement.css). Both are intentional, so this test pins the thing
+    // that was actually wrong — cards touching — rather than freezing a
+    // gutter inconsistency it did not cause and should not hide.
+    expect(gap, `adjacent cards touched (gap=${gap}px)`).toBeGreaterThanOrEqual(6);
+    expect(gap, `adjacent cards drifted far apart (gap=${gap}px)`).toBeLessThanOrEqual(24);
   }
 });

--- a/e2e/placement-ig-embed.spec.js
+++ b/e2e/placement-ig-embed.spec.js
@@ -1,4 +1,10 @@
 import { test, expect } from "@playwright/test";
+import {
+  IG_MIN_WIDTH,
+  scrollToPlacements,
+  stubInstagram,
+  waitForStubbedEmbeds,
+} from "./fixtures/instagram.js";
 
 // Issue: on the homepage `Placements` carousel, Kota Akshay's Instagram-embed
 // variant card was clipping IG's chrome (username row, "GOT PLACED FOR" banner,
@@ -25,38 +31,23 @@ const VIEWPORTS = [
   { name: "desktop-1440", width: 1440, height: 900, slidesToShow: 4 },
 ];
 
-// Slow selectors: IG's embed script is loaded lazily by an IntersectionObserver
-// inside `InstagramEmbed.jsx`, then IG replaces the blockquote with an iframe.
-// Each step takes a couple of seconds on a warm dev server.
+// The embed is stubbed rather than fetched. See ./fixtures/instagram.js — the
+// stub applies IG's `min-width: 326px` stylesheet and its `width="326"`
+// presentation attribute every single run, which is the hostile input these
+// tests exist to prove our CSS beats. Waiting on the real script made the
+// outcome depend on IG's response time instead.
+//
+// One intersection is enough for all of them: `InstagramEmbed.jsx` loads the
+// script once per page, and `process()` then scans every blockquote in the
+// DOM. So there is no carousel-advancing loop here any more — that loop was
+// clicking a "next" arrow up to twelve times with the failure swallowed,
+// which quietly did nothing whenever the arrow was not where it expected.
 async function bringKotaIntoView(page) {
-  await page.locator("#Placements").scrollIntoViewIfNeeded();
-  // Wait for the placement carousel to hydrate.
-  await page.waitForSelector(".placements .slick-slide .card--instagram", {
+  await scrollToPlacements(page);
+  await waitForStubbedEmbeds(page);
+  await page.waitForSelector(".placements .slick-active .card--instagram iframe", {
     timeout: 15_000,
   });
-  // Force slick to the slide with the IG card. Slick clones slides for
-  // infinite mode; use the un-cloned instance and scroll it into the active
-  // window so IntersectionObserver fires.
-  const igCard = page
-    .locator(".placements .slick-slide:not(.slick-cloned) .card--instagram")
-    .first();
-  await igCard.scrollIntoViewIfNeeded();
-  // Advance the carousel until the IG card sits in an active slide — that
-  // is what triggers the lazy embed load.
-  for (let i = 0; i < 12; i++) {
-    const isActive = await page
-      .locator(".placements .slick-active .card--instagram")
-      .count();
-    if (isActive > 0) break;
-    await page.locator(".placements .slick-next, .placements .slick-arrow.slick-next, .placements button[aria-label*='Next']").first().click().catch(() => {});
-    await page.waitForTimeout(500);
-  }
-  // Wait for IG's script to run and the iframe to be inserted.
-  await page.waitForSelector(".placements .slick-active .card--instagram iframe", {
-    timeout: 20_000,
-  });
-  // Give IG a beat to finalise iframe layout after its own postMessage resize.
-  await page.waitForTimeout(1500);
 }
 
 async function measure(page) {
@@ -89,6 +80,7 @@ async function measure(page) {
 for (const vp of VIEWPORTS) {
   test(`Instagram embed fits inside its card at ${vp.name}`, async ({ page }) => {
     await page.setViewportSize({ width: vp.width, height: vp.height });
+    await stubInstagram(page);
     await page.goto("/");
     await bringKotaIntoView(page);
 
@@ -109,6 +101,7 @@ for (const vp of VIEWPORTS) {
 
 test("IG's blockquote and iframe min-width overrides are actually applied", async ({ page }) => {
   await page.setViewportSize({ width: 1440, height: 900 });
+  await stubInstagram(page);
   await page.goto("/");
   await bringKotaIntoView(page);
   const m = await measure(page);
@@ -120,4 +113,22 @@ test("IG's blockquote and iframe min-width overrides are actually applied", asyn
   // wider than the card and we don't know why".
   expect(m.blockquoteMinWidth, "blockquote min-width should be 0 not 326px").toBe("0px");
   expect(m.iframeMinWidth, "iframe min-width should be 0 not 326px").toBe("0px");
+
+  // Guard the guard. If the stub ever stopped applying IG's rule, the two
+  // assertions above would pass against nothing and quietly stop defending
+  // the override they exist for.
+  const hostileRuleApplied = await page.evaluate(
+    () => !!document.querySelector("style[data-ig-stub]"),
+  );
+  expect(hostileRuleApplied, "the stub must impose IG's own min-width rule").toBe(true);
+
+  // And the iframe still carries IG's width attribute, which author
+  // `!important` is what beats.
+  const widthAttr = await page.evaluate(
+    () =>
+      document
+        .querySelector(".placements .slick-active .card--instagram iframe")
+        ?.getAttribute("width"),
+  );
+  expect(Number(widthAttr)).toBe(IG_MIN_WIDTH);
 });


### PR DESCRIPTION
Closes #182.

The E2E job was a coin flip. Three runs of one unchanged commit today gave a failure in `placement-ig-embed`, a failure in a different spec, and a pass. One of those runs also took the wrangler dev server down with it, after which every remaining test failed with `ERR_CONNECTION_REFUSED`, so the job reported five unrelated failures for a diff that touched none of this.

Five of the twenty-five tests waited on `instagram.com/embed.js` and on real iframes hydrating from IG's CDN, with waits of 15s and 20s. None of those tests are about Instagram. They are about **our CSS surviving Instagram**.

## The stub is adversarial on purpose

`e2e/fixtures/instagram.js` serves a stubbed `embed.js` and blocks every other IG host. It reproduces the three things the real script does that `Placement.css` exists to defeat:

1. injects IG's own `.instagram-media { min-width: 326px }` stylesheet
2. renders an iframe carrying `width="326"` as a presentation attribute
3. grows that iframe a frame later, the way IG's `postMessage` resize does

That makes the tests **stronger**, not weaker. The real script only applied that pressure when it happened to load in time; the stub applies it every run. Verified by deleting the `min-width: 0 !important` override from `Placement.css`: all four viewport tests fail with the exact clipping error they were written for. Restored afterwards.

The min-width test also now asserts the stub actually imposed the hostile rule, so it cannot quietly start passing against nothing.

## Two tests were measuring something other than what they claimed

**`does not jump when IG embeds hydrate`** took its "before" height from a live page at an arbitrary point in async hydration, so it was sometimes the pre-hydrate height and sometimes the post-hydrate one. That is the 8359px jump (900 to 9259) CI reported this morning on a PR that had touched none of this. It now measures two exact states in two loads: blocked, then fully hydrated and settled. Real numbers are **900 and 923, a 23px jump** against a 150px envelope.

**`adjacent IG cards have a visible horizontal gap`** required two IG cards, but there is only ever **one un-cloned IG card** on the page. The rest of that count was slick's own clones, so it was measuring a card against copies of itself, and whether it found two at all depended on where the carousel had settled. It failed locally with a count of one while passing in CI on the same commit. It now asserts the inset that actually produces the gap, 4px each side of the slide, which holds however many placements come back with an `instagram_url`.

## One thing I found and did not hide

Writing an end-to-end version of the gap check across the whole row turned up a **301px gap**. It is slick's clone-to-real track boundary, entirely off screen, so clones are excluded and the reason is written down in the test rather than left as a mystery constant. On-screen gaps are 17, 17 and 13px.

The band is 6 to 24px rather than the old 6 to 16 because the IG card is deliberately wider than a standard card (`calc(100% - 8px)` versus `94%` plus a margin, so the embed gets every pixel). That gutter inconsistency is intentional and documented in `Placement.css`, so the test pins **cards touching**, which was the actual complaint, rather than freezing an inconsistency it did not cause and should not hide.

## Checks

- Full e2e suite three times: **26 passed, 26 passed, 26 passed**
- Runtime down from ~30s of timeouts to 12-21s
- `npm test` unaffected
- `npm run lint` 268 problems before and after, byte-identical

> A note on the lint number if you check it locally: running the dev server creates a `.wrangler/` directory that `eslint .` walks, which inflates the count to 448. It is gitignored, so CI never sees it. `npx eslint . --ignore-pattern ".wrangler/**"` gives the real 268. Might be worth adding to the eslint ignores separately.

These are your specs from #174 and #177, so I have not merged this. The invariants they pin are unchanged; only what they depend on has.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M5gEi3ZzDdJzUtjXJSZHLe
