### PR TITLE
feat(portal): save a lesson's video to the phone for offline (closes #189)

### DIFF
--- a/android/app/capacitor.build.gradle
+++ b/android/app/capacitor.build.gradle
@@ -11,6 +11,7 @@ apply from: "../capacitor-cordova-android-plugins/cordova.variables.gradle"
 dependencies {
     implementation project(':capacitor-app')
     implementation project(':capacitor-browser')
+    implementation project(':capacitor-filesystem')
     implementation project(':capacitor-splash-screen')
 
 }

--- a/android/capacitor.settings.gradle
+++ b/android/capacitor.settings.gradle
@@ -8,5 +8,8 @@ project(':capacitor-app').projectDir = new File('../node_modules/@capacitor/app/
 include ':capacitor-browser'
 project(':capacitor-browser').projectDir = new File('../node_modules/@capacitor/browser/android')
 
+include ':capacitor-filesystem'
+project(':capacitor-filesystem').projectDir = new File('../node_modules/@capacitor/filesystem/android')
+
 include ':capacitor-splash-screen'
 project(':capacitor-splash-screen').projectDir = new File('../node_modules/@capacitor/splash-screen/android')

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@capacitor/app": "^8.1.1",
         "@capacitor/browser": "^8.0.4",
         "@capacitor/core": "^8.5.1",
+        "@capacitor/filesystem": "^8.1.3",
         "@capacitor/splash-screen": "^8.0.2",
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.0",
@@ -898,6 +899,18 @@
         "tslib": "^2.1.0"
       }
     },
+    "node_modules/@capacitor/filesystem": {
+      "version": "8.1.3",
+      "resolved": "https://registry.npmjs.org/@capacitor/filesystem/-/filesystem-8.1.3.tgz",
+      "integrity": "sha512-GNBlRkaXEEb+6WP/YsDXr2zygyOHoieuye6viyd2ZkEdBwfseG41jxfarVxLWH0r0owhyNUbwJ/Qi8fubqr6wA==",
+      "license": "MIT",
+      "dependencies": {
+        "@capacitor/synapse": "^1.0.4"
+      },
+      "peerDependencies": {
+        "@capacitor/core": ">=8.0.0"
+      }
+    },
     "node_modules/@capacitor/splash-screen": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@capacitor/splash-screen/-/splash-screen-8.0.2.tgz",
@@ -906,6 +919,12 @@
       "peerDependencies": {
         "@capacitor/core": ">=8.0.0"
       }
