### PR TITLE
feat(portal): lesson video player on the course page, data-light (closes #188)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -129,7 +129,7 @@ function App() {
           path="/portal/courses/:slug"
           element={
             <PortalRoute>
-              <PortalCourse />
+              {({ user }) => <PortalCourse user={user} />}
             </PortalRoute>
           }
         />

--- a/src/components/portal/LessonVideo.jsx
+++ b/src/components/portal/LessonVideo.jsx
@@ -1,0 +1,140 @@
+import { useEffect, useRef, useState } from "react";
+import PropTypes from "prop-types";
+import PlayArrowRoundedIcon from "@mui/icons-material/PlayArrowRounded";
+import { apiCredentials, apiOrigin } from "../../lib/apiBase";
+import { formatDuration } from "./coursesCache";
+import {
+  estimateBytes,
+  formatBytes,
+  formatClock,
+  onMeteredConnection,
+  readPosition,
+  savePosition,
+  videoSource,
+} from "./lessonPlayback";
+
+// How often, while playing, the position is saved. Often enough that a
+// dropped connection or a closed app loses little; rarely enough to be free.
+const SAVE_EVERY_SECONDS = 5;
+
+/**
+ * A lesson's video (#188).
+ *
+ * Nothing is fetched until the student taps: before then there is no <video>
+ * element at all, so no browser or WebView can preload a byte on a metered
+ * connection. The button says how big the lesson is first, and plays from
+ * where the student stopped last time.
+ */
+function LessonVideo({ lesson, userId }) {
+  const [started, setStarted] = useState(false);
+  const [problem, setProblem] = useState(null); // null | "offline" | "failed"
+  const [resumeAt, setResumeAt] = useState(() => readPosition(userId, lesson.id));
+  const videoRef = useRef(null);
+  const lastSaved = useRef(0);
+
+  const origin = apiOrigin();
+  const src = videoSource(lesson.video_url, origin);
+  // Inside the app the API is cross-origin, so the session cookie only travels
+  // with a credentialed request, as every other portal call does.
+  const credentialed = apiCredentials() === "include" && origin !== "" && src.startsWith(origin);
+
+  // Leaving the page mid-lesson still saves where the student got to
+  useEffect(() => {
+    const video = videoRef.current;
+    return () => {
+      if (video && video.currentTime) savePosition(userId, lesson.id, video.currentTime, video.duration);
+    };
+  }, [started, userId, lesson.id]);
+
+  const save = (video) => {
+    savePosition(userId, lesson.id, video.currentTime, video.duration);
+    lastSaved.current = video.currentTime;
+  };
+
+  const start = () => {
+    if (typeof navigator !== "undefined" && navigator.onLine === false) {
+      setProblem("offline");
+      return;
+    }
+    setProblem(null);
+    setStarted(true);
+  };
+
+  if (!started) {
+    const duration = formatDuration(lesson.duration_seconds);
+    // The API's size when it gives one; otherwise an estimate for the 360p copy
+    const size = lesson.size_bytes
+      ? formatBytes(lesson.size_bytes)
+      : formatBytes(estimateBytes(lesson.duration_seconds)) && `about ${formatBytes(estimateBytes(lesson.duration_seconds))}`;
+    const meta = [duration !== "—" ? duration : "", size].filter(Boolean).join(" · ");
+
+    return (
+      <div className="portal-video portal-video--idle">
+        <button type="button" className="portal-video-start" onClick={start}>
+          <PlayArrowRoundedIcon fontSize="small" aria-hidden="true" />
+          {resumeAt > 0 ? `Resume from ${formatClock(resumeAt)}` : "Play lesson"}
+        </button>
+        {meta && <p className="portal-video-meta">{meta}</p>}
+        {onMeteredConnection() && (
+          <p className="portal-video-note">You are on a slow or metered connection. Nothing downloads until you tap.</p>
+        )}
+        {problem === "offline" && (
+          <p className="portal-video-note portal-video-note--problem" role="status">
+            You are offline. Play this lesson again once you have a connection.
+          </p>
+        )}
+        {problem === "failed" && (
+          <p className="portal-video-note portal-video-note--problem" role="status">
+            This video could not be loaded. Check your connection and tap to try again.
+          </p>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <div className="portal-video">
+      <video
+        ref={videoRef}
+        className="portal-video-player"
+        src={src}
+        crossOrigin={credentialed ? "use-credentials" : undefined}
+        controls
+        autoPlay
+        playsInline
+        preload="metadata"
+        onLoadedMetadata={(e) => {
+          const video = e.currentTarget;
+          if (resumeAt > 0 && (!video.duration || resumeAt < video.duration)) video.currentTime = resumeAt;
+        }}
+        onTimeUpdate={(e) => {
+          const video = e.currentTarget;
+          if (Math.abs(video.currentTime - lastSaved.current) >= SAVE_EVERY_SECONDS) save(video);
+        }}
+        onPause={(e) => save(e.currentTarget)}
+        onEnded={(e) => {
+          save(e.currentTarget); // at the end, this clears the saved place
+          setResumeAt(0);
+        }}
+        onError={() => {
+          // Back to the button, with a way to try again, rather than a dead player
+          setResumeAt(readPosition(userId, lesson.id));
+          setStarted(false);
+          setProblem(typeof navigator !== "undefined" && navigator.onLine === false ? "offline" : "failed");
+        }}
+      />
+    </div>
+  );
+}
+
+LessonVideo.propTypes = {
+  lesson: PropTypes.shape({
+    id: PropTypes.oneOfType([PropTypes.number, PropTypes.string]).isRequired,
+    video_url: PropTypes.string,
+    duration_seconds: PropTypes.number,
+    size_bytes: PropTypes.number, // not sent yet; the size is estimated until #187 adds it
+  }).isRequired,
+  userId: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+};
+
+export default LessonVideo;

--- a/src/components/portal/Portal.css
+++ b/src/components/portal/Portal.css
@@ -514,3 +514,67 @@
        shipped to the client, and no untrusted HTML either. */
     white-space: pre-wrap;
 }
+
+/* --- lesson video (#188) --------------------------------------------------- */
+
+.portal-video { margin: 0 0 var(--rca-space-3); }
+
+/* Before the tap: the size and length, and nothing downloading */
+.portal-video--idle
+{
+    display: grid;
+    justify-items: start;
+    gap: var(--rca-space-2);
+    padding: var(--rca-space-4);
+    border: 1px dashed var(--rca-border);
+    border-radius: var(--rca-radius-md);
+    background-color: var(--rca-surface-subtle);
+}
+
+.portal-video-start
+{
+    display: inline-flex;
+    align-items: center;
+    gap: var(--rca-space-2);
+    min-height: var(--rca-control-h-mobile);
+    padding: 0 var(--rca-space-5);
+    border: 0;
+    border-radius: var(--rca-radius-md);
+    background-color: var(--rca-navy);
+    color: var(--rca-ink-invert);
+    font: inherit;
+    font-size: var(--rca-fs-body);
+    font-weight: var(--rca-fw-semibold);
+    cursor: pointer;
+    transition: background-color var(--rca-transition);
+}
+
+.portal-video-start:hover { background-color: var(--rca-navy-hover); }
+.portal-video-start:active { background-color: var(--rca-navy-pressed); }
+.portal-video-start:focus-visible { outline: none; box-shadow: var(--rca-focus-ring); }
+
+.portal-video-meta
+{
+    margin: 0;
+    font-size: var(--rca-fs-caption);
+    color: var(--rca-ink-soft);
+    font-variant-numeric: tabular-nums;
+}
+
+.portal-video-note
+{
+    margin: 0;
+    font-size: var(--rca-fs-caption);
+    color: var(--rca-ink-soft);
+}
+
+.portal-video-note--problem { color: var(--rca-ink); font-weight: var(--rca-fw-semibold); }
+
+.portal-video-player
+{
+    display: block;
+    width: 100%;
+    aspect-ratio: 16 / 9;
+    border-radius: var(--rca-radius-md);
+    background-color: var(--rca-ink);
+}

--- a/src/components/portal/PortalCourse.jsx
+++ b/src/components/portal/PortalCourse.jsx
@@ -1,7 +1,9 @@
 import { useEffect, useState } from "react";
+import PropTypes from "prop-types";
 import { Link, useParams } from "react-router-dom";
 import ArrowBackRoundedIcon from "@mui/icons-material/ArrowBackRounded";
 import PortalSkeleton from "./PortalSkeleton";
+import LessonVideo from "./LessonVideo";
 import { formatDuration } from "./coursesCache";
 import "./Portal.css";
 import { apiCredentials, apiUrl } from "../../lib/apiBase";
@@ -10,11 +12,12 @@ import { apiCredentials, apiUrl } from "../../lib/apiBase";
  * /portal/courses/:slug — one course and its lessons (#137).
  *
  * Notes are the readable half of a lesson and cost a few kilobytes; video is
- * the expensive half and is not this ticket. Each lesson expands in place
+ * the expensive half, and loads only when the student taps it (#188). Each
+ * lesson expands in place
  * rather than pushing the student to a per-lesson route, so reading a course
  * end to end on a phone is one screen and no further requests.
  */
-function PortalCourse() {
+function PortalCourse({ user }) {
   const { slug } = useParams();
   const [state, setState] = useState({ status: "loading", course: null });
   const [openId, setOpenId] = useState(null);
@@ -118,10 +121,13 @@ function PortalCourse() {
                     ) : (
                       <p className="portal-card-sub">No notes for this lesson yet.</p>
                     )}
-                    {/* Video is deliberately absent until the storage decision
-                        on #43 is made. A dead play button would be worse than
-                        an honest line of text. */}
-                    <p className="portal-card-sub">Video for this lesson is coming soon.</p>
+                    {/* A lesson without video yet says so, rather than showing
+                        a play button that goes nowhere. */}
+                    {l.video_url ? (
+                      <LessonVideo lesson={l} userId={user?.id} />
+                    ) : (
+                      <p className="portal-card-sub">Video for this lesson is coming soon.</p>
+                    )}
                   </div>
                 )}
               </li>
@@ -132,5 +138,11 @@ function PortalCourse() {
     </main>
   );
 }
+
+PortalCourse.propTypes = {
+  user: PropTypes.shape({
+    id: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+  }),
+};
 
 export default PortalCourse;

--- a/src/components/portal/lessonPlayback.js
+++ b/src/components/portal/lessonPlayback.js
@@ -1,0 +1,105 @@
+/**
+ * The rules behind a lesson's video (#188): nothing downloads until the
+ * student taps, the size is shown before that, and a return visit resumes
+ * where they stopped. Plain functions, like coursesCache, so they are
+ * unit-testable without a browser.
+ */
+
+export const POSITION_KEY = "rca_lesson_position";
+
+// The data-saver copy on #43 is a 360p export: roughly 500 kbit/s of video and
+// audio together. Used only to estimate a size the API has not given.
+export const DATA_SAVER_KBPS = 500;
+
+// Stopping in the first seconds isn't worth resuming from, and stopping in the
+// last seconds means the lesson is done: both clear the saved position.
+export const MIN_RESUME_SECONDS = 10;
+export const END_MARGIN_SECONDS = 15;
+
+/** Per student and per lesson, so a shared phone keeps each sibling's place. */
+export function positionKey(userId, lessonId) {
+  return `${POSITION_KEY}:${userId ?? "anon"}:${lessonId}`;
+}
+
+/** Seconds to resume from, or 0. */
+export function readPosition(userId, lessonId, storage = safeStorage()) {
+  if (!storage) return 0;
+  try {
+    const seconds = Number(storage.getItem(positionKey(userId, lessonId)));
+    return Number.isFinite(seconds) && seconds > 0 ? seconds : 0;
+  } catch {
+    return 0;
+  }
+}
+
+/** Saves where the student is; forgets it near the start or the end. */
+export function savePosition(userId, lessonId, seconds, duration, storage = safeStorage()) {
+  if (!storage) return;
+  const key = positionKey(userId, lessonId);
+  const at = Number(seconds);
+  const length = Number(duration);
+  const nearEnd = Number.isFinite(length) && length > 0 && at >= length - END_MARGIN_SECONDS;
+  try {
+    if (!Number.isFinite(at) || at < MIN_RESUME_SECONDS || nearEnd) storage.removeItem(key);
+    else storage.setItem(key, String(Math.floor(at)));
+  } catch {
+    // Private mode or a full store: resuming is a nicety, never a crash.
+  }
+}
+
+/** Roughly what a lesson costs to watch, in bytes, when the real size isn't known. */
+export function estimateBytes(durationSeconds, kbps = DATA_SAVER_KBPS) {
+  const seconds = Number(durationSeconds);
+  if (!Number.isFinite(seconds) || seconds <= 0) return 0;
+  return Math.round((seconds * kbps * 1000) / 8);
+}
+
+/** "38 MB", "2.4 GB", "under 1 MB", or "" when there is nothing to say. */
+export function formatBytes(bytes) {
+  const n = Number(bytes);
+  if (!Number.isFinite(n) || n <= 0) return "";
+  const mb = n / 1_000_000;
+  if (mb < 1) return "under 1 MB";
+  if (mb < 1000) return `${Math.round(mb)} MB`;
+  return `${(mb / 1000).toFixed(1)} GB`;
+}
+
+/** "1:05" or "1:02:05", for "Resume from". */
+export function formatClock(seconds) {
+  const total = Math.max(0, Math.floor(Number(seconds) || 0));
+  const h = Math.floor(total / 3600);
+  const m = Math.floor((total % 3600) / 60);
+  const s = String(total % 60).padStart(2, "0");
+  return h > 0 ? `${h}:${String(m).padStart(2, "0")}:${s}` : `${m}:${s}`;
+}
+
+/**
+ * Whether the connection says data is precious: the browser's Save-Data
+ * switch, or a 2G/3G estimate. Where the browser doesn't say (iPhones, older
+ * WebViews) it reads as not known, and the size shown is the only warning.
+ */
+export function onMeteredConnection(nav = globalThis.navigator) {
+  const connection = nav && nav.connection;
+  if (!connection) return false;
+  return Boolean(connection.saveData) || ["slow-2g", "2g", "3g"].includes(connection.effectiveType);
+}
+
+/**
+ * The URL the <video> element loads. Lesson video comes from the portal API
+ * (#187), so like every portal request it is made absolute inside the app
+ * (see lib/apiBase). A full http(s) URL, such as a sample file while #187 is
+ * built, is used as it is.
+ */
+export function videoSource(url, origin = "") {
+  if (!url) return "";
+  if (/^https?:\/\//i.test(url)) return url;
+  return `${origin}${url.startsWith("/") ? "" : "/"}${url}`;
+}
+
+function safeStorage() {
+  try {
+    return globalThis.localStorage || null;
+  } catch {
+    return null;
+  }
+}

--- a/src/components/portal/lessonPlayback.test.js
+++ b/src/components/portal/lessonPlayback.test.js
@@ -1,0 +1,148 @@
+import { describe, it, expect } from "vitest";
+import {
+  positionKey,
+  readPosition,
+  savePosition,
+  estimateBytes,
+  formatBytes,
+  formatClock,
+  onMeteredConnection,
+  videoSource,
+  MIN_RESUME_SECONDS,
+  END_MARGIN_SECONDS,
+} from "./lessonPlayback";
+
+// A localStorage stand-in. `fail` makes every call throw, which is what a
+// browser in private mode or over quota actually does.
+function memStore(seed = {}, fail = false) {
+  const map = new Map(Object.entries(seed));
+  const boom = () => {
+    throw new Error("storage unavailable");
+  };
+  return {
+    getItem: (k) => (fail ? boom() : (map.has(k) ? map.get(k) : null)),
+    setItem: (k, v) => (fail ? boom() : void map.set(k, v)),
+    removeItem: (k) => (fail ? boom() : void map.delete(k)),
+    map,
+  };
+}
+
+describe("positionKey", () => {
+  it("is scoped per student and per lesson", () => {
+    expect(positionKey(1, 7)).not.toBe(positionKey(2, 7));
+    expect(positionKey(1, 7)).not.toBe(positionKey(1, 8));
+  });
+
+  it("has a stable fallback when there is no user id", () => {
+    expect(positionKey(undefined, 7)).toBe(positionKey(null, 7));
+  });
+});
+
+describe("savePosition / readPosition", () => {
+  it("resumes where the student stopped, in whole seconds", () => {
+    const store = memStore();
+    savePosition(1, 7, 125.8, 2700, store);
+    expect(readPosition(1, 7, store)).toBe(125);
+  });
+
+  it("keeps each student's place on a shared phone", () => {
+    const store = memStore();
+    savePosition(1, 7, 300, 2700, store);
+    savePosition(2, 7, 900, 2700, store);
+    expect(readPosition(1, 7, store)).toBe(300);
+    expect(readPosition(2, 7, store)).toBe(900);
+  });
+
+  it("forgets a stop in the first seconds", () => {
+    const store = memStore();
+    savePosition(1, 7, 300, 2700, store);
+    savePosition(1, 7, MIN_RESUME_SECONDS - 1, 2700, store);
+    expect(readPosition(1, 7, store)).toBe(0);
+  });
+
+  it("forgets a finished lesson, so it starts from the top next time", () => {
+    const store = memStore();
+    savePosition(1, 7, 300, 2700, store);
+    savePosition(1, 7, 2700 - END_MARGIN_SECONDS, 2700, store);
+    expect(readPosition(1, 7, store)).toBe(0);
+  });
+
+  it("still saves when the duration isn't known yet", () => {
+    const store = memStore();
+    savePosition(1, 7, 300, NaN, store);
+    expect(readPosition(1, 7, store)).toBe(300);
+  });
+
+  it("reads a hand-edited value as no position", () => {
+    const store = memStore({ [positionKey(1, 7)]: "not a number" });
+    expect(readPosition(1, 7, store)).toBe(0);
+  });
+
+  it("never throws when storage does", () => {
+    const store = memStore({}, true);
+    expect(() => savePosition(1, 7, 300, 2700, store)).not.toThrow();
+    expect(readPosition(1, 7, store)).toBe(0);
+  });
+});
+
+describe("estimateBytes / formatBytes", () => {
+  it("estimates a 360p lesson at about 500 kbit/s", () => {
+    expect(estimateBytes(600)).toBe(37_500_000); // 10 minutes
+    expect(formatBytes(estimateBytes(600))).toBe("38 MB");
+  });
+
+  it("says nothing for a lesson with no duration", () => {
+    expect(estimateBytes(0)).toBe(0);
+    expect(estimateBytes(null)).toBe(0);
+    expect(formatBytes(0)).toBe("");
+  });
+
+  it("formats small and large sizes", () => {
+    expect(formatBytes(500_000)).toBe("under 1 MB");
+    expect(formatBytes(2_400_000_000)).toBe("2.4 GB");
+  });
+});
+
+describe("formatClock", () => {
+  it("formats minutes and hours", () => {
+    expect(formatClock(0)).toBe("0:00");
+    expect(formatClock(65)).toBe("1:05");
+    expect(formatClock(3725)).toBe("1:02:05");
+  });
+});
+
+describe("onMeteredConnection", () => {
+  it("is true for Save-Data or a 2G/3G estimate", () => {
+    expect(onMeteredConnection({ connection: { saveData: true, effectiveType: "4g" } })).toBe(true);
+    expect(onMeteredConnection({ connection: { effectiveType: "3g" } })).toBe(true);
+    expect(onMeteredConnection({ connection: { effectiveType: "slow-2g" } })).toBe(true);
+  });
+
+  it("is false for a fast connection, or where the browser doesn't say", () => {
+    expect(onMeteredConnection({ connection: { effectiveType: "4g" } })).toBe(false);
+    expect(onMeteredConnection({})).toBe(false);
+    expect(onMeteredConnection(undefined)).toBe(false);
+  });
+});
+
+describe("videoSource", () => {
+  it("makes an API path absolute inside the app", () => {
+    expect(videoSource("/api/portal/lessons/3/video", "https://restcoderacademy.in")).toBe(
+      "https://restcoderacademy.in/api/portal/lessons/3/video"
+    );
+  });
+
+  it("leaves an API path relative on the web", () => {
+    expect(videoSource("/api/portal/lessons/3/video", "")).toBe("/api/portal/lessons/3/video");
+  });
+
+  it("uses a full URL as it is", () => {
+    expect(videoSource("https://example.com/sample.mp4", "https://restcoderacademy.in")).toBe(
+      "https://example.com/sample.mp4"
+    );
+  });
+
+  it("is empty with no URL", () => {
+    expect(videoSource("", "https://restcoderacademy.in")).toBe("");
+  });
+});


### PR DESCRIPTION
Closes #188. Part of #43 (epic #41).

## What
On `/portal/courses/:slug`, a lesson with `video_url` now shows a player inside the expanded lesson, replacing "Video for this lesson is coming soon." Lessons without video keep that line.

- **Tap to load:** there is no `<video>` element until the student taps, so nothing preloads on a metered connection.
- **Size first:** the button shows the length and the size: `size_bytes` when the API sends it, otherwise an estimate for the 360p copy (~500 kbit/s, per the open question on #43).
- **Slow connections:** on Save-Data or a 2G/3G estimate it says nothing downloads until you tap.
- **Resume:** position saved every 5 s, on pause and on leaving; per student and per lesson, so a shared phone keeps each sibling's place (same idea as `coursesCache`). Cleared in the first 10 s and at the end.
- **Offline / load failure:** back to the button with a retry, in the portal's existing wording style.
- **App:** the video URL goes through `apiBase` and loads with credentials, like the other portal calls (#163), so it's ready for #187's `/api/portal/lessons/:id/video`.
- The course route now passes `user` to `PortalCourse`, the way the home route does.

## Files
- `src/components/portal/lessonPlayback.js` + `.test.js`: the rules (resume, size estimate, metered check, URL), 19 unit tests
- `src/components/portal/LessonVideo.jsx`: the player
- `PortalCourse.jsx`, `App.jsx`, `Portal.css`

## Checks
- `npm test`: 19 files, **289 tests passed** (19 new).
- `npm run build`: builds.
- `eslint` on the changed files: only the existing `Banner` unused import and fast-refresh warning in `App.jsx`, both identical on `main`.
- **Not yet verified on a phone with a real video:** that needs #187 (video API) and a lesson with `video_url` set.

## Next
#189 (offline download) builds on this player. #190 (upload page) needs #185 + #186.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TjRrCR5NZEfMUVaJLjExo9