+    },
+    "node_modules/@capacitor/synapse": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@capacitor/synapse/-/synapse-1.0.4.tgz",
+      "integrity": "sha512-/C1FUo8/OkKuAT4nCIu/34ny9siNHr9qtFezu4kxm6GY1wNFxrCFWjfYx5C1tUhVGz3fxBABegupkpjXvjCHrw==",
+      "license": "ISC"
     },
     "node_modules/@cloudflare/kv-asset-handler": {
       "version": "0.5.0",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@capacitor/app": "^8.1.1",
     "@capacitor/browser": "^8.0.4",
     "@capacitor/core": "^8.5.1",
+    "@capacitor/filesystem": "^8.1.3",
     "@capacitor/splash-screen": "^8.0.2",
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.0",

--- a/src/components/portal/LessonMedia.jsx
+++ b/src/components/portal/LessonMedia.jsx
@@ -1,0 +1,274 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import PropTypes from "prop-types";
+import DownloadRoundedIcon from "@mui/icons-material/DownloadRounded";
+import { apiCredentials, apiOrigin } from "../../lib/apiBase";
+import LessonVideo from "./LessonVideo";
+import { estimateBytes, formatBytes, videoSource } from "./lessonPlayback";
+import {
+  downloadFor,
+  downloadLesson,
+  lessonFilePath,
+  progressPercent,
+  readDownloads,
+  removeCourseCopy,
+  removeDownload,
+  saveCourseCopy,
+  writeDownload,
+} from "./lessonDownloads";
+import { canSaveLessons, lessonFiles } from "./offlineFiles";
+
+const isOffline = () => typeof navigator !== "undefined" && navigator.onLine === false;
+
+/**
+ * A lesson's video, and in the app a way to save it to the phone (#189).
+ *
+ * On the website this is only the player: saving is an app feature.
+ */
+function LessonMedia(props) {
+  if (!canSaveLessons()) return <LessonVideo lesson={props.lesson} userId={props.userId} />;
+  return <SavableLesson {...props} />;
+}
+
+/**
+ * Save for offline, with progress, stop, resume and delete.
+ *
+ * A dropped connection keeps what was saved, and saving carries on by itself
+ * when the connection comes back while the page is open. A saved lesson plays
+ * from the phone, connection or not.
+ */
+function SavableLesson({ lesson, userId, course, version, onChange, onBusy }) {
+  const path = lessonFilePath(userId, lesson.id);
+  const [entry, setEntry] = useState(() => downloadFor(readDownloads(userId), lesson.id));
+  const [progress, setProgress] = useState(null); // { bytes, total } while saving
+  const [problem, setProblem] = useState(null); // null | "offline" | "failed" | "space"
+  const [offlineSrc, setOfflineSrc] = useState(null);
+  const abort = useRef(null);
+  const job = useRef(null);
+  const resumeWhenOnline = useRef(false);
+  const running = progress !== null;
+
+  // Another control on the page (Delete all) may have changed what is saved
+  useEffect(() => {
+    setEntry(downloadFor(readDownloads(userId), lesson.id));
+  }, [version, userId, lesson.id]);
+
+  // A whole lesson plays from the phone
+  const done = Boolean(entry && entry.done);
+  useEffect(() => {
+    let live = true;
+    if (!done) {
+      setOfflineSrc(null);
+      return undefined;
+    }
+    lessonFiles
+      .playableUrl(path)
+      .then((url) => live && setOfflineSrc(url))
+      .catch(() => live && setOfflineSrc(null));
+    return () => {
+      live = false;
+    };
+  }, [done, path]);
+
+  // Leaving the page stops saving; what was saved stays for next time
+  useEffect(() => () => abort.current?.abort(), []);
+
+  const record = useCallback(
+    (next) => {
+      writeDownload(userId, next);
+      setEntry(next);
+      onChange?.();
+    },
+    [userId, onChange],
+  );
+
+  const save = useCallback(async () => {
+    if (job.current) return;
+    if (isOffline()) {
+      setProblem("offline");
+      resumeWhenOnline.current = true;
+      return;
+    }
+    const controller = new AbortController();
+    abort.current = controller;
+    resumeWhenOnline.current = false;
+    setProblem(null);
+    onBusy?.(lesson.id, true);
+
+    // The course page has to open offline for a saved lesson to be reachable
+    saveCourseCopy(userId, course);
+    const saved = downloadFor(readDownloads(userId), lesson.id);
+    const base = {
+      lessonId: lesson.id,
+      slug: course.slug,
+      path,
+      bytes: saved?.bytes || 0,
+      total: saved?.total ?? lesson.size_bytes ?? null,
+      done: false,
+    };
+    record(base);
+    setProgress({ bytes: base.bytes, total: base.total });
+
+    const origin = apiOrigin();
+    const url = videoSource(lesson.video_url, origin);
+    let total = base.total;
+
+    job.current = (async () => {
+      try {
+        const result = await downloadLesson({
+          url,
+          path,
+          files: lessonFiles,
+          signal: controller.signal,
+          // The session cookie goes to the portal API only, as LessonVideo does
+          credentials: origin && url.startsWith(origin) ? apiCredentials() : "omit",
+          onProgress: (p) => {
+            if (p.total) total = p.total;
+            setProgress({ bytes: p.bytes, total });
+            writeDownload(userId, { ...base, bytes: p.bytes, total });
+          },
+        });
+        record({ ...base, bytes: result.bytes, total: result.total, done: true });
+      } catch (err) {
+        record({ ...base, bytes: await lessonFiles.size(path), total });
+        if (controller.signal.aborted) return; // Stop or Delete: not a problem
+        const dropped = isOffline() || err?.name === "TypeError" || err?.reason === "short";
+        const full = /quota|space|ENOSPC/i.test(String(err?.message));
+        setProblem(dropped ? "offline" : full ? "space" : "failed");
+        resumeWhenOnline.current = dropped;
+      } finally {
+        if (abort.current === controller) abort.current = null;
+        job.current = null;
+        setProgress(null);
+        onBusy?.(lesson.id, false);
+      }
+    })();
+    await job.current;
+  }, [course, lesson.id, lesson.size_bytes, lesson.video_url, onBusy, path, record, userId]);
+
+  // Back online: carry on from where the drop left it
+  useEffect(() => {
+    const onOnline = () => {
+      if (resumeWhenOnline.current) save();
+    };
+    window.addEventListener("online", onOnline);
+    return () => window.removeEventListener("online", onOnline);
+  }, [save]);
+
+  const stop = () => {
+    resumeWhenOnline.current = false;
+    abort.current?.abort();
+  };
+
+  const remove = async () => {
+    resumeWhenOnline.current = false;
+    abort.current?.abort();
+    // Let the stopped download write its last piece before the file goes, so
+    // nothing is left behind
+    await job.current?.catch(() => {});
+    await lessonFiles.remove(path);
+    const left = removeDownload(userId, lesson.id);
+    if (!Object.values(left).some((e) => e.slug === course.slug)) removeCourseCopy(userId, course.slug);
+    setEntry(null);
+    setProblem(null);
+    onChange?.();
+  };
+
+  const total = progress?.total ?? entry?.total ?? lesson.size_bytes ?? null;
+  const sizeLabel = total
+    ? formatBytes(total)
+    : formatBytes(estimateBytes(lesson.duration_seconds)) && `about ${formatBytes(estimateBytes(lesson.duration_seconds))}`;
+
+  let status;
+  if (running) {
+    const pct = progressPercent(progress.bytes, total);
+    status = (
+      <>
+        <progress className="portal-save-bar" max={100} value={pct ?? undefined} aria-label="Saving lesson" />
+        <p className="portal-save-status">
+          {pct != null
+            ? `Saving ${pct}% · ${formatBytes(progress.bytes) || "0 MB"} of ${formatBytes(total)}`
+            : `Saving · ${formatBytes(progress.bytes) || "starting"}`}
+        </p>
+        <button type="button" className="portal-save-btn" onClick={stop}>
+          Stop
+        </button>
+      </>
+    );
+  } else if (entry && entry.done) {
+    status = (
+      <>
+        <p className="portal-save-status">Saved on this phone · {formatBytes(entry.bytes) || "under 1 MB"}</p>
+        <button type="button" className="portal-save-btn portal-save-btn--quiet" onClick={remove}>
+          Delete
+        </button>
+      </>
+    );
+  } else if (entry) {
+    const pct = progressPercent(entry.bytes, total);
+    status = (
+      <>
+        <p className="portal-save-status">
+          {pct != null ? `Saved ${pct}% so far` : `Saved ${formatBytes(entry.bytes) || "under 1 MB"} so far`}
+        </p>
+        <button type="button" className="portal-save-btn" onClick={save}>
+          Resume saving
+        </button>
+        <button type="button" className="portal-save-btn portal-save-btn--quiet" onClick={remove}>
+          Delete
+        </button>
+      </>
+    );
+  } else {
+    status = (
+      <button type="button" className="portal-save-btn" onClick={save}>
+        <DownloadRoundedIcon fontSize="small" aria-hidden="true" />
+        {sizeLabel ? `Save for offline · ${sizeLabel}` : "Save for offline"}
+      </button>
+    );
+  }
+
+  return (
+    <>
+      <LessonVideo lesson={lesson} userId={userId} offlineSrc={offlineSrc} />
+      <div className="portal-save" aria-live="polite">
+        {status}
+        {problem === "offline" && (
+          <p className="portal-video-note portal-video-note--problem" role="status">
+            No connection. Saving carries on from where it stopped once you are back online.
+          </p>
+        )}
+        {problem === "space" && (
+          <p className="portal-video-note portal-video-note--problem" role="status">
+            Your phone is out of space. Delete a saved lesson and try again.
+          </p>
+        )}
+        {problem === "failed" && (
+          <p className="portal-video-note portal-video-note--problem" role="status">
+            This lesson could not be saved. Tap to try again.
+          </p>
+        )}
+      </div>
+    </>
+  );
+}
+
+const lessonShape = PropTypes.shape({
+  id: PropTypes.oneOfType([PropTypes.number, PropTypes.string]).isRequired,
+  video_url: PropTypes.string,
+  duration_seconds: PropTypes.number,
+  size_bytes: PropTypes.number,
+}).isRequired;
+
+const mediaProps = {
+  lesson: lessonShape,
+  userId: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+  course: PropTypes.shape({ slug: PropTypes.string.isRequired }).isRequired,
+  version: PropTypes.number, // bumped by the course page when saved lessons change
+  onChange: PropTypes.func, // called when this lesson's saved state changes
+  onBusy: PropTypes.func, // (lessonId, saving) so the page can hold Delete all
+};
+
+LessonMedia.propTypes = mediaProps;
+SavableLesson.propTypes = mediaProps;
+
+export default LessonMedia;

--- a/src/components/portal/LessonVideo.jsx
+++ b/src/components/portal/LessonVideo.jsx
@@ -24,19 +24,24 @@ const SAVE_EVERY_SECONDS = 5;
  * element at all, so no browser or WebView can preload a byte on a metered
  * connection. The button says how big the lesson is first, and plays from
  * where the student stopped last time.
+ *
+ * `offlineSrc` is a lesson saved on the phone (#189): it plays from there,
+ * with or without a connection, and costs no data.
  */
-function LessonVideo({ lesson, userId }) {
-  const [started, setStarted] = useState(false);
+function LessonVideo({ lesson, userId, offlineSrc }) {
+  const [source, setSource] = useState(null); // what is playing; null before the tap
   const [problem, setProblem] = useState(null); // null | "offline" | "failed"
   const [resumeAt, setResumeAt] = useState(() => readPosition(userId, lesson.id));
   const videoRef = useRef(null);
   const lastSaved = useRef(0);
+  const started = source !== null;
 
   const origin = apiOrigin();
-  const src = videoSource(lesson.video_url, origin);
   // Inside the app the API is cross-origin, so the session cookie only travels
-  // with a credentialed request, as every other portal call does.
-  const credentialed = apiCredentials() === "include" && origin !== "" && src.startsWith(origin);
+  // with a credentialed request, as every other portal call does. A saved copy
+  // is on the phone and needs none.
+  const credentialed =
+    started && !source.offline && apiCredentials() === "include" && origin !== "" && source.url.startsWith(origin);
 
   // Leaving the page mid-lesson still saves where the student got to
   useEffect(() => {
@@ -52,20 +57,23 @@ function LessonVideo({ lesson, userId }) {
   };
 
   const start = () => {
-    if (typeof navigator !== "undefined" && navigator.onLine === false) {
+    if (!offlineSrc && typeof navigator !== "undefined" && navigator.onLine === false) {
       setProblem("offline");
       return;
     }
     setProblem(null);
-    setStarted(true);
+    // Fixed at the tap, so a download finishing mid-lesson does not restart it
+    setSource(offlineSrc ? { url: offlineSrc, offline: true } : { url: videoSource(lesson.video_url, origin), offline: false });
   };
 
   if (!started) {
     const duration = formatDuration(lesson.duration_seconds);
     // The API's size when it gives one; otherwise an estimate for the 360p copy
-    const size = lesson.size_bytes
-      ? formatBytes(lesson.size_bytes)
-      : formatBytes(estimateBytes(lesson.duration_seconds)) && `about ${formatBytes(estimateBytes(lesson.duration_seconds))}`;
+    const size = offlineSrc
+      ? "saved on this phone"
+      : lesson.size_bytes
+        ? formatBytes(lesson.size_bytes)
+        : formatBytes(estimateBytes(lesson.duration_seconds)) && `about ${formatBytes(estimateBytes(lesson.duration_seconds))}`;
     const meta = [duration !== "—" ? duration : "", size].filter(Boolean).join(" · ");
 
     return (
@@ -75,7 +83,7 @@ function LessonVideo({ lesson, userId }) {
           {resumeAt > 0 ? `Resume from ${formatClock(resumeAt)}` : "Play lesson"}
         </button>
         {meta && <p className="portal-video-meta">{meta}</p>}
-        {onMeteredConnection() && (
+        {!offlineSrc && onMeteredConnection() && (
           <p className="portal-video-note">You are on a slow or metered connection. Nothing downloads until you tap.</p>
         )}
         {problem === "offline" && (
@@ -97,7 +105,7 @@ function LessonVideo({ lesson, userId }) {
       <video
         ref={videoRef}
         className="portal-video-player"
-        src={src}
+        src={source.url}
         crossOrigin={credentialed ? "use-credentials" : undefined}
         controls
         autoPlay
@@ -118,9 +126,10 @@ function LessonVideo({ lesson, userId }) {
         }}
         onError={() => {
           // Back to the button, with a way to try again, rather than a dead player
+          const offline = !source.offline && typeof navigator !== "undefined" && navigator.onLine === false;
           setResumeAt(readPosition(userId, lesson.id));
-          setStarted(false);
-          setProblem(typeof navigator !== "undefined" && navigator.onLine === false ? "offline" : "failed");
+          setSource(null);
+          setProblem(offline ? "offline" : "failed");
         }}
       />
     </div>
@@ -135,6 +144,7 @@ LessonVideo.propTypes = {
     size_bytes: PropTypes.number, // not sent yet; the size is estimated until #187 adds it
   }).isRequired,
   userId: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+  offlineSrc: PropTypes.string, // a copy saved on the phone (#189)
 };
 
 export default LessonVideo;

--- a/src/components/portal/Portal.css
+++ b/src/components/portal/Portal.css
@@ -578,3 +578,76 @@
     border-radius: var(--rca-radius-md);
     background-color: var(--rca-ink);
 }
+
+/* --- saving a lesson for offline, in the app (#189) ------------------------ */
+
+.portal-save
+{
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: var(--rca-space-2) var(--rca-space-3);
+    margin: 0 0 var(--rca-space-3);
+}
+
+/* Secondary to Play: outlined, but the same thumb-sized height */
+.portal-save-btn
+{
+    display: inline-flex;
+    align-items: center;
+    gap: var(--rca-space-2);
+    min-height: var(--rca-control-h-mobile);
+    padding: 0 var(--rca-space-4);
+    border: 1px solid var(--rca-border-strong);
+    border-radius: var(--rca-radius-md);
+    background-color: var(--rca-surface);
+    color: var(--rca-ink);
+    font: inherit;
+    font-size: var(--rca-fs-small);
+    font-weight: var(--rca-fw-semibold);
+    cursor: pointer;
+    transition: background-color var(--rca-transition);
+}
+
+.portal-save-btn:hover { background-color: var(--rca-surface-subtle); }
+.portal-save-btn:focus-visible { outline: none; box-shadow: var(--rca-focus-ring); }
+.portal-save-btn:disabled { color: var(--rca-disabled-ink); cursor: not-allowed; background-color: transparent; }
+
+.portal-save-btn--quiet { border-color: transparent; background-color: transparent; color: var(--rca-ink-soft); }
+
+.portal-save-status
+{
+    margin: 0;
+    font-size: var(--rca-fs-caption);
+    color: var(--rca-ink-soft);
+    font-variant-numeric: tabular-nums;
+}
+
+.portal-save-bar
+{
+    flex-basis: 100%;
+    width: 100%;
+    height: 6px;
+    accent-color: var(--rca-navy);
+}
+
+.portal-save .portal-video-note { flex-basis: 100%; }
+
+/* How much space this course's saved lessons take, and one tap to free it */
+.portal-saved-usage
+{
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--rca-space-2);
+    margin: 0 0 var(--rca-space-5);
+    padding: var(--rca-space-2) var(--rca-space-2) var(--rca-space-2) var(--rca-space-4);
+    border: 1px solid var(--rca-border);
+    border-radius: var(--rca-radius-md);
+    font-size: var(--rca-fs-caption);
+    color: var(--rca-ink-soft);
+    font-variant-numeric: tabular-nums;
+}
+
+.portal-saved-usage p { margin: 0; }

--- a/src/components/portal/PortalCourse.jsx
+++ b/src/components/portal/PortalCourse.jsx
@@ -1,10 +1,20 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import PropTypes from "prop-types";
 import { Link, useParams } from "react-router-dom";
 import ArrowBackRoundedIcon from "@mui/icons-material/ArrowBackRounded";
 import PortalSkeleton from "./PortalSkeleton";
-import LessonVideo from "./LessonVideo";
+import LessonMedia from "./LessonMedia";
 import { formatDuration } from "./coursesCache";
+import { formatBytes } from "./lessonPlayback";
+import {
+  courseUsage,
+  readCourseCopy,
+  readDownloads,
+  removeCourseCopy,
+  removeDownload,
+  saveCourseCopy,
+} from "./lessonDownloads";
+import { canSaveLessons, lessonFiles } from "./offlineFiles";
 import "./Portal.css";
 import { apiCredentials, apiUrl } from "../../lib/apiBase";
 
@@ -16,11 +26,19 @@ import { apiCredentials, apiUrl } from "../../lib/apiBase";
  * lesson expands in place
  * rather than pushing the student to a per-lesson route, so reading a course
  * end to end on a phone is one screen and no further requests.
+ *
+ * In the app, a lesson can be saved to the phone (#189). While any lesson of a
+ * course is saved, a copy of the course is kept too, so this page opens from it
+ * with no connection and the saved lessons play.
  */
 function PortalCourse({ user }) {
   const { slug } = useParams();
-  const [state, setState] = useState({ status: "loading", course: null });
+  const userId = user?.id;
+  const [state, setState] = useState({ status: "loading", course: null, saved: false });
   const [openId, setOpenId] = useState(null);
+  // Bumped whenever a saved lesson changes, so the storage line re-reads
+  const [version, setVersion] = useState(0);
+  const [busy, setBusy] = useState(() => new Set()); // lessons saving right now
 
   useEffect(() => {
     let live = true;
@@ -30,20 +48,40 @@ function PortalCourse({ user }) {
           credentials: apiCredentials(),
         });
         if (!live) return;
-        if (res.status === 404) return setState({ status: "not_found", course: null });
-        if (!res.ok) return setState({ status: "error", course: null });
+        if (res.status === 404) return setState({ status: "not_found", course: null, saved: false });
+        if (!res.ok) return setState({ status: "error", course: null, saved: false });
         const body = await res.json().catch(() => ({}));
-        setState({ status: "ready", course: body.course || null });
+        const course = body.course || null;
+        // A course with saved lessons keeps its copy current: new lessons and
+        // edited notes reach the phone the next time it is online
+        if (course && readCourseCopy(userId, slug)) saveCourseCopy(userId, course);
+        setState({ status: "ready", course, saved: false });
       } catch {
-        // Not cached: a course body is large and a student reads it once. The
-        // list on /portal is what has to survive offline, not every lesson.
-        if (live) setState({ status: "offline", course: null });
+        // Only a course with a lesson saved on this phone is kept (#189). A
+        // course body is large and most are read once, online.
+        const copy = readCourseCopy(userId, slug);
+        if (!live) return;
+        setState(
+          copy
+            ? { status: "ready", course: copy.course, saved: true }
+            : { status: "offline", course: null, saved: false },
+        );
       }
     })();
     return () => {
       live = false;
     };
-  }, [slug]);
+  }, [slug, userId]);
+
+  const changed = useCallback(() => setVersion((v) => v + 1), []);
+  const markBusy = useCallback((lessonId, saving) => {
+    setBusy((prev) => {
+      const next = new Set(prev);
+      if (saving) next.add(lessonId);
+      else next.delete(lessonId);
+      return next;
+    });
+  }, []);
 
   if (state.status === "loading") return <PortalSkeleton />;
 
@@ -71,6 +109,19 @@ function PortalCourse({ user }) {
 
   const { course } = state;
   const lessons = course.lessons || [];
+  // `version` is read so this recomputes after a save or delete
+  const usage = canSaveLessons() && version >= 0 ? courseUsage(readDownloads(userId), course.slug) : { lessons: 0 };
+
+  // Frees the space every saved lesson of this course takes
+  const deleteAll = async () => {
+    for (const entry of Object.values(readDownloads(userId))) {
+      if (entry.slug !== course.slug) continue;
+      await lessonFiles.remove(entry.path);
+      removeDownload(userId, entry.lessonId);
+    }
+    removeCourseCopy(userId, course.slug);
+    changed();
+  };
 
   return (
     <main className="portal portal-course-page">
@@ -85,7 +136,26 @@ function PortalCourse({ user }) {
           <h1>{course.title}</h1>
         </div>
       </header>
+      {state.saved && (
+        <p className="portal-cached" role="status">
+          You are offline. Showing your saved copy: saved lessons play, the others need a connection.
+        </p>
+      )}
       {course.summary && <p className="portal-course-summary">{course.summary}</p>}
+
+      {usage.lessons > 0 && (
+        <div className="portal-saved-usage">
+          <p>
+            On this phone: {formatBytes(usage.bytes) || "under 1 MB"} ·{" "}
+            {usage.lessons === 1 ? "1 lesson" : `${usage.lessons} lessons`}
+          </p>
+          {/* Held while a lesson is saving, so a running download cannot
+              write into a file that has just been deleted */}
+          <button type="button" className="portal-save-btn portal-save-btn--quiet" onClick={deleteAll} disabled={busy.size > 0}>
+            Delete all
+          </button>
+        </div>
+      )}
 
       <section className="portal-section" aria-labelledby="lessons">
         <h2 id="lessons">{lessons.length === 1 ? "1 lesson" : `${lessons.length} lessons`}</h2>
@@ -124,7 +194,14 @@ function PortalCourse({ user }) {
                     {/* A lesson without video yet says so, rather than showing
                         a play button that goes nowhere. */}
                     {l.video_url ? (
-                      <LessonVideo lesson={l} userId={user?.id} />
+                      <LessonMedia
+                        lesson={l}
+                        userId={userId}
+                        course={course}
+                        version={version}
+                        onChange={changed}
+                        onBusy={markBusy}
+                      />
                     ) : (
                       <p className="portal-card-sub">Video for this lesson is coming soon.</p>
                     )}

--- a/src/components/portal/lessonDownloads.js
+++ b/src/components/portal/lessonDownloads.js
@@ -1,0 +1,294 @@
+/**
+ * Saving a lesson's video to the phone, in the Android app (#189).
+ *
+ * A rural connection drops mid-lesson more often than it refuses outright, so a
+ * student can save a lesson once on a good connection and watch it later with
+ * none. Like lessonPlayback and coursesCache, the rules are plain functions:
+ * the download loop takes `fetch` and the file store as arguments, so a dropped
+ * connection and a resume are unit-tested without a phone.
+ *
+ * What lives where:
+ *   - the video, in the app's private storage (offlineFiles.js), one file per
+ *     student and lesson;
+ *   - a small record per download in localStorage: its course, its full size,
+ *     and whether it finished;
+ *   - a copy of the course (titles and notes) for as long as any of its lessons
+ *     is saved, so the course page opens with no connection.
+ * The file's size on disk is the truth for how much is saved: a record can lag
+ * a killed app by one piece, the file cannot.
+ */
+
+export const DOWNLOADS_KEY = "rca_lesson_downloads";
+export const COURSE_COPY_KEY = "rca_course_copy";
+export const DOWNLOAD_DIR = "lessons";
+
+// Bytes held in memory before they are written to the file. A dropped
+// connection loses at most this much, and a low-end phone never holds a whole
+// lesson in memory.
+export const PIECE_BYTES = 1024 * 1024;
+
+const who = (userId) => userId ?? "anon";
+
+/** Per student, so a shared phone keeps each sibling's saved lessons apart. */
+export function downloadsKey(userId) {
+  return `${DOWNLOADS_KEY}:${who(userId)}`;
+}
+
+export function courseCopyKey(userId, slug) {
+  return `${COURSE_COPY_KEY}:${who(userId)}:${slug}`;
+}
+
+/** Where a lesson's video is kept. Ids are reduced to safe characters, so no id can reach outside the folder. */
+export function lessonFilePath(userId, lessonId) {
+  const safe = (v) => String(v ?? "anon").replace(/[^A-Za-z0-9_-]/g, "_");
+  return `${DOWNLOAD_DIR}/${safe(userId)}/${safe(lessonId)}.mp4`;
+}
+
+/** Every saved or half-saved lesson for this student, keyed by lesson id. */
+export function readDownloads(userId, storage = safeStorage()) {
+  if (!storage) return {};
+  try {
+    const parsed = JSON.parse(storage.getItem(downloadsKey(userId)) || "{}");
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return {};
+    const out = {};
+    for (const [id, entry] of Object.entries(parsed)) {
+      // A hand-edited or half-written record must not break the course page
+      if (entry && typeof entry.path === "string" && typeof entry.slug === "string") out[id] = entry;
+    }
+    return out;
+  } catch {
+    return {};
+  }
+}
+
+/** Adds or replaces one lesson's record. */
+export function writeDownload(userId, entry, storage = safeStorage(), now = Date.now()) {
+  if (!storage || !entry || entry.lessonId == null) return false;
+  try {
+    const all = readDownloads(userId, storage);
+    all[String(entry.lessonId)] = { ...entry, savedAt: now };
+    storage.setItem(downloadsKey(userId), JSON.stringify(all));
+    return true;
+  } catch {
+    // Private mode or a full store: the file is still on disk, and the next
+    // attempt picks up from its size.
+    return false;
+  }
+}
+
+/** Forgets one lesson; returns what is left. */
+export function removeDownload(userId, lessonId, storage = safeStorage()) {
+  const all = readDownloads(userId, storage);
+  delete all[String(lessonId)];
+  try {
+    storage?.setItem(downloadsKey(userId), JSON.stringify(all));
+  } catch {
+    /* nothing useful to do */
+  }
+  return all;
+}
+
+export function downloadFor(downloads, lessonId) {
+  return (downloads && downloads[String(lessonId)]) || null;
+}
+
+/** Space a course's lessons take on this phone. Half-saved ones count: they take space too. */
+export function courseUsage(downloads, slug) {
+  let bytes = 0;
+  let lessons = 0;
+  for (const entry of Object.values(downloads || {})) {
+    if (entry.slug !== slug) continue;
+    lessons += 1;
+    const n = Number(entry.bytes);
+    if (Number.isFinite(n) && n > 0) bytes += n;
+  }
+  return { bytes, lessons };
+}
+
+/** 0-100, or null while the full size is not known. */
+export function progressPercent(bytes, total) {
+  const have = Number(bytes);
+  const all = Number(total);
+  if (!Number.isFinite(all) || all <= 0) return null;
+  if (!Number.isFinite(have) || have <= 0) return 0;
+  return Math.min(100, Math.floor((have / all) * 100));
+}
+
+/** Keeps the course (titles and notes) so its page opens offline. */
+export function saveCourseCopy(userId, course, storage = safeStorage(), now = Date.now()) {
+  if (!storage || !course || !course.slug) return false;
+  try {
+    storage.setItem(courseCopyKey(userId, course.slug), JSON.stringify({ course, savedAt: now }));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * No age limit, unlike the course list's cache: the copy lives exactly as long
+ * as a saved lesson needs it, and deleting the last one removes it.
+ */
+export function readCourseCopy(userId, slug, storage = safeStorage()) {
+  if (!storage || !slug) return null;
+  try {
+    const parsed = JSON.parse(storage.getItem(courseCopyKey(userId, slug)) || "null");
+    if (!parsed || !parsed.course || !Array.isArray(parsed.course.lessons) || typeof parsed.savedAt !== "number") {
+      return null;
+    }
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+export function removeCourseCopy(userId, slug, storage = safeStorage()) {
+  try {
+    storage?.removeItem(courseCopyKey(userId, slug));
+  } catch {
+    /* nothing useful to do */
+  }
+}
+
+/**
+ * `bytes 0-1023/5000` → { start: 0, end: 1023, total: 5000 }.
+ * `bytes *\/5000` (a 416's answer) → start and end null. total is null for `/*`.
+ */
+export function parseContentRange(value) {
+  const m = /^bytes\s+(?:(\d+)-(\d+)|\*)\/(\d+|\*)$/i.exec(String(value || "").trim());
+  if (!m) return null;
+  return {
+    start: m[1] === undefined ? null : Number(m[1]),
+    end: m[2] === undefined ? null : Number(m[2]),
+    total: m[3] === "*" ? null : Number(m[3]),
+  };
+}
+
+/**
+ * Base64, which is how the file plugin takes binary. Built in slices: one
+ * String.fromCharCode over a megabyte overflows the call stack.
+ */
+export function toBase64(bytes) {
+  let s = "";
+  for (let i = 0; i < bytes.length; i += 0x8000) {
+    s += String.fromCharCode.apply(null, bytes.subarray(i, i + 0x8000));
+  }
+  return btoa(s);
+}
+
+export class DownloadError extends Error {
+  constructor(reason, status) {
+    super(`lesson download: ${reason}${status ? ` (${status})` : ""}`);
+    this.name = "DownloadError";
+    this.reason = reason; // "http" | "range" | "short"
+    this.status = status;
+  }
+}
+
+/**
+ * Saves `url` to `path`, carrying on from whatever is already there.
+ *
+ * Asks for `Range: bytes=<saved>-`. A 206 that starts where the file ends is
+ * appended; a 200 means the server ignored the range, so the file starts over
+ * rather than get its first bytes glued on twice. Pieces are written as they
+ * arrive, so a connection that drops mid-lesson keeps everything up to the last
+ * piece, and the next call picks up from there.
+ *
+ * `files` is { size(path), reset(path), append(path, base64) }: offlineFiles.js
+ * in the app, an in-memory stand-in in the tests.
+ *
+ * Returns { bytes, total, done: true }. Otherwise throws: a DownloadError, the
+ * network's own TypeError, or an AbortError. The partial file stays in place.
+ */
+export async function downloadLesson({
+  url,
+  path,
+  files,
+  fetchImpl = globalThis.fetch,
+  credentials,
+  signal,
+  onProgress,
+  pieceBytes = PIECE_BYTES,
+}) {
+  let start = await files.size(path);
+  const headers = start > 0 ? { Range: `bytes=${start}-` } : {};
+  const res = await fetchImpl(url, { headers, credentials, signal });
+
+  if (res.status === 416 && start > 0) {
+    // Asked for bytes past the end. Either the file is already whole, or it is
+    // longer than the lesson now is (the video was replaced): start over.
+    const range = parseContentRange(res.headers.get("content-range"));
+    if (range && range.total === start) return { bytes: start, total: start, done: true };
+    await files.reset(path);
+    return downloadLesson({ url, path, files, fetchImpl, credentials, signal, onProgress, pieceBytes });
+  }
+  if (!res.ok) throw new DownloadError("http", res.status);
+
+  let total;
+  if (res.status === 206) {
+    const range = parseContentRange(res.headers.get("content-range"));
+    // Bytes from anywhere but where the file ends would corrupt it
+    if (!range || range.start !== start) throw new DownloadError("range", res.status);
+    total = range.total;
+  } else {
+    start = 0;
+    const length = Number(res.headers.get("content-length"));
+    total = Number.isFinite(length) && length > 0 ? length : null;
+  }
+  if (start === 0) await files.reset(path);
+
+  let saved = start;
+  let pending = [];
+  let pendingBytes = 0;
+  if (onProgress) onProgress({ bytes: saved, total });
+
+  const flush = async () => {
+    if (!pendingBytes) return;
+    const joined = new Uint8Array(pendingBytes);
+    let at = 0;
+    for (const piece of pending) {
+      joined.set(piece, at);
+      at += piece.length;
+    }
+    pending = [];
+    pendingBytes = 0;
+    await files.append(path, toBase64(joined));
+    saved += joined.length;
+    if (onProgress) onProgress({ bytes: saved, total });
+  };
+
+  const take = async (piece) => {
+    pending.push(piece);
+    pendingBytes += piece.length;
+    if (pendingBytes >= pieceBytes) await flush();
+  };
+
+  try {
+    if (res.body && typeof res.body.getReader === "function") {
+      const reader = res.body.getReader();
+      for (;;) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        if (value && value.length) await take(value);
+      }
+    } else {
+      // An older WebView without streamed bodies: the whole response at once
+      await take(new Uint8Array(await res.arrayBuffer()));
+    }
+  } finally {
+    // What arrived before a drop is kept, so the next attempt resumes after it
+    await flush();
+  }
+
+  // The connection closed early without an error: keep what came, report it
+  if (total != null && saved < total) throw new DownloadError("short");
+  return { bytes: saved, total: total ?? saved, done: true };
+}
+
+function safeStorage() {
+  try {
+    return globalThis.localStorage || null;
+  } catch {
+    return null;
+  }
+}

--- a/src/components/portal/lessonDownloads.test.js
+++ b/src/components/portal/lessonDownloads.test.js
@@ -1,0 +1,410 @@
+import { Buffer } from "node:buffer";
+import { describe, it, expect, vi } from "vitest";
+import {
+  DownloadError,
+  courseCopyKey,
+  courseUsage,
+  downloadFor,
+  downloadLesson,
+  downloadsKey,
+  lessonFilePath,
+  parseContentRange,
+  progressPercent,
+  readCourseCopy,
+  readDownloads,
+  removeCourseCopy,
+  removeDownload,
+  saveCourseCopy,
+  toBase64,
+  writeDownload,
+} from "./lessonDownloads";
+
+// A localStorage stand-in. `fail` makes every call throw, which is what a
+// browser in private mode or over quota actually does.
+function memStore(seed = {}, fail = false) {
+  const map = new Map(Object.entries(seed));
+  const boom = () => {
+    throw new Error("storage unavailable");
+  };
+  return {
+    getItem: (k) => (fail ? boom() : map.has(k) ? map.get(k) : null),
+    setItem: (k, v) => (fail ? boom() : void map.set(k, v)),
+    removeItem: (k) => (fail ? boom() : void map.delete(k)),
+    map,
+  };
+}
+
+// The phone's file store, in memory: path → bytes. Takes base64 like the plugin.
+function memFiles(seed = {}) {
+  const map = new Map(Object.entries(seed).map(([k, v]) => [k, Uint8Array.from(v)]));
+  const files = {
+    map,
+    size: vi.fn(async (p) => (map.has(p) ? map.get(p).length : 0)),
+    reset: vi.fn(async (p) => void map.set(p, new Uint8Array(0))),
+    append: vi.fn(async (p, b64) => {
+      const add = Uint8Array.from(Buffer.from(b64, "base64"));
+      const old = map.get(p) || new Uint8Array(0);
+      const next = new Uint8Array(old.length + add.length);
+      next.set(old);
+      next.set(add, old.length);
+      map.set(p, next);
+    }),
+    bytes: (p) => Array.from(map.get(p) || []),
+  };
+  return files;
+}
+
+// A 20-byte "lesson": 1..20, so a misplaced byte is visible in a failure
+const LESSON = Uint8Array.from({ length: 20 }, (_, i) => i + 1);
+const ALL = Array.from(LESSON);
+const PATH = "lessons/7/42.mp4";
+
+/**
+ * A video server. With `honourRange` it answers ranges the way R2 does behind
+ * #187's endpoint; without, it sends the whole file with a 200. `dropAfter`
+ * errors the stream after that many bytes, as a lost connection does; `stopAt`
+ * closes it cleanly there instead. Sends `pieces` bytes at a time.
+ */
+function server({ honourRange = true, dropAfter = Infinity, stopAt = Infinity, pieces = 3, length = true } = {}) {
+  const ranges = [];
+  const fetchImpl = vi.fn(async (_url, init = {}) => {
+    const range = init.headers && init.headers.Range;
+    ranges.push(range || null);
+    let from = 0;
+    let status = 200;
+    const headers = new Headers({ "content-type": "video/mp4" });
+    if (range && honourRange) {
+      from = Number(/bytes=(\d+)-/.exec(range)[1]);
+      if (from >= LESSON.length) {
+        return new Response(null, { status: 416, headers: { "content-range": `bytes */${LESSON.length}` } });
+      }
+      status = 206;
+      headers.set("content-range", `bytes ${from}-${LESSON.length - 1}/${LESSON.length}`);
+    }
+    if (length) headers.set("content-length", String(LESSON.length - from));
+    const body = LESSON.slice(from);
+    let sent = 0;
+    const stream = new ReadableStream({
+      pull(controller) {
+        if (sent >= body.length || sent >= stopAt) return controller.close();
+        if (sent >= dropAfter) return controller.error(new TypeError("network connection lost"));
+        const end = Math.min(body.length, sent + pieces, dropAfter, stopAt);
+        controller.enqueue(body.slice(sent, end));
+        sent = end;
+      },
+    });
+    return new Response(stream, { status, headers });
+  });
+  return { fetchImpl, ranges };
+}
+
+describe("keys and paths", () => {
+  it("keeps each student's downloads and course copies apart", () => {
+    expect(downloadsKey(1)).not.toBe(downloadsKey(2));
+    expect(downloadsKey(undefined)).toBe(downloadsKey(null));
+    expect(courseCopyKey(1, "java")).not.toBe(courseCopyKey(2, "java"));
+    expect(courseCopyKey(1, "java")).not.toBe(courseCopyKey(1, "python"));
+  });
+
+  it("puts each student's lesson in its own file", () => {
+    expect(lessonFilePath(7, 42)).toBe("lessons/7/42.mp4");
+    expect(lessonFilePath(7, 42)).not.toBe(lessonFilePath(8, 42));
+    expect(lessonFilePath(null, 42)).toBe("lessons/anon/42.mp4");
+  });
+
+  it("cannot be steered outside the lessons folder by an odd id", () => {
+    const path = lessonFilePath("../../x", "a/b");
+    expect(path.startsWith("lessons/")).toBe(true);
+    expect(path.split("/")).toHaveLength(3);
+    expect(path).not.toContain("..");
+  });
+});
+
+describe("download records", () => {
+  it("round-trips, stamped with when it was saved", () => {
+    const store = memStore();
+    const entry = { lessonId: 42, slug: "java", path: PATH, bytes: 10, total: 20, done: false };
+    expect(writeDownload(7, entry, store, 1000)).toBe(true);
+    expect(readDownloads(7, store)).toEqual({ 42: { ...entry, savedAt: 1000 } });
+    expect(downloadFor(readDownloads(7, store), 42)).toMatchObject({ bytes: 10 });
+    expect(readDownloads(8, store)).toEqual({});
+  });
+
+  it("replaces a lesson's record rather than adding a second one", () => {
+    const store = memStore();
+    writeDownload(7, { lessonId: 42, slug: "java", path: PATH, bytes: 10 }, store);
+    writeDownload(7, { lessonId: 42, slug: "java", path: PATH, bytes: 20, done: true }, store);
+    const all = readDownloads(7, store);
+    expect(Object.keys(all)).toEqual(["42"]);
+    expect(all[42]).toMatchObject({ bytes: 20, done: true });
+  });
+
+  it("removes one lesson and returns the rest", () => {
+    const store = memStore();
+    writeDownload(7, { lessonId: 1, slug: "java", path: "a" }, store);
+    writeDownload(7, { lessonId: 2, slug: "java", path: "b" }, store);
+    const left = removeDownload(7, 1, store);
+    expect(Object.keys(left)).toEqual(["2"]);
+    expect(Object.keys(readDownloads(7, store))).toEqual(["2"]);
+  });
+
+  it("reads a corrupt or hand-edited store as empty, keeping the good records", () => {
+    expect(readDownloads(7, memStore({ [downloadsKey(7)]: "{not json" }))).toEqual({});
+    expect(readDownloads(7, memStore({ [downloadsKey(7)]: "[1,2]" }))).toEqual({});
+    const mixed = memStore({
+      [downloadsKey(7)]: JSON.stringify({ 1: { path: "a", slug: "java" }, 2: { path: 5 }, 3: null }),
+    });
+    expect(Object.keys(readDownloads(7, mixed))).toEqual(["1"]);
+  });
+
+  it("never throws when storage does", () => {
+    const broken = memStore({}, true);
+    expect(readDownloads(7, broken)).toEqual({});
+    expect(writeDownload(7, { lessonId: 1, slug: "java", path: "a" }, broken)).toBe(false);
+    expect(removeDownload(7, 1, broken)).toEqual({});
+    expect(readDownloads(7, null)).toEqual({});
+  });
+
+  it("refuses a record with no lesson id", () => {
+    expect(writeDownload(7, { slug: "java", path: "a" }, memStore())).toBe(false);
+  });
+});
+
+describe("courseUsage", () => {
+  const downloads = {
+    1: { slug: "java", path: "a", bytes: 30_000_000, done: true },
+    2: { slug: "java", path: "b", bytes: 5_000_000, done: false },
+    3: { slug: "python", path: "c", bytes: 99_000_000, done: true },
+    4: { slug: "java", path: "d", bytes: "junk" },
+  };
+
+  it("adds up one course's lessons, half-saved ones included", () => {
+    expect(courseUsage(downloads, "java")).toEqual({ bytes: 35_000_000, lessons: 3 });
+  });
+
+  it("is zero for a course with nothing saved", () => {
+    expect(courseUsage(downloads, "mern")).toEqual({ bytes: 0, lessons: 0 });
+    expect(courseUsage(undefined, "java")).toEqual({ bytes: 0, lessons: 0 });
+  });
+});
+
+describe("progressPercent", () => {
+  it("is a whole percentage, never over 100", () => {
+    expect(progressPercent(5, 20)).toBe(25);
+    expect(progressPercent(19, 20)).toBe(95);
+    expect(progressPercent(25, 20)).toBe(100);
+    expect(progressPercent(0, 20)).toBe(0);
+  });
+
+  it("is null while the full size is unknown", () => {
+    expect(progressPercent(5, null)).toBeNull();
+    expect(progressPercent(5, 0)).toBeNull();
+  });
+});
+
+describe("course copies", () => {
+  const course = { slug: "java", title: "Java", lessons: [{ id: 42, title: "Intro", notes: "Read me" }] };
+
+  it("round-trips per student and course", () => {
+    const store = memStore();
+    expect(saveCourseCopy(7, course, store, 500)).toBe(true);
+    expect(readCourseCopy(7, "java", store)).toEqual({ course, savedAt: 500 });
+    expect(readCourseCopy(8, "java", store)).toBeNull();
+    removeCourseCopy(7, "java", store);
+    expect(readCourseCopy(7, "java", store)).toBeNull();
+  });
+
+  it("reads a malformed copy as none", () => {
+    const key = courseCopyKey(7, "java");
+    expect(readCourseCopy(7, "java", memStore({ [key]: "{oops" }))).toBeNull();
+    expect(readCourseCopy(7, "java", memStore({ [key]: JSON.stringify({ course: { slug: "java" }, savedAt: 1 }) }))).toBeNull();
+    expect(readCourseCopy(7, "java", memStore({ [key]: JSON.stringify({ course }) }))).toBeNull();
+  });
+
+  it("never throws when storage does, and skips a course with no slug", () => {
+    const broken = memStore({}, true);
+    expect(saveCourseCopy(7, course, broken)).toBe(false);
+    expect(readCourseCopy(7, "java", broken)).toBeNull();
+    expect(() => removeCourseCopy(7, "java", broken)).not.toThrow();
+    expect(saveCourseCopy(7, { title: "no slug" }, memStore())).toBe(false);
+  });
+});
+
+describe("parseContentRange", () => {
+  it("reads a partial response's range", () => {
+    expect(parseContentRange("bytes 5-19/20")).toEqual({ start: 5, end: 19, total: 20 });
+  });
+
+  it("reads a 416's answer and an unknown total", () => {
+    expect(parseContentRange("bytes */20")).toEqual({ start: null, end: null, total: 20 });
+    expect(parseContentRange("bytes 0-9/*")).toEqual({ start: 0, end: 9, total: null });
+  });
+
+  it("rejects anything else", () => {
+    expect(parseContentRange("items 0-9/20")).toBeNull();
+    expect(parseContentRange("")).toBeNull();
+    expect(parseContentRange(null)).toBeNull();
+  });
+});
+
+describe("toBase64", () => {
+  it("matches Node's encoder, past the slice size", () => {
+    const bytes = Uint8Array.from({ length: 70_000 }, (_, i) => (i * 7) % 256);
+    expect(toBase64(bytes)).toBe(Buffer.from(bytes).toString("base64"));
+    expect(toBase64(new Uint8Array(0))).toBe("");
+  });
+});
+
+describe("downloadLesson", () => {
+  it("saves a lesson from scratch, reporting progress as it goes", async () => {
+    const files = memFiles();
+    const { fetchImpl, ranges } = server();
+    const seen = [];
+    const result = await downloadLesson({
+      url: "/v",
+      path: PATH,
+      files,
+      fetchImpl,
+      pieceBytes: 4,
+      onProgress: (p) => seen.push(p),
+    });
+    expect(result).toEqual({ bytes: 20, total: 20, done: true });
+    expect(files.bytes(PATH)).toEqual(ALL);
+    expect(ranges).toEqual([null]); // nothing saved yet, so no Range
+    expect(seen[0]).toEqual({ bytes: 0, total: 20 });
+    expect(seen.at(-1)).toEqual({ bytes: 20, total: 20 });
+    expect(seen.map((p) => p.bytes)).toEqual([...seen.map((p) => p.bytes)].sort((a, b) => a - b));
+  });
+
+  it("writes in pieces rather than holding the whole lesson in memory", async () => {
+    const files = memFiles();
+    await downloadLesson({ url: "/v", path: PATH, files, fetchImpl: server({ pieces: 2 }).fetchImpl, pieceBytes: 4 });
+    // 20 bytes in pieces of 4 or more: several writes, none of them the whole file
+    expect(files.append.mock.calls.length).toBeGreaterThan(2);
+    for (const [, b64] of files.append.mock.calls) expect(Buffer.from(b64, "base64").length).toBeLessThan(20);
+  });
+
+  it("keeps what arrived when the connection drops, and resumes after it", async () => {
+    const files = memFiles();
+    const dropping = server({ dropAfter: 9 });
+    await expect(
+      downloadLesson({ url: "/v", path: PATH, files, fetchImpl: dropping.fetchImpl, pieceBytes: 4 }),
+    ).rejects.toThrow("network connection lost");
+    expect(files.bytes(PATH)).toEqual(ALL.slice(0, 9));
+
+    const back = server();
+    const result = await downloadLesson({ url: "/v", path: PATH, files, fetchImpl: back.fetchImpl, pieceBytes: 4 });
+    expect(back.ranges).toEqual(["bytes=9-"]);
+    expect(result).toEqual({ bytes: 20, total: 20, done: true });
+    expect(files.bytes(PATH)).toEqual(ALL);
+  });
+
+  it("carries on from a file already partly saved, asking only for the rest", async () => {
+    const files = memFiles({ [PATH]: ALL.slice(0, 5) });
+    const { fetchImpl, ranges } = server();
+    const seen = [];
+    await downloadLesson({ url: "/v", path: PATH, files, fetchImpl, onProgress: (p) => seen.push(p) });
+    expect(ranges).toEqual(["bytes=5-"]);
+    expect(files.reset).not.toHaveBeenCalled();
+    expect(files.bytes(PATH)).toEqual(ALL);
+    expect(seen[0]).toEqual({ bytes: 5, total: 20 }); // the bar starts where it left off
+  });
+
+  it("starts over when the server ignores the range, rather than duplicate bytes", async () => {
+    const files = memFiles({ [PATH]: [9, 9, 9, 9, 9] });
+    const { fetchImpl, ranges } = server({ honourRange: false });
+    const result = await downloadLesson({ url: "/v", path: PATH, files, fetchImpl });
+    expect(ranges).toEqual(["bytes=5-"]);
+    expect(result.bytes).toBe(20);
+    expect(files.bytes(PATH)).toEqual(ALL);
+  });
+
+  it("treats a 416 for a whole file as done, without a byte written", async () => {
+    const files = memFiles({ [PATH]: ALL });
+    const result = await downloadLesson({ url: "/v", path: PATH, files, fetchImpl: server().fetchImpl });
+    expect(result).toEqual({ bytes: 20, total: 20, done: true });
+    expect(files.append).not.toHaveBeenCalled();
+  });
+
+  it("starts over when the saved file is longer than the lesson now is", async () => {
+    const files = memFiles({ [PATH]: Array.from({ length: 25 }, () => 0) });
+    const { fetchImpl, ranges } = server();
+    await downloadLesson({ url: "/v", path: PATH, files, fetchImpl });
+    expect(ranges).toEqual(["bytes=25-", null]);
+    expect(files.bytes(PATH)).toEqual(ALL);
+  });
+
+  it("refuses a partial response that starts in the wrong place", async () => {
+    const files = memFiles({ [PATH]: ALL.slice(0, 5) });
+    const fetchImpl = async () =>
+      new Response(LESSON, { status: 206, headers: { "content-range": "bytes 0-19/20" } });
+    const err = await downloadLesson({ url: "/v", path: PATH, files, fetchImpl }).catch((e) => e);
+    expect(err).toBeInstanceOf(DownloadError);
+    expect(err.reason).toBe("range");
+    expect(files.bytes(PATH)).toEqual(ALL.slice(0, 5)); // untouched
+  });
+
+  it("reports an HTTP failure with its status", async () => {
+    const files = memFiles();
+    const fetchImpl = async () => new Response("not found", { status: 404 });
+    const err = await downloadLesson({ url: "/v", path: PATH, files, fetchImpl }).catch((e) => e);
+    expect(err).toBeInstanceOf(DownloadError);
+    expect(err).toMatchObject({ reason: "http", status: 404 });
+  });
+
+  it("reports a connection that closes early without an error, keeping what came", async () => {
+    const files = memFiles();
+    const { fetchImpl } = server({ stopAt: 10 });
+    const err = await downloadLesson({ url: "/v", path: PATH, files, fetchImpl }).catch((e) => e);
+    expect(err).toMatchObject({ reason: "short" });
+    expect(files.bytes(PATH)).toEqual(ALL.slice(0, 10));
+  });
+
+  it("finishes when the server does not say how big the lesson is", async () => {
+    const files = memFiles();
+    const result = await downloadLesson({ url: "/v", path: PATH, files, fetchImpl: server({ length: false }).fetchImpl });
+    expect(result).toEqual({ bytes: 20, total: 20, done: true });
+  });
+
+  it("works on a WebView without streamed response bodies", async () => {
+    const files = memFiles();
+    const fetchImpl = async () => ({
+      status: 200,
+      ok: true,
+      headers: new Headers({ "content-length": "20" }),
+      body: null,
+      arrayBuffer: async () => LESSON.slice().buffer,
+    });
+    await downloadLesson({ url: "/v", path: PATH, files, fetchImpl });
+    expect(files.bytes(PATH)).toEqual(ALL);
+  });
+
+  it("sends the session cookie mode and the stop signal with the request", async () => {
+    const files = memFiles();
+    const { fetchImpl } = server();
+    const controller = new AbortController();
+    await downloadLesson({ url: "https://api/v", path: PATH, files, fetchImpl, credentials: "include", signal: controller.signal });
+    expect(fetchImpl).toHaveBeenCalledWith("https://api/v", expect.objectContaining({ credentials: "include", signal: controller.signal }));
+  });
+
+  it("stops when told to, keeping what was saved", async () => {
+    const files = memFiles();
+    const controller = new AbortController();
+    const { fetchImpl } = server({ pieces: 4 });
+    const run = downloadLesson({
+      url: "/v",
+      path: PATH,
+      files,
+      fetchImpl,
+      pieceBytes: 4,
+      signal: controller.signal,
+      onProgress: (p) => {
+        if (p.bytes >= 8) controller.abort();
+      },
+    });
+    // The fake server ignores the signal, as a finished response does: what
+    // matters is that nothing already written is lost
+    await run.catch(() => {});
+    expect(files.bytes(PATH).slice(0, 8)).toEqual(ALL.slice(0, 8));
+  });
+});

--- a/src/components/portal/offlineFiles.js
+++ b/src/components/portal/offlineFiles.js
@@ -1,0 +1,67 @@
+/**
+ * The phone's side of saved lessons (#189): where a lesson's video is kept.
+ *
+ * Directory.Data is the app's private storage: no permission prompt, no other
+ * app can read it, and Android removes it with the app. The plugin is loaded
+ * only when used, so the website bundle never fetches it, the same way
+ * nativeAuth loads @capacitor/browser.
+ */
+import { isNative } from "../../lib/apiBase";
+
+let plugin = null;
+function filesystem() {
+  plugin = plugin || import("@capacitor/filesystem");
+  return plugin;
+}
+
+/** Saving lessons is an app feature; the website only streams. */
+export function canSaveLessons() {
+  return isNative();
+}
+
+/** The file store downloadLesson writes through. */
+export const lessonFiles = {
+  /** Bytes saved so far; 0 when there is no file yet. */
+  async size(path) {
+    const { Filesystem, Directory } = await filesystem();
+    try {
+      const info = await Filesystem.stat({ path, directory: Directory.Data });
+      return Number(info.size) || 0;
+    } catch {
+      return 0;
+    }
+  },
+
+  /** An empty file, with its folder, ready to append to. */
+  async reset(path) {
+    const { Filesystem, Directory } = await filesystem();
+    await Filesystem.writeFile({ path, data: "", directory: Directory.Data, recursive: true });
+  },
+
+  /** With no encoding given, the plugin reads `data` as base64: binary-safe. */
+  async append(path, base64) {
+    const { Filesystem, Directory } = await filesystem();
+    await Filesystem.appendFile({ path, data: base64, directory: Directory.Data });
+  },
+
+  async remove(path) {
+    const { Filesystem, Directory } = await filesystem();
+    try {
+      await Filesystem.deleteFile({ path, directory: Directory.Data });
+    } catch {
+      // Already gone: deleting is done either way
+    }
+  },
+
+  /**
+   * A URL the WebView's <video> can play the saved file from. It is served by
+   * the app's own local server, which answers range requests, so seeking works
+   * with no connection.
+   */
+  async playableUrl(path) {
+    const { Filesystem, Directory } = await filesystem();
+    const { uri } = await Filesystem.getUri({ path, directory: Directory.Data });
+    const cap = globalThis.Capacitor;
+    return cap && typeof cap.convertFileSrc === "function" ? cap.convertFileSrc(uri) : uri;
+  },
+};


### PR DESCRIPTION
Closes #189. Part of #43 (epic #41).

## What
In the Android app, each lesson with video gets a **Save for offline** button under the player. A saved lesson plays from the phone with no connection. The website is unchanged: saving is an app feature, and the plugin is loaded only inside the app.

- **Size first:** the button shows the size (`size_bytes` when the API sends it, otherwise the same 360p estimate the player uses).
- **Progress:** a bar with percent and MB, and a **Stop** button.
- **Resume after a dropped connection:** the video is written to the phone in 1 MB pieces as it arrives, so a drop keeps everything up to the last piece. The next attempt asks for `Range: bytes=<saved>-` and carries on from there. It resumes by itself when the connection comes back while the page is open, or with **Resume saving**.
- **Safe with any server:** a 206 that starts anywhere but the end of the file is refused, so the file can't be corrupted. A 200 (range ignored) starts the file over instead of gluing bytes on twice. A 416 on a whole file counts as done.
- **Offline course page:** while any lesson of a course is saved, a copy of the course (titles and notes) is kept, and refreshed whenever the page loads online. With no connection, the page opens from that copy, labelled "Showing your saved copy". Today only the course list survives offline (#137).
- **Storage per course:** "On this phone: 76 MB · 2 lessons" on the course page, with **Delete all**. Each saved lesson has its own **Delete**. Deleting removes the file, so the space is freed. The course copy goes when its last saved lesson does.
- **Shared phones:** files, records and course copies are per student, the same way resume positions and the course-list cache are.
- **Where it's kept:** the app's private storage (`Directory.Data`). No permission prompt, no other app can read it, and uninstalling removes it.

## Files
- `src/components/portal/lessonDownloads.js` + `.test.js`: the rules and the download loop (`fetch` and the file store passed in), **34 unit tests**. They cover a drop mid-download followed by a resume, a partly saved file, a server that ignores Range, a 416, a wrong range start, a connection that closes early, an unknown size, and a WebView without streamed bodies.
- `src/components/portal/offlineFiles.js`: the phone side, via `@capacitor/filesystem` 8.1.3.
- `src/components/portal/LessonMedia.jsx`: the save / progress / stop / resume / delete controls around the player.
- `LessonVideo.jsx`: takes `offlineSrc` and plays the saved copy. The source is fixed at the tap, so a download finishing mid-lesson doesn't restart it.
- `PortalCourse.jsx`: opens from the saved copy offline, plus the storage line and Delete all.
- `Portal.css`: styles, on the existing tokens.
- `package.json` / lock: `@capacitor/filesystem`. `android/app/capacitor.build.gradle` and `android/capacitor.settings.gradle`: regenerated by `npx cap sync android`.

## Checks
- `npm test`: 22 files, **365 tests passed** (34 new).
- `npm run build`: builds.
- `eslint` on the changed files: 0 problems.
- **Not yet verified on a phone:** the "Done when" (a downloaded lesson plays in airplane mode, and deleting it frees the space) needs #187 (the video API with range requests) and a device. This machine has no Android SDK. The loop is built to #187's spec, and until then it also works against a server without range support by starting over.

## Next
- #187 adds `size_bytes` and range requests, and this starts resuming mid-file instead of starting over.
- Showing saved space on the course list (`/portal`) would be a small follow-up if wanted. It's per course on the course page for now.
